### PR TITLE
Phase B security hardening: 7 DoS / SSRF / output gates

### DIFF
--- a/docs/diagnostics-codes.md
+++ b/docs/diagnostics-codes.md
@@ -19,6 +19,10 @@ Severity levels:
 | `HTML-JAVASCRIPT-URL-IGNORED-001` | Warning | An `href`/`xlink:href` attribute carried a `javascript:` URL. The attribute was removed so the link will not appear in the emitted PDF; the surrounding element and its text content remain. |
 | `HTML-CANVAS-IGNORED-001` | Warning | A `<canvas>` element was encountered. NetPdf does not execute the scripted drawing API. Replaced with empty space. |
 | `HTML-OBJECT-EMBED-UNSUPPORTED-001` | Warning | `<object>` or `<embed>` encountered; not supported. |
+| `HTML-EVENT-HANDLER-IGNORED-001` | Info | An `on*` event-handler attribute (e.g., `onclick`, `onload`) was found on an element and stripped. NetPdf does not execute scripts in v1; the strip is defense-in-depth so Phase 5 PDF/UA emission can't surface attribute values into accessibility metadata. |
+| `HTML-DOM-LIMIT-EXCEEDED-001` | Warning | The parsed DOM exceeded one of the per-document DoS caps (element count, nesting depth, attributes per element, attribute value length, or text-node content length). Excess regions are removed; over-long values + text are clamped with `…`. One diagnostic per violation kind. Per Phase B B-1. |
+| `HTML-STRIP-NOT-STABLE-001` | Warning | The iterative HTML strip pass did not converge after the maximum iteration cap; dangerous content (script / `on*` handler / `javascript:`/`vbscript:`/`data:` URL) may remain in the DOM. Defense against AngleSharp normalization or SVG `<foreignObject>` re-introducing stripped content. The message names the surviving kinds. Per Phase B B-4. |
+| `HTML-INPUT-TOO-LARGE-001` | Warning | The HTML input length exceeded the per-document character cap; the parse was rejected before AngleSharp materialized the tree. Defends against very large single-string inputs that would otherwise consume parser CPU + heap. Per Phase B B-1 (PR #16 follow-up). |
 
 ---
 
@@ -52,6 +56,9 @@ Severity levels:
 | `CSS-ATTR-MULTI-ARG-UNSUPPORTED-001` | Warning | A modern `attr(name type, fallback)` form was rejected — cycle 1 supports the bare `attr(name)` form only. The pseudo-element generates no box rather than silently dropping the type / fallback args. Roadmap cycle 2 delivers the typed-value pipeline. |
 | `CSS-MODERN-COLOR-FUNCTION-UNSUPPORTED-001` | Info | A modern color function (`oklch()` / `oklab()` / `lab()` / `lch()` / `color()` / `color-mix()`) was used in a property value. Cycle 1 rejects these — the cascade's "invalid at computed value time" rule applies (initial / inherited value used). Roadmap cycle 2 ships sRGB-conversion of these so the rendered color is approximate but visible. |
 | `CSS-PSEUDO-SUPPRESSED-ON-REPLACED-001` | Info | A `::before` / `::after` rule targeted a replaced element (`<img>` / `<video>` / `<canvas>` / `<iframe>` / `<object>` / `<embed>`); per CSS Pseudo L4 §3 the pseudo-element is suppressed because replaced elements are atomic and can't host generated content. The author rule has no effect. |
+| `CSS-VAR-EXPANSION-LIMIT-001` | Warning | A `var()` substitution exceeded a depth, output-length, or per-element cumulative-output budget. Per Phase A A-3. |
+| `CSS-CONTENT-FUNCTION-UNSUPPORTED-001` | Warning | `content` value used a function or keyword the cycle-1 list parser doesn't accept (e.g., `counter()`, `url()`, `open-quote`), or the per-pseudo generated-content output exceeded the 64 KiB cap. Per Phase A A-5. |
+| `CSS-RULE-LIMIT-EXCEEDED-001` | Warning | A stylesheet exceeded one of the per-stylesheet / per-rule DoS caps: rule count (50 000 per sheet), declarations on a single rule (256), or selector alternatives in one rule's selector list (1 024). On rule-count overflow the cascade stops processing further rules; on per-rule overflow the declaration / alternative list is tail-truncated. Per Phase B B-2 (selector-alternative enforcement added in PR #16 follow-up). |
 
 ---
 
@@ -129,4 +136,4 @@ Or streamed live via `HtmlPdfOptions.Diagnostics: IDiagnosticsSink`.
 
 ---
 
-Last updated: 2026-05-04 (Phase 2 Task 1 review cycle: added `HTML-JAVASCRIPT-URL-IGNORED-001`).
+Last updated: 2026-05-07 (PR #16 review cycle: added `HTML-EVENT-HANDLER-IGNORED-001`, `HTML-DOM-LIMIT-EXCEEDED-001`, `HTML-STRIP-NOT-STABLE-001`, `HTML-INPUT-TOO-LARGE-001`, `CSS-VAR-EXPANSION-LIMIT-001`, `CSS-CONTENT-FUNCTION-UNSUPPORTED-001`, `CSS-RULE-LIMIT-EXCEEDED-001`).

--- a/src/NetPdf.Css/Cascade/CalcResolver.cs
+++ b/src/NetPdf.Css/Cascade/CalcResolver.cs
@@ -91,26 +91,48 @@ internal static class CalcResolver
             if (TryReadFunctionStart(rawValue, pos, out var fnName, out var bodyStart))
             {
                 var bodyEnd = FindMatchingCloseParen(rawValue, bodyStart);
-                if (bodyEnd < 0)
-                {
-                    // Unterminated — pass through verbatim.
-                    output.Append(rawValue, pos, rawValue.Length - pos);
-                    return output.ToString();
-                }
-                var body = rawValue[bodyStart..bodyEnd];
-                // Per Phase B B-3 — body-length cap. Emit one diagnostic +
-                // pass through verbatim (downstream layout treats unreduced
-                // calc() as invalid-at-computed-value-time per spec).
-                if (body.Length > MaxBodyLength)
+
+                // Per Phase B B-3 + PR #16 review user-recommendation #6 +
+                // Copilot review #7 — check the body LENGTH (not the sliced
+                // body string) before deciding whether to allocate. Two
+                // overflow paths lead here:
+                //   (a) bodyEnd >= 0 (terminated): body length =
+                //       bodyEnd - bodyStart. Pre-cap check avoids slicing
+                //       megabytes of substring before rejecting.
+                //   (b) bodyEnd < 0 (unterminated): body extends to end of
+                //       input. The original code passed unterminated bodies
+                //       through verbatim WITHOUT the cap, so a hostile
+                //       `calc(<5 MiB tail>` slipped through. Treat
+                //       unterminated as "if remainder > MaxBodyLength,
+                //       emit the cap diagnostic too" before passing through.
+                var bodyLength = (bodyEnd < 0)
+                    ? rawValue.Length - bodyStart
+                    : bodyEnd - bodyStart;
+                if (bodyLength > MaxBodyLength)
                 {
                     diagnostics?.Emit(new CssDiagnostic(
                         CssDiagnosticCodes.CssCalcInvalid001,
                         $"{fnName}() body exceeded the {MaxBodyLength}-char cap; expression preserved verbatim and treated as invalid at computed-value time.",
                         CssDiagnosticSeverity.Warning, location));
+                    if (bodyEnd < 0)
+                    {
+                        output.Append(rawValue, pos, rawValue.Length - pos);
+                        return output.ToString();
+                    }
                     output.Append(rawValue, pos, bodyEnd - pos + 1);
                     pos = bodyEnd + 1;
                     continue;
                 }
+
+                if (bodyEnd < 0)
+                {
+                    // Unterminated + within cap — pass through verbatim. The
+                    // CSS parser would have rejected the whole declaration
+                    // up-stream anyway; this branch is defensive.
+                    output.Append(rawValue, pos, rawValue.Length - pos);
+                    return output.ToString();
+                }
+                var body = rawValue[bodyStart..bodyEnd];
                 var reduced = TryReduceFunction(fnName, body, diagnostics, location);
                 if (reduced.HasValue)
                 {

--- a/src/NetPdf.Css/Cascade/CalcResolver.cs
+++ b/src/NetPdf.Css/Cascade/CalcResolver.cs
@@ -49,6 +49,16 @@ internal static class CalcResolver
     /// limit for consistency.</summary>
     public const int MaxDepth = 32;
 
+    /// <summary>Per Phase B B-3 — maximum length of a single math-function body
+    /// (the text between the opening <c>(</c> and the matching <c>)</c>). A
+    /// hand-authored <c>calc()</c> rarely exceeds ~120 chars; thousands of
+    /// chars indicate either a generated bundle (acceptable) or an attacker
+    /// trying to amplify CPU through a long operand chain that <see cref="MaxDepth"/>
+    /// alone wouldn't catch (depth measures nesting, not breadth). 4 KiB
+    /// keeps adversarial inputs to bounded CPU while leaving headroom for
+    /// generated CSS.</summary>
+    public const int MaxBodyLength = 4 * 1024;
+
     /// <summary>Math-function names recognized by this resolver, lowercase. Detection
     /// is ASCII case-insensitive per CSS Syntax L3, but the name on the left is the
     /// canonical form used for dispatch.</summary>
@@ -88,6 +98,19 @@ internal static class CalcResolver
                     return output.ToString();
                 }
                 var body = rawValue[bodyStart..bodyEnd];
+                // Per Phase B B-3 — body-length cap. Emit one diagnostic +
+                // pass through verbatim (downstream layout treats unreduced
+                // calc() as invalid-at-computed-value-time per spec).
+                if (body.Length > MaxBodyLength)
+                {
+                    diagnostics?.Emit(new CssDiagnostic(
+                        CssDiagnosticCodes.CssCalcInvalid001,
+                        $"{fnName}() body exceeded the {MaxBodyLength}-char cap; expression preserved verbatim and treated as invalid at computed-value time.",
+                        CssDiagnosticSeverity.Warning, location));
+                    output.Append(rawValue, pos, bodyEnd - pos + 1);
+                    pos = bodyEnd + 1;
+                    continue;
+                }
                 var reduced = TryReduceFunction(fnName, body, diagnostics, location);
                 if (reduced.HasValue)
                 {

--- a/src/NetPdf.Css/Cascade/CascadeResolver.cs
+++ b/src/NetPdf.Css/Cascade/CascadeResolver.cs
@@ -152,9 +152,16 @@ internal static class CascadeResolver
             : new SelectorParseWarningBudgetSink(diagnostics);
 
         var ruleOrder = 0;
+        // Per PR #16 review user-recommendation #4 — capture the starting
+        // output count so the rule-cap check is per-stylesheet, not global.
+        // Without this, a multi-sheet document where the first sheet
+        // approaches MaxRulesPerStylesheet would silently truncate
+        // subsequent independent sheets.
+        var sheetStartCount = output.Count;
         CollectFromRules(sheet.Rules, sheet.Origin, sheet.Order, ref ruleOrder,
             output, hasContainingSheets, media, layers,
-            currentLayer: LayerRegistry.UnlayeredIndex, budgetedSink, cancellationToken);
+            currentLayer: LayerRegistry.UnlayeredIndex, budgetedSink,
+            sheetStartCount, cancellationToken);
     }
 
     /// <summary>Per Phase A A-8 — sink decorator that throttles
@@ -244,6 +251,7 @@ internal static class CascadeResolver
         LayerRegistry layers,
         int currentLayer,
         ICssDiagnosticsSink? diagnostics,
+        int sheetStartCount,
         System.Threading.CancellationToken cancellationToken,
         int depth = 0)
     {
@@ -273,7 +281,11 @@ internal static class CascadeResolver
             // diagnostic at the moment of overflow + drop every subsequent
             // rule (style + at-rule child rules included — the cap is
             // sheet-wide, not per-grouping).
-            if (output.Count >= MaxRulesPerStylesheet)
+            // Per PR #16 review user-recommendation #4 — the count is
+            // PER-STYLESHEET (output.Count - sheetStartCount), not the
+            // global output.Count, so a sheet that previously hit the cap
+            // doesn't poison every subsequent independent sheet.
+            if (output.Count - sheetStartCount >= MaxRulesPerStylesheet)
             {
                 diagnostics?.Emit(new CssDiagnostic(
                     CssDiagnosticCodes.CssRuleLimitExceeded001,
@@ -292,12 +304,12 @@ internal static class CascadeResolver
                 case CssAtRule ar:
                     CollectAtRule(ar, origin, sheetOrder, ref ruleOrder,
                         output, hasContainingSheets, media, layers, currentLayer, diagnostics,
-                        cancellationToken, depth);
+                        sheetStartCount, cancellationToken, depth);
                     break;
                 case CssImportRule import:
                     CollectImportRule(import, origin, sheetOrder, ref ruleOrder,
                         output, hasContainingSheets, media, layers, currentLayer, diagnostics,
-                        cancellationToken, depth);
+                        sheetStartCount, cancellationToken, depth);
                     break;
                 // Other rule kinds (page, font-face, …) don't contribute declarations to
                 // the regular element cascade; they have separate consumers.
@@ -318,6 +330,26 @@ internal static class CascadeResolver
         var compiled = CompileSelector(sr.Selector.RawText, diagnostics, sr.Location);
         if (compiled is not null && compiled.ContainsHas)
             hasContainingSheets.Add(sheetOrder);
+
+        // Per PR #16 review user-recommendation #3 + Copilot review #6 —
+        // enforce MaxSelectorAlternatives. The cap was declared in Phase B
+        // but never wired up; a single rule with millions of comma-separated
+        // alternatives (each compiled to its own SelectorBytecode) would
+        // amplify the per-element matching loop past the per-rule budget.
+        // Truncate post-compile by rebuilding the SelectorList with only
+        // the first N alternatives — the matching loop iterates the
+        // truncated list directly.
+        if (compiled is not null && compiled.Alternatives.Length > MaxSelectorAlternatives)
+        {
+            diagnostics?.Emit(new CssDiagnostic(
+                CssDiagnosticCodes.CssRuleLimitExceeded001,
+                $"Rule exceeded the {MaxSelectorAlternatives}-selector-alternative cap; excess alternatives dropped.",
+                CssDiagnosticSeverity.Warning,
+                sr.Location));
+            compiled = new NetPdf.Css.Selectors.SelectorList(
+                ImmutableArray.CreateRange(compiled.Alternatives.Take(MaxSelectorAlternatives)),
+                compiled.SourceText);
+        }
 
         // Per Phase B B-2 — cap declarations per rule. A hostile rule with
         // thousands of `data-*: value` declarations would inflate every
@@ -354,6 +386,7 @@ internal static class CascadeResolver
         LayerRegistry layers,
         int currentLayer,
         ICssDiagnosticsSink? diagnostics,
+        int sheetStartCount,
         System.Threading.CancellationToken cancellationToken,
         int depth)
     {
@@ -363,13 +396,13 @@ internal static class CascadeResolver
                 if (!media.Matches(ar.Prelude)) return;
                 CollectFromRules(ar.ChildRules, origin, sheetOrder, ref ruleOrder,
                     output, hasContainingSheets, media, layers, currentLayer, diagnostics,
-                    cancellationToken, depth + 1);
+                    sheetStartCount, cancellationToken, depth + 1);
                 break;
             case "supports":
                 if (!SupportsConditionMatches(ar.Prelude, diagnostics, ar.Location)) return;
                 CollectFromRules(ar.ChildRules, origin, sheetOrder, ref ruleOrder,
                     output, hasContainingSheets, media, layers, currentLayer, diagnostics,
-                    cancellationToken, depth + 1);
+                    sheetStartCount, cancellationToken, depth + 1);
                 break;
             case "container":
                 diagnostics?.Emit(new CssDiagnostic(
@@ -381,7 +414,7 @@ internal static class CascadeResolver
             case "layer":
                 CollectLayerAtRule(ar, origin, sheetOrder, ref ruleOrder,
                     output, hasContainingSheets, media, layers, diagnostics,
-                    cancellationToken, depth);
+                    sheetStartCount, cancellationToken, depth);
                 break;
             default:
                 // Unknown at-rule. Three shapes to handle:
@@ -426,6 +459,7 @@ internal static class CascadeResolver
         CssMediaContext media,
         LayerRegistry layers,
         ICssDiagnosticsSink? diagnostics,
+        int sheetStartCount,
         System.Threading.CancellationToken cancellationToken,
         int depth)
     {
@@ -461,7 +495,7 @@ internal static class CascadeResolver
 
         CollectFromRules(ar.ChildRules, origin, sheetOrder, ref ruleOrder,
             output, hasContainingSheets, media, layers, layerIdx, diagnostics,
-            cancellationToken, depth + 1);
+            sheetStartCount, cancellationToken, depth + 1);
     }
 
     /// <summary>Walk an <c>@import</c>'s already-resolved <see cref="CssImportRule.ImportedRules"/>
@@ -486,6 +520,7 @@ internal static class CascadeResolver
         LayerRegistry layers,
         int currentLayer,
         ICssDiagnosticsSink? diagnostics,
+        int sheetStartCount,
         System.Threading.CancellationToken cancellationToken,
         int depth)
     {
@@ -508,7 +543,7 @@ internal static class CascadeResolver
 
         CollectFromRules(import.ImportedRules, origin, sheetOrder, ref ruleOrder,
             output, hasContainingSheets, media, layers, importLayer, diagnostics,
-            cancellationToken, depth + 1);
+            sheetStartCount, cancellationToken, depth + 1);
     }
 
     /// <summary>Per Rec 2: <c>@import url(x) supports(display: grid)</c> arrives at the

--- a/src/NetPdf.Css/Cascade/CascadeResolver.cs
+++ b/src/NetPdf.Css/Cascade/CascadeResolver.cs
@@ -212,6 +212,27 @@ internal static class CascadeResolver
     /// stack budget.</summary>
     private const int MaxAtRuleNestingDepth = 32;
 
+    /// <summary>Per Phase B B-2 — maximum number of compiled rules per
+    /// stylesheet. A hostile sheet with millions of rules would otherwise
+    /// pour CPU into selector compilation + per-element matching even with
+    /// the bloom-filter pre-filter active. 50k is wide enough for any
+    /// real-world author CSS (Tailwind's full build is ~30k) while bounding
+    /// the per-stylesheet upper limit.</summary>
+    internal const int MaxRulesPerStylesheet = 50_000;
+
+    /// <summary>Per Phase B B-2 — maximum number of declarations on a single
+    /// rule. Real rules have &lt; 30; an attacker could synthesize a rule
+    /// with thousands of <c>data-x: y</c> declarations to bloat the cascade
+    /// table per element. Excess declarations are dropped from the tail.</summary>
+    internal const int MaxDeclarationsPerRule = 256;
+
+    /// <summary>Per Phase B B-2 — maximum number of selector alternatives in
+    /// one rule's selector list (i.e., comma-separated selector groups).
+    /// Real rules have &lt; 5 (occasionally &lt; 100 for normalize.css-style
+    /// shorthand); 1024 is the wide cap that catches doc-bombing without
+    /// rejecting legitimate megalists.</summary>
+    internal const int MaxSelectorAlternatives = 1024;
+
     private static void CollectFromRules(
         ImmutableArray<CssRule> rules,
         CssStylesheetOrigin origin,
@@ -245,6 +266,23 @@ internal static class CascadeResolver
             // adversarially-deep nested @media tree could otherwise spend tens of
             // seconds in selector compilation before any post-loop check runs.
             cancellationToken.ThrowIfCancellationRequested();
+
+            // Per Phase B B-2 — cap the running count of compiled rules per
+            // stylesheet so a hostile sheet with millions of rules doesn't
+            // pull the cascade into multi-second CPU paths. Emit one
+            // diagnostic at the moment of overflow + drop every subsequent
+            // rule (style + at-rule child rules included — the cap is
+            // sheet-wide, not per-grouping).
+            if (output.Count >= MaxRulesPerStylesheet)
+            {
+                diagnostics?.Emit(new CssDiagnostic(
+                    CssDiagnosticCodes.CssRuleLimitExceeded001,
+                    $"Stylesheet exceeded the {MaxRulesPerStylesheet}-rule cap; remaining rules skipped.",
+                    CssDiagnosticSeverity.Warning,
+                    CssSourceLocation.Unknown));
+                return;
+            }
+
             switch (rule)
             {
                 case CssStyleRule sr:
@@ -280,9 +318,25 @@ internal static class CascadeResolver
         var compiled = CompileSelector(sr.Selector.RawText, diagnostics, sr.Location);
         if (compiled is not null && compiled.ContainsHas)
             hasContainingSheets.Add(sheetOrder);
+
+        // Per Phase B B-2 — cap declarations per rule. A hostile rule with
+        // thousands of `data-*: value` declarations would inflate every
+        // matched-rule-set per element; tail-truncate so the cascade still
+        // sees the head (most rules pile their important props at the top).
+        var declarations = sr.Declarations;
+        if (declarations.Length > MaxDeclarationsPerRule)
+        {
+            diagnostics?.Emit(new CssDiagnostic(
+                CssDiagnosticCodes.CssRuleLimitExceeded001,
+                $"Rule exceeded the {MaxDeclarationsPerRule}-declaration cap; tail declarations dropped.",
+                CssDiagnosticSeverity.Warning,
+                sr.Location));
+            declarations = ImmutableArray.CreateRange(declarations.Take(MaxDeclarationsPerRule));
+        }
+
         output.Add(new CompiledRule(
             Selectors: compiled,
-            Declarations: sr.Declarations,
+            Declarations: declarations,
             Origin: origin,
             StylesheetOrder: sheetOrder,
             RuleOrder: ruleOrder++,

--- a/src/NetPdf.Css/Diagnostics/CssDiagnosticCodes.cs
+++ b/src/NetPdf.Css/Diagnostics/CssDiagnosticCodes.cs
@@ -74,10 +74,17 @@ internal static class CssDiagnosticCodes
     /// are atomic and can't host generated content. Severity: Info.</summary>
     public const string CssPseudoSuppressedOnReplaced001 = "CSS-PSEUDO-SUPPRESSED-ON-REPLACED-001";
 
-    /// <summary>A stylesheet exceeded one of the per-stylesheet DoS caps:
-    /// total rule count, declarations per rule, or selector alternatives per
-    /// rule. The cascade resolver stops processing rules past the cap and
-    /// truncates declaration / alternative lists to the configured limit.
-    /// Per Phase B B-2. Severity: Warning.</summary>
+    /// <summary>A stylesheet exceeded one of the per-stylesheet / per-rule
+    /// DoS caps: total rules per stylesheet
+    /// (<see cref="Cascade.CascadeResolver.MaxRulesPerStylesheet"/>),
+    /// declarations on a single rule
+    /// (<see cref="Cascade.CascadeResolver.MaxDeclarationsPerRule"/>),
+    /// or comma-separated selector alternatives in one rule's selector list
+    /// (<see cref="Cascade.CascadeResolver.MaxSelectorAlternatives"/>).
+    /// On rule-count overflow the cascade resolver stops processing further
+    /// rules in that stylesheet; on per-rule overflow it tail-truncates the
+    /// declaration or alternative list to the configured limit.
+    /// Per Phase B B-2 + PR #16 review (selector-alternative enforcement
+    /// added in follow-up). Severity: Warning.</summary>
     public const string CssRuleLimitExceeded001 = "CSS-RULE-LIMIT-EXCEEDED-001";
 }

--- a/src/NetPdf.Css/Diagnostics/CssDiagnosticCodes.cs
+++ b/src/NetPdf.Css/Diagnostics/CssDiagnosticCodes.cs
@@ -73,4 +73,11 @@ internal static class CssDiagnosticCodes
     /// CSS Pseudo L4 §3 the pseudo-element is suppressed because replaced elements
     /// are atomic and can't host generated content. Severity: Info.</summary>
     public const string CssPseudoSuppressedOnReplaced001 = "CSS-PSEUDO-SUPPRESSED-ON-REPLACED-001";
+
+    /// <summary>A stylesheet exceeded one of the per-stylesheet DoS caps:
+    /// total rule count, declarations per rule, or selector alternatives per
+    /// rule. The cascade resolver stops processing rules past the cap and
+    /// truncates declaration / alternative lists to the configured limit.
+    /// Per Phase B B-2. Severity: Warning.</summary>
+    public const string CssRuleLimitExceeded001 = "CSS-RULE-LIMIT-EXCEEDED-001";
 }

--- a/src/NetPdf/Diagnostics/DiagnosticCodes.cs
+++ b/src/NetPdf/Diagnostics/DiagnosticCodes.cs
@@ -43,6 +43,29 @@ internal static class DiagnosticCodes
     /// </summary>
     public const string HtmlEventHandlerIgnored001 = "HTML-EVENT-HANDLER-IGNORED-001";
 
+    /// <summary>
+    /// A parsed HTML document exceeded one of the per-document DoS caps:
+    /// total element count, nesting depth, attributes per element, attribute
+    /// value length, or text-node content length. The offending region was
+    /// truncated (excess elements / attributes removed; excess text /
+    /// attribute-value strings clamped) so downstream stages still see a
+    /// rendering-shaped document. One diagnostic is emitted per violation
+    /// kind, naming the cap that fired. Per Phase B B-1.
+    /// Severity: <see cref="DiagnosticSeverity.Warning"/>.
+    /// </summary>
+    public const string HtmlDomLimitExceeded001 = "HTML-DOM-LIMIT-EXCEEDED-001";
+
+    /// <summary>
+    /// The iterative HTML strip pass (per Phase B B-4 — defense against
+    /// AngleSharp normalization or SVG <c>&lt;foreignObject&gt;</c>
+    /// re-introducing stripped script / javascript-URL / event-handler
+    /// content) failed to converge after the maximum iteration cap.
+    /// Dangerous content may still be present in the DOM. The diagnostic
+    /// names the unstable element kind so the author can investigate.
+    /// Severity: <see cref="DiagnosticSeverity.Warning"/>.
+    /// </summary>
+    public const string HtmlStripNotStable001 = "HTML-STRIP-NOT-STABLE-001";
+
     // endregion HTML-*
 
     // region CSS-*

--- a/src/NetPdf/Diagnostics/DiagnosticCodes.cs
+++ b/src/NetPdf/Diagnostics/DiagnosticCodes.cs
@@ -61,10 +61,23 @@ internal static class DiagnosticCodes
     /// re-introducing stripped script / javascript-URL / event-handler
     /// content) failed to converge after the maximum iteration cap.
     /// Dangerous content may still be present in the DOM. The diagnostic
-    /// names the unstable element kind so the author can investigate.
+    /// message names the surviving kind(s) — <c>&lt;script&gt;</c>,
+    /// <c>on*</c> event handler, or <c>javascript:</c>/<c>vbscript:</c>/<c>data:</c>
+    /// URL — so the author can investigate.
     /// Severity: <see cref="DiagnosticSeverity.Warning"/>.
     /// </summary>
     public const string HtmlStripNotStable001 = "HTML-STRIP-NOT-STABLE-001";
+
+    /// <summary>
+    /// The HTML input length exceeded the per-document character cap
+    /// (<see cref="HtmlParsingHost.MaxInputLength"/>). The parse is
+    /// rejected before AngleSharp materializes the tree — defends against
+    /// "1 GiB single-string" attacks where post-parse caps would only
+    /// fire after the parser had already consumed memory + CPU on the
+    /// full input. Per Phase B B-1 follow-up (PR #16 review).
+    /// Severity: <see cref="DiagnosticSeverity.Warning"/>.
+    /// </summary>
+    public const string HtmlInputTooLarge001 = "HTML-INPUT-TOO-LARGE-001";
 
     // endregion HTML-*
 

--- a/src/NetPdf/HtmlParsingHost.cs
+++ b/src/NetPdf/HtmlParsingHost.cs
@@ -127,11 +127,89 @@ internal sealed class HtmlParsingHost
             .ConfigureAwait(false);
 
         var sourceFile = options.BaseUri?.AbsoluteUri;
-        StripScripts(document, options.Diagnostics, sourceFile);
-        StripJavaScriptUrls(document, options.Diagnostics, sourceFile);
-        StripEventHandlerAttributes(document, options.Diagnostics, sourceFile);
+        // Per Phase B B-4 — iterative strip until stable. AngleSharp normalization
+        // can re-route content (e.g., SVG <foreignObject> containing HTML) so a
+        // single strip pass may leave dangerous attributes / elements in the
+        // tree. Re-run the three strip walks until a pass finds nothing to
+        // remove, capped at MaxStripIterations to bound CPU.
+        StripUntilStable(document, options.Diagnostics, sourceFile);
+        // Per Phase B B-1 — DoS caps on the parsed DOM. Runs AFTER strip so the
+        // element / attribute counts measure the real rendering surface, not
+        // material that's about to be removed anyway.
+        EnforceDomSizeCaps(document, options.Diagnostics, sourceFile);
         return document;
     }
+
+    /// <summary>Per Phase B B-4 — fixed-point loop over the three strip walks.
+    /// Most documents converge after the first pass (nothing to remove);
+    /// adversarial documents may need a second pass when AngleSharp's
+    /// normalization re-emits content. <see cref="MaxStripIterations"/>
+    /// bounds wall-clock CPU. If the loop exits at the cap with dangerous
+    /// content still present, emit <c>HTML-STRIP-NOT-STABLE-001</c>.</summary>
+    private static void StripUntilStable(IDocument document, IDiagnosticsSink? sink, string? sourceFile)
+    {
+        for (var iter = 0; iter < MaxStripIterations; iter++)
+        {
+            StripScripts(document, sink, sourceFile);
+            StripJavaScriptUrls(document, sink, sourceFile);
+            StripEventHandlerAttributes(document, sink, sourceFile);
+            if (!HasDangerousContent(document)) return;
+        }
+        sink?.Emit(new Diagnostic(
+            DiagnosticCodes.HtmlStripNotStable001,
+            $"Iterative HTML strip did not converge after {MaxStripIterations} passes; dangerous content may remain in the DOM.",
+            DiagnosticSeverity.Warning,
+            SourceLocation.Unknown));
+    }
+
+    /// <summary>Per Phase B B-4 — maximum number of strip iterations before
+    /// emitting <c>HTML-STRIP-NOT-STABLE-001</c>. Most documents finish in
+    /// the first pass (nothing to remove); 4 is generous for layered
+    /// SVG / foreignObject / nested-namespace cases without inviting
+    /// adversarial amplification.</summary>
+    internal const int MaxStripIterations = 4;
+
+    /// <summary>Returns <see langword="true"/> when the document still
+    /// contains <c>&lt;script&gt;</c> elements, <c>javascript:</c>-bearing
+    /// URL attributes, or <c>on*</c> event-handler attributes after the
+    /// most recent strip pass. Fast path: walk the document once + check
+    /// element name / attribute names against the strip predicates.</summary>
+    private static bool HasDangerousContent(IDocument document)
+    {
+        if (document.DocumentElement is null) return false;
+        foreach (var el in document.All)
+        {
+            if (el is null) continue;
+            // <script> elements (any namespace).
+            if (string.Equals(el.LocalName, "script", System.StringComparison.OrdinalIgnoreCase))
+                return true;
+            foreach (var attr in el.Attributes)
+            {
+                if (attr is null) continue;
+                var name = attr.LocalName;
+                if (name.Length >= 3
+                    && (name[0] == 'o' || name[0] == 'O')
+                    && (name[1] == 'n' || name[1] == 'N'))
+                {
+                    return true; // surviving on* event handler
+                }
+                // Surviving javascript: / vbscript: / data: URL on a known
+                // url-bearing attribute name. The strip walk covers many
+                // attributes by selector; this check is a safety net.
+                if (IsKnownUrlAttribute(name) && IsDangerousUrl(attr.Value))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Per Phase B B-4 — attribute names recognized as URL-bearing
+    /// for the <see cref="HasDangerousContent"/> safety net. Mirrors the
+    /// strip walk's coverage: every name that <see cref="StripJavaScriptUrls"/>
+    /// touches.</summary>
+    private static bool IsKnownUrlAttribute(string name) =>
+        name is "href" or "src" or "srcset" or "action" or "data" or "poster"
+             or "formaction" or "content";
 
     private static void StripScripts(IDocument document, IDiagnosticsSink? sink, string? sourceFile)
     {
@@ -248,6 +326,101 @@ internal sealed class HtmlParsingHost
             // Remove via (namespaceUri, localName) so the right xlink-namespaced attribute drops.
             element.RemoveAttribute(NamespaceNames.XLinkUri, "href");
         }
+
+        // Per Phase B B-5 — SVG-namespace-specific strip pass. SVG carries
+        // executable surfaces beyond what the HTML strip walk above covers:
+        //   1. <animate>/<set>/<animateTransform>/<animateMotion> can SET an
+        //      element's href / xlink:href / src to a javascript: URL via
+        //      attributeName + to/from/values. AngleSharp doesn't apply the
+        //      animation, but Phase 5 PDF emission could re-route the value
+        //      into clickable annotations. Strip the animation if its target
+        //      attribute is URL-bearing AND any of its value forms is dangerous.
+        //   2. <use href="javascript:...">: SVG 2 unprefixed form. The HTML
+        //      strip walk only covers a/area, not <use>. The xlink:href loop
+        //      above covers the prefixed variant; add the unprefixed too.
+        //   3. Generic SVG namespace `href` (without xlink prefix) on any
+        //      element — defense-in-depth for elements not yet enumerated.
+        StripSvgSpecific(document, sink, sourceFile);
+    }
+
+    /// <summary>Per Phase B B-5 — strip SVG-specific dangerous-URL surfaces
+    /// not caught by the HTML walk: <c>&lt;use href&gt;</c> (and other SVG
+    /// elements with unprefixed <c>href</c>), and animation elements
+    /// (<c>&lt;animate&gt;</c>, <c>&lt;set&gt;</c>, <c>&lt;animateTransform&gt;</c>,
+    /// <c>&lt;animateMotion&gt;</c>) whose <c>attributeName</c> is URL-bearing
+    /// and whose <c>to</c> / <c>from</c> / <c>values</c> name a dangerous
+    /// scheme.</summary>
+    private static void StripSvgSpecific(IDocument document, IDiagnosticsSink? sink, string? sourceFile)
+    {
+        foreach (var element in document.All.ToArray())
+        {
+            // Only inspect SVG-namespaced elements; HTML href has been
+            // covered by the explicit-attribute strip walk above.
+            if (!string.Equals(element.NamespaceUri, NamespaceNames.SvgUri, System.StringComparison.Ordinal))
+                continue;
+
+            // Unprefixed href on any SVG element (covers <use href>, <image href>,
+            // <pattern href>, <linearGradient href>, etc.). The element-name set
+            // for SVG href is large and growing; checking every SVG element
+            // with an unprefixed href avoids the maintenance treadmill.
+            var href = element.GetAttribute("href");
+            if (href is not null && IsDangerousUrl(href))
+            {
+                sink?.Emit(new Diagnostic(
+                    DiagnosticCodes.HtmlJavaScriptUrlIgnored001,
+                    $"A {DescribeUrlScheme(href)} URL was found on an SVG <{element.LocalName}> element's href attribute. The attribute was removed.",
+                    DiagnosticSeverity.Warning,
+                    ToSourceLocation(element, sourceFile)));
+                element.RemoveAttribute("href");
+            }
+
+            // Animation elements: <animate>, <set>, <animateTransform>,
+            // <animateMotion>. If attributeName is URL-bearing AND any of
+            // to/from/values contains a dangerous scheme, drop the entire
+            // animation — there's no safe partial recovery.
+            if (IsSvgAnimationElement(element.LocalName))
+            {
+                var attributeName = element.GetAttribute("attributeName");
+                if (attributeName is null) continue;
+                if (!IsKnownUrlAttribute(attributeName)) continue;
+
+                if (HasDangerousAnimationValue(element))
+                {
+                    sink?.Emit(new Diagnostic(
+                        DiagnosticCodes.HtmlJavaScriptUrlIgnored001,
+                        $"An SVG <{element.LocalName}> element targeted '{attributeName}' with a dangerous URL value. The animation element was removed.",
+                        DiagnosticSeverity.Warning,
+                        ToSourceLocation(element, sourceFile)));
+                    element.Remove();
+                }
+            }
+        }
+    }
+
+    /// <summary>True for the four SVG animation elements that can set an
+    /// attribute to an attacker-controlled value at "play time": <c>animate</c>,
+    /// <c>set</c>, <c>animateTransform</c>, <c>animateMotion</c>. Names
+    /// match the SVG spec's element local names case-sensitively (SVG is
+    /// case-sensitive in the XML grammar; AngleSharp preserves case in the
+    /// SVG namespace).</summary>
+    private static bool IsSvgAnimationElement(string localName) =>
+        localName is "animate" or "set" or "animateTransform" or "animateMotion";
+
+    /// <summary>Returns true when any of the animation element's value
+    /// attributes (<c>to</c>, <c>from</c>, <c>values</c>) contains a
+    /// javascript: / vbscript: / data: URL. <c>values</c> is a
+    /// semicolon-separated list per SVG Animation; check each segment.</summary>
+    private static bool HasDangerousAnimationValue(IElement element)
+    {
+        if (IsDangerousUrl(element.GetAttribute("to"))) return true;
+        if (IsDangerousUrl(element.GetAttribute("from"))) return true;
+        var values = element.GetAttribute("values");
+        if (string.IsNullOrEmpty(values)) return false;
+        foreach (var v in values.Split(';'))
+        {
+            if (IsDangerousUrl(v.Trim())) return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -389,6 +562,154 @@ internal sealed class HtmlParsingHost
                     ToSourceLocation(element, sourceFile)));
                 element.RemoveAttribute(name);
             }
+        }
+    }
+
+    // ----- Phase B B-1: DOM size caps -------------------------------------
+
+    /// <summary>Maximum total number of <see cref="IElement"/> nodes in the
+    /// post-strip document. Real-world large invoices / reports have a few
+    /// thousand elements; 250k is a wide allowance that still cuts off
+    /// adversarial documents long before downstream stages start consuming
+    /// minutes of CPU on selector matching alone.</summary>
+    internal const int MaxElementCount = 250_000;
+
+    /// <summary>Maximum nesting depth of element ancestors. Hand-authored docs
+    /// rarely exceed 50; mXSS payloads + zip-bomb-shaped HTML deliberately
+    /// nest far past that. 1024 keeps the recursive walks (cascade,
+    /// VarResolver, BoxBuilder) inside their stack budgets.</summary>
+    internal const int MaxNestingDepth = 1024;
+
+    /// <summary>Maximum number of attributes on a single element. Real
+    /// elements have &lt; 20; an attacker piling thousands of <c>data-*</c>
+    /// attributes on one element would make AngleSharp's per-attribute
+    /// lookups quadratic.</summary>
+    internal const int MaxAttributesPerElement = 256;
+
+    /// <summary>Maximum length of a single attribute value. 1 MiB is generous
+    /// — base64-encoded inline images on <c>src</c> live in the same
+    /// neighborhood — but tight enough that a single <c>data-x="...10MB..."</c>
+    /// can't pull the document into the multi-megabyte band by itself.</summary>
+    internal const int MaxAttributeValueLength = 1024 * 1024;
+
+    /// <summary>Maximum length of a single text-node's content. Legitimate
+    /// large text (verbose chapter, JSON fixture, long table cell) exists,
+    /// so the cap is permissive. 4 MiB stops a single <c>&lt;pre&gt;</c>
+    /// block from becoming a memory bomb on its own.</summary>
+    internal const int MaxTextContentLength = 4 * 1024 * 1024;
+
+    /// <summary>Walk the document depth-first, count elements / attributes /
+    /// text-content lengths, and TRUNCATE any region that exceeds the
+    /// per-document caps. One <c>HTML-DOM-LIMIT-EXCEEDED-001</c> diagnostic
+    /// per violation kind so a pathological doc emits at most ~5 entries —
+    /// not one per offending node.</summary>
+    private static void EnforceDomSizeCaps(IDocument document, IDiagnosticsSink? sink, string? sourceFile)
+    {
+        if (document.DocumentElement is null) return;
+
+        var emitted = new System.Collections.Generic.HashSet<string>();
+        void EmitOnce(string kind, string message, INode? node)
+        {
+            if (!emitted.Add(kind)) return;
+            sink?.Emit(new Diagnostic(
+                DiagnosticCodes.HtmlDomLimitExceeded001,
+                message,
+                DiagnosticSeverity.Warning,
+                node is IElement el ? ToSourceLocation(el, sourceFile) : SourceLocation.Unknown));
+        }
+
+        var elementCount = 0;
+        var stack = new System.Collections.Generic.Stack<(IElement Node, int Depth)>();
+        stack.Push((document.DocumentElement, 0));
+
+        while (stack.Count > 0)
+        {
+            var (element, depth) = stack.Pop();
+            elementCount++;
+
+            if (elementCount > MaxElementCount)
+            {
+                EmitOnce("count",
+                    $"DOM element count exceeded the {MaxElementCount} cap; remaining elements were dropped.",
+                    element);
+                element.Remove();
+                continue;
+            }
+
+            if (depth > MaxNestingDepth)
+            {
+                EmitOnce("depth",
+                    $"DOM nesting depth exceeded the {MaxNestingDepth} cap; over-deep subtree was dropped.",
+                    element);
+                element.Remove();
+                continue;
+            }
+
+            EnforceAttributeCaps(element, EmitOnce);
+            EnforceChildTextLengths(element, EmitOnce);
+
+            // Snapshot children before push — Remove() mutates the parent's
+            // child collection. Push in reverse so traversal is left-to-right
+            // (depth-first pre-order).
+            var children = element.Children.ToArray();
+            for (var i = children.Length - 1; i >= 0; i--)
+            {
+                stack.Push((children[i], depth + 1));
+            }
+        }
+    }
+
+    /// <summary>Trim attributes past <see cref="MaxAttributesPerElement"/> and
+    /// clamp any over-long attribute value to <see cref="MaxAttributeValueLength"/>
+    /// chars (with U+2026 ellipsis). Emits at most one diagnostic per
+    /// violation kind.</summary>
+    private static void EnforceAttributeCaps(IElement element, System.Action<string, string, INode?> emitOnce)
+    {
+        // Snapshot the attribute names; the live attribute collection
+        // invalidates as we remove entries.
+        var attrSnapshot = element.Attributes.Where(a => a is not null).ToArray();
+        if (attrSnapshot.Length > MaxAttributesPerElement)
+        {
+            emitOnce("attr-count",
+                $"Element <{element.LocalName}> exceeded the {MaxAttributesPerElement} attributes-per-element cap; excess attributes removed.",
+                element);
+            for (var i = MaxAttributesPerElement; i < attrSnapshot.Length; i++)
+            {
+                element.RemoveAttribute(attrSnapshot[i]!.NamespaceUri, attrSnapshot[i]!.Name);
+            }
+            attrSnapshot = element.Attributes.Where(a => a is not null).ToArray();
+        }
+        foreach (var attr in attrSnapshot)
+        {
+            if (attr is null) continue;
+            var value = attr.Value;
+            if (value is null) continue;
+            if (value.Length <= MaxAttributeValueLength) continue;
+            emitOnce("attr-length",
+                $"An attribute value exceeded the {MaxAttributeValueLength / 1024} KiB cap; value clamped.",
+                element);
+            // U+2026 sentinel marks the truncation point; downstream code
+            // that decodes the value (e.g., url() / srcset) will simply fail
+            // to resolve — better than processing megabytes of attacker text.
+            element.SetAttribute(attr.NamespaceUri, attr.Name, value[..MaxAttributeValueLength] + "…");
+        }
+    }
+
+    /// <summary>Walk the element's text-node children and clamp any whose
+    /// content exceeds <see cref="MaxTextContentLength"/>. Element children
+    /// are not visited here — the depth-first walk in
+    /// <see cref="EnforceDomSizeCaps"/> visits them on their own.</summary>
+    private static void EnforceChildTextLengths(IElement element, System.Action<string, string, INode?> emitOnce)
+    {
+        foreach (var child in element.ChildNodes)
+        {
+            if (child is not IText text) continue;
+            var data = text.Data;
+            if (data is null || data.Length <= MaxTextContentLength) continue;
+            emitOnce("text-length",
+                $"A text node exceeded the {MaxTextContentLength / (1024 * 1024)} MiB cap; content clamped.",
+                element);
+            text.Data = data[..MaxTextContentLength];
         }
     }
 

--- a/src/NetPdf/HtmlParsingHost.cs
+++ b/src/NetPdf/HtmlParsingHost.cs
@@ -120,6 +120,27 @@ internal sealed class HtmlParsingHost
         ArgumentNullException.ThrowIfNull(options);
         ct.ThrowIfCancellationRequested();
 
+        // Per PR #16 review user-recommendation #1 — pre-parse input length
+        // cap. EnforceDomSizeCaps runs AFTER AngleSharp materializes the
+        // entire DOM, so an attacker who feeds a 1 GiB HTML string still
+        // pays parser CPU + heap for the full tree before per-element
+        // truncation begins. Capping the input string up-front bounds that
+        // worst case at MaxInputLength characters (32 MiB). Treated as a
+        // hard reject rather than truncate: a half-parsed document is
+        // worse than a clear failure (truncation can split open tags + the
+        // DOM caps then can't tell the difference between "intentional
+        // partial" and "attack").
+        if (html.Length > MaxInputLength)
+        {
+            options.Diagnostics?.Emit(new Diagnostic(
+                DiagnosticCodes.HtmlInputTooLarge001,
+                $"HTML input length {html.Length} exceeds the {MaxInputLength}-character cap; the document was rejected before parsing.",
+                DiagnosticSeverity.Warning,
+                SourceLocation.Unknown));
+            throw new System.IO.InvalidDataException(
+                $"HTML input length {html.Length} exceeds the {MaxInputLength}-character cap.");
+        }
+
         var context = BrowsingContext.New(_configuration);
         var address = options.BaseUri?.AbsoluteUri ?? "about:blank";
 
@@ -153,11 +174,17 @@ internal sealed class HtmlParsingHost
             StripScripts(document, sink, sourceFile);
             StripJavaScriptUrls(document, sink, sourceFile);
             StripEventHandlerAttributes(document, sink, sourceFile);
-            if (!HasDangerousContent(document)) return;
+            if (!HasDangerousContent(document, out _)) return;
         }
+        // Per PR #16 Copilot review #9 — name the surviving kind(s) so the
+        // diagnostic is actionable. The doc-comment on
+        // HTML-STRIP-NOT-STABLE-001 promised this; the original message
+        // didn't deliver it. Probe ONCE here so callers see what didn't
+        // converge without us re-iterating the DOM in HasDangerousContent.
+        HasDangerousContent(document, out var survivingKinds);
         sink?.Emit(new Diagnostic(
             DiagnosticCodes.HtmlStripNotStable001,
-            $"Iterative HTML strip did not converge after {MaxStripIterations} passes; dangerous content may remain in the DOM.",
+            $"Iterative HTML strip did not converge after {MaxStripIterations} passes; surviving dangerous content: {survivingKinds}.",
             DiagnosticSeverity.Warning,
             SourceLocation.Unknown));
     }
@@ -174,15 +201,24 @@ internal sealed class HtmlParsingHost
     /// URL attributes, or <c>on*</c> event-handler attributes after the
     /// most recent strip pass. Fast path: walk the document once + check
     /// element name / attribute names against the strip predicates.</summary>
-    private static bool HasDangerousContent(IDocument document)
+    /// <param name="document">The document to inspect.</param>
+    /// <param name="survivingKinds">Comma-separated list of the kinds that
+    /// survived (e.g., <c>"script,onclick,javascript-url"</c>) — empty
+    /// when the document is clean. Lets the caller emit an actionable
+    /// diagnostic per PR #16 Copilot review #9 without re-walking.</param>
+    private static bool HasDangerousContent(IDocument document, out string survivingKinds)
     {
+        survivingKinds = string.Empty;
         if (document.DocumentElement is null) return false;
+        var hasScript = false;
+        var hasOnHandler = false;
+        var hasDangerousUrl = false;
         foreach (var el in document.All)
         {
             if (el is null) continue;
             // <script> elements (any namespace).
             if (string.Equals(el.LocalName, "script", System.StringComparison.OrdinalIgnoreCase))
-                return true;
+                hasScript = true;
             foreach (var attr in el.Attributes)
             {
                 if (attr is null) continue;
@@ -191,16 +227,24 @@ internal sealed class HtmlParsingHost
                     && (name[0] == 'o' || name[0] == 'O')
                     && (name[1] == 'n' || name[1] == 'N'))
                 {
-                    return true; // surviving on* event handler
+                    hasOnHandler = true;
                 }
                 // Surviving javascript: / vbscript: / data: URL on a known
                 // url-bearing attribute name. The strip walk covers many
                 // attributes by selector; this check is a safety net.
                 if (IsKnownUrlAttribute(name) && IsDangerousUrl(attr.Value))
-                    return true;
+                    hasDangerousUrl = true;
             }
+            // Short-circuit when all three are flipped — nothing more to learn.
+            if (hasScript && hasOnHandler && hasDangerousUrl) break;
         }
-        return false;
+        if (!hasScript && !hasOnHandler && !hasDangerousUrl) return false;
+        var parts = new System.Collections.Generic.List<string>(3);
+        if (hasScript) parts.Add("<script>");
+        if (hasOnHandler) parts.Add("on* event handler");
+        if (hasDangerousUrl) parts.Add("javascript:/vbscript:/data: URL");
+        survivingKinds = string.Join(", ", parts);
+        return true;
     }
 
     /// <summary>Per Phase B B-4 — attribute names recognized as URL-bearing
@@ -378,11 +422,17 @@ internal sealed class HtmlParsingHost
             // <animateMotion>. If attributeName is URL-bearing AND any of
             // to/from/values contains a dangerous scheme, drop the entire
             // animation — there's no safe partial recovery.
+            // Per PR #16 Copilot review #5 + user-recommendation #2 —
+            // attributeName carries qualified names too: SVG animation
+            // commonly targets `xlink:href`. Strip the prefix before the
+            // URL-attribute lookup so `<animate attributeName="xlink:href"
+            // to="javascript:...">` doesn't slip past the local-name check.
             if (IsSvgAnimationElement(element.LocalName))
             {
                 var attributeName = element.GetAttribute("attributeName");
                 if (attributeName is null) continue;
-                if (!IsKnownUrlAttribute(attributeName)) continue;
+                var localTarget = StripNamespacePrefix(attributeName);
+                if (!IsKnownUrlAttribute(localTarget)) continue;
 
                 if (HasDangerousAnimationValue(element))
                 {
@@ -395,6 +445,18 @@ internal sealed class HtmlParsingHost
                 }
             }
         }
+    }
+
+    /// <summary>Per PR #16 Copilot review #5 — strip a leading namespace
+    /// prefix (everything up to and including the first <c>:</c>) from a
+    /// qualified attribute name. <c>xlink:href</c> → <c>href</c>;
+    /// <c>href</c> → <c>href</c> (unchanged when no prefix). Returns the
+    /// local-name fragment so URL-attribute lookups work uniformly across
+    /// HTML + SVG + qualified attribute references.</summary>
+    private static string StripNamespacePrefix(string qualifiedName)
+    {
+        var colon = qualifiedName.IndexOf(':');
+        return colon < 0 ? qualifiedName : qualifiedName[(colon + 1)..];
     }
 
     /// <summary>True for the four SVG animation elements that can set an
@@ -567,6 +629,15 @@ internal sealed class HtmlParsingHost
 
     // ----- Phase B B-1: DOM size caps -------------------------------------
 
+    /// <summary>Per PR #16 review user-recommendation #1 — maximum HTML input
+    /// length (UTF-16 chars). Defends against the "1 GiB single-string"
+    /// attack: <see cref="EnforceDomSizeCaps"/> can only run after AngleSharp
+    /// has already parsed the tree, so a hostile input is bounded only by
+    /// the parser's intermediate storage cost without an up-front cap. 32 MiB
+    /// (16 M chars × 2 bytes/char) is generous for any real document — the
+    /// largest invoices in the corpus are &lt; 200 KiB.</summary>
+    internal const int MaxInputLength = 16 * 1024 * 1024;
+
     /// <summary>Maximum total number of <see cref="IElement"/> nodes in the
     /// post-strip document. Real-world large invoices / reports have a few
     /// thousand elements; 250k is a wide allowance that still cuts off
@@ -648,9 +719,45 @@ internal sealed class HtmlParsingHost
             EnforceAttributeCaps(element, EmitOnce);
             EnforceChildTextLengths(element, EmitOnce);
 
-            // Snapshot children before push — Remove() mutates the parent's
-            // child collection. Push in reverse so traversal is left-to-right
-            // (depth-first pre-order).
+            // Per PR #16 Copilot review #1 — bound the children-snapshot to
+            // the remaining element budget. Without this, a wide
+            // <body>{1M children} parents into a 1M-entry IElement[] before
+            // the per-pop MaxElementCount check fires. Compute the budget
+            // up-front; only materialize that many children + delete the
+            // rest in place. The Length lookup on Children is O(1) on
+            // AngleSharp's child collection.
+            var childCount = element.Children.Length;
+            var remainingBudget = MaxElementCount - elementCount;
+            if (remainingBudget <= 0)
+            {
+                // Already at the cap. Drop every child of this element + emit
+                // the count diagnostic if not yet emitted.
+                EmitOnce("count",
+                    $"DOM element count exceeded the {MaxElementCount} cap; remaining elements were dropped.",
+                    element);
+                while (element.FirstElementChild is { } first) first.Remove();
+                continue;
+            }
+            if (childCount > remainingBudget)
+            {
+                EmitOnce("count",
+                    $"DOM element count exceeded the {MaxElementCount} cap; remaining elements were dropped.",
+                    element);
+                // Drop the doomed tail in place (using FirstElementChild +
+                // sibling traversal would force iteration to advance past
+                // the budget — using LastElementChild + Remove drops them
+                // back-to-front in O(doomed) without creating a tail array).
+                while (element.Children.Length > remainingBudget)
+                {
+                    element.LastElementChild!.Remove();
+                }
+                childCount = remainingBudget;
+            }
+
+            // Now snapshot the (bounded) child set + push for traversal.
+            // Push in reverse so depth-first pre-order traversal stays
+            // left-to-right when popping.
+            if (childCount == 0) continue;
             var children = element.Children.ToArray();
             for (var i = children.Length - 1; i >= 0; i--)
             {
@@ -663,6 +770,16 @@ internal sealed class HtmlParsingHost
     /// clamp any over-long attribute value to <see cref="MaxAttributeValueLength"/>
     /// chars (with U+2026 ellipsis). Emits at most one diagnostic per
     /// violation kind.</summary>
+    /// <remarks>
+    /// Per PR #16 Copilot review #3 + #4 — the
+    /// <c>(namespaceUri, localName)</c> overloads of
+    /// <c>IElement.RemoveAttribute</c> + <c>IElement.SetAttribute</c>
+    /// expect a LOCAL name (e.g., <c>href</c>), not the qualified form
+    /// (<c>xlink:href</c>) that <see cref="IAttr.Name"/> returns for
+    /// namespaced attributes. Pass <see cref="IAttr.LocalName"/> instead.
+    /// For non-namespaced attributes <c>NamespaceUri</c> is <see langword="null"/>;
+    /// the no-namespace overload then handles those correctly.
+    /// </remarks>
     private static void EnforceAttributeCaps(IElement element, System.Action<string, string, INode?> emitOnce)
     {
         // Snapshot the attribute names; the live attribute collection
@@ -675,7 +792,7 @@ internal sealed class HtmlParsingHost
                 element);
             for (var i = MaxAttributesPerElement; i < attrSnapshot.Length; i++)
             {
-                element.RemoveAttribute(attrSnapshot[i]!.NamespaceUri, attrSnapshot[i]!.Name);
+                RemoveAttributeNamespaceAware(element, attrSnapshot[i]!);
             }
             attrSnapshot = element.Attributes.Where(a => a is not null).ToArray();
         }
@@ -691,7 +808,43 @@ internal sealed class HtmlParsingHost
             // U+2026 sentinel marks the truncation point; downstream code
             // that decodes the value (e.g., url() / srcset) will simply fail
             // to resolve — better than processing megabytes of attacker text.
-            element.SetAttribute(attr.NamespaceUri, attr.Name, value[..MaxAttributeValueLength] + "…");
+            SetAttributeNamespaceAware(element, attr,
+                value[..MaxAttributeValueLength] + "…");
+        }
+    }
+
+    /// <summary>Namespace-aware attribute removal. <see cref="IAttr.NamespaceUri"/>
+    /// is <see langword="null"/> for plain HTML attributes (<c>href</c>,
+    /// <c>class</c>) and a real URI for namespaced attributes
+    /// (<c>xlink:href</c> → <c>http://www.w3.org/1999/xlink</c>). Picks the
+    /// matching <c>IElement.RemoveAttribute</c> overload so the right
+    /// attribute drops in either case.</summary>
+    private static void RemoveAttributeNamespaceAware(IElement element, IAttr attr)
+    {
+        if (string.IsNullOrEmpty(attr.NamespaceUri))
+        {
+            element.RemoveAttribute(attr.Name);
+        }
+        else
+        {
+            element.RemoveAttribute(attr.NamespaceUri, attr.LocalName);
+        }
+    }
+
+    /// <summary>Namespace-aware attribute set. Mirrors
+    /// <see cref="RemoveAttributeNamespaceAware"/> — pick the local-name
+    /// overload for namespaced attributes so we don't end up with two
+    /// attributes (the original <c>xlink:href</c> + a freshly-created
+    /// <c>xlink:href</c> in the no-namespace bucket).</summary>
+    private static void SetAttributeNamespaceAware(IElement element, IAttr attr, string newValue)
+    {
+        if (string.IsNullOrEmpty(attr.NamespaceUri))
+        {
+            element.SetAttribute(attr.Name, newValue);
+        }
+        else
+        {
+            element.SetAttribute(attr.NamespaceUri, attr.LocalName, newValue);
         }
     }
 
@@ -699,6 +852,12 @@ internal sealed class HtmlParsingHost
     /// content exceeds <see cref="MaxTextContentLength"/>. Element children
     /// are not visited here — the depth-first walk in
     /// <see cref="EnforceDomSizeCaps"/> visits them on their own.</summary>
+    /// <remarks>Per PR #16 Copilot review #2 — clamped values include the
+    /// U+2026 ellipsis sentinel to match the contract documented on
+    /// <c>HTML-DOM-LIMIT-EXCEEDED-001</c> + the parallel attribute-value
+    /// clamp in <see cref="EnforceAttributeCaps"/>. Lets a downstream reader
+    /// know visually that the content was cut off rather than naturally
+    /// short.</remarks>
     private static void EnforceChildTextLengths(IElement element, System.Action<string, string, INode?> emitOnce)
     {
         foreach (var child in element.ChildNodes)
@@ -709,7 +868,7 @@ internal sealed class HtmlParsingHost
             emitOnce("text-length",
                 $"A text node exceeded the {MaxTextContentLength / (1024 * 1024)} MiB cap; content clamped.",
                 element);
-            text.Data = data[..MaxTextContentLength];
+            text.Data = data[..MaxTextContentLength] + "…";
         }
     }
 

--- a/src/NetPdf/Resources/UriSafetyValidator.cs
+++ b/src/NetPdf/Resources/UriSafetyValidator.cs
@@ -43,12 +43,48 @@ namespace NetPdf;
 /// </summary>
 public static class UriSafetyValidator
 {
+    /// <summary>Per PR #16 review user-recommendation #5 + Copilot review #8 —
+    /// the result of <see cref="Validate"/> is no longer a binary
+    /// safe/unsafe split. <c>file:</c> URIs under the <c>AllowFileSchemeUnderBaseUri</c>
+    /// default need a base-path check that this validator does not perform
+    /// (it has no <c>BaseUri</c> in scope), and treating the
+    /// scheme-allowlist verdict as a complete answer led to easy misuse.
+    /// The three-state <see cref="SafetyOutcome"/> makes the contract
+    /// explicit at the call site.</summary>
+    public enum SafetyOutcome
+    {
+        /// <summary>Scheme + host both pass policy. The loader may proceed
+        /// with the fetch.</summary>
+        Safe = 0,
+        /// <summary>Scheme or host violates policy. The loader must reject
+        /// the fetch + emit <c>RES-SECURITY-DENIED-001</c>.</summary>
+        Unsafe = 1,
+        /// <summary>Scheme is allowed but a follow-up check is required
+        /// before the fetch is safe. For <c>file:</c> URIs this means the
+        /// loader must verify the resolved path lies under
+        /// <c>HtmlPdfOptions.BaseUri</c>'s directory subtree (the
+        /// <c>AllowFileSchemeUnderBaseUri</c> contract). The validator
+        /// cannot perform this check itself because it does not know the
+        /// active <c>BaseUri</c>.</summary>
+        RequiresBasePathCheck = 2,
+    }
+
     /// <summary>Result of a validation check.</summary>
-    /// <param name="IsSafe"><see langword="true"/> when the URI passes both
-    /// scheme + host policy checks.</param>
-    /// <param name="Reason">When unsafe, a human-readable reason suitable for
-    /// inclusion in a diagnostic message. <see langword="null"/> when safe.</param>
-    public readonly record struct Verdict(bool IsSafe, string? Reason);
+    /// <param name="Outcome">The three-state safety verdict.</param>
+    /// <param name="Reason">When <see cref="Outcome"/> is
+    /// <see cref="SafetyOutcome.Unsafe"/>, a human-readable reason
+    /// suitable for diagnostic emission. For
+    /// <see cref="SafetyOutcome.RequiresBasePathCheck"/>, names the
+    /// follow-up check the loader must perform. <see langword="null"/>
+    /// when <see cref="Outcome"/> is <see cref="SafetyOutcome.Safe"/>.</param>
+    public readonly record struct Verdict(SafetyOutcome Outcome, string? Reason)
+    {
+        /// <summary>Convenience: <see langword="true"/> only when
+        /// <see cref="Outcome"/> is <see cref="SafetyOutcome.Safe"/>.
+        /// Callers that need the three-state distinction should switch
+        /// on <see cref="Outcome"/> directly.</summary>
+        public bool IsSafe => Outcome == SafetyOutcome.Safe;
+    }
 
     /// <summary>Validate <paramref name="uri"/>'s scheme + host against
     /// <paramref name="policy"/>. For host validation, the URI host is parsed
@@ -61,28 +97,41 @@ public static class UriSafetyValidator
         ArgumentNullException.ThrowIfNull(policy);
 
         var schemeVerdict = ValidateScheme(uri, policy);
-        if (!schemeVerdict.IsSafe) return schemeVerdict;
+        if (schemeVerdict.Outcome != SafetyOutcome.Safe) return schemeVerdict;
 
-        // For HTTP(S), if the host parses as an IP literal, run the blocklist
-        // check now. Symbolic hosts defer to post-DNS validation.
-        if (uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
+        // Per PR #16 Copilot review #8 — IP blocklist + AllowedHosts apply
+        // ONLY to fetch-routing schemes (http, https). For file: + data:
+        // schemes the host portion either doesn't exist (data:) or is
+        // not network-routed (file://localhost/etc/x is a path semantic,
+        // not a network host). Applying the blocklist there yielded
+        // surprising rejections for legitimate inputs.
+        var scheme = uri.Scheme.ToLowerInvariant();
+        if (scheme is "http" or "https")
         {
-            if (IPAddress.TryParse(uri.Host, out var ip) && IsBlockedIp(ip, out var why))
+            // For HTTP(S), if the host parses as an IP literal, run the
+            // blocklist check now. Symbolic hosts defer to post-DNS
+            // validation.
+            if (uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
             {
-                return new Verdict(false, $"host '{uri.Host}' is in the {why} blocklist");
+                if (IPAddress.TryParse(uri.Host, out var ip) && IsBlockedIp(ip, out var why))
+                {
+                    return new Verdict(SafetyOutcome.Unsafe,
+                        $"host '{uri.Host}' is in the {why} blocklist");
+                }
+            }
+
+            // Host allowlist (when configured). Wildcards: leading "*." matches
+            // any single subdomain. The check is case-insensitive per host
+            // grammar.
+            if (policy.AllowedHosts is { Count: > 0 } allowedHosts
+                && !MatchesAllowedHost(uri.Host, allowedHosts))
+            {
+                return new Verdict(SafetyOutcome.Unsafe,
+                    $"host '{uri.Host}' is not in the allowed-host list");
             }
         }
 
-        // Host allowlist (when configured). Wildcards: leading "*." matches
-        // any single subdomain. The check is case-insensitive per host
-        // grammar.
-        if (policy.AllowedHosts is { Count: > 0 } allowedHosts
-            && !MatchesAllowedHost(uri.Host, allowedHosts))
-        {
-            return new Verdict(false, $"host '{uri.Host}' is not in the allowed-host list");
-        }
-
-        return new Verdict(true, null);
+        return schemeVerdict;
     }
 
     /// <summary>Scheme-only check (no host inspection). Useful when the caller
@@ -97,29 +146,34 @@ public static class UriSafetyValidator
         {
             case "http":
                 return policy.AllowHttpScheme
-                    ? new Verdict(true, null)
-                    : new Verdict(false, "http: scheme is disabled by SecurityPolicy");
+                    ? new Verdict(SafetyOutcome.Safe, null)
+                    : new Verdict(SafetyOutcome.Unsafe, "http: scheme is disabled by SecurityPolicy");
             case "https":
                 return policy.AllowHttpsScheme
-                    ? new Verdict(true, null)
-                    : new Verdict(false, "https: scheme is disabled by SecurityPolicy");
+                    ? new Verdict(SafetyOutcome.Safe, null)
+                    : new Verdict(SafetyOutcome.Unsafe, "https: scheme is disabled by SecurityPolicy");
             case "file":
-                if (policy.AllowFileScheme) return new Verdict(true, null);
+                if (policy.AllowFileScheme)
+                    return new Verdict(SafetyOutcome.Safe, null);
                 if (policy.AllowFileSchemeUnderBaseUri)
                 {
-                    // Under-baseuri matching is the loader's responsibility
-                    // — it has the BaseUri, this validator does not. Returning
-                    // safe here is OK; the loader's path-prefix check is the
-                    // actual gate.
-                    return new Verdict(true, null);
+                    // Per PR #16 review user-recommendation #5 — the under-baseuri
+                    // gate IS the actual safety check, but the validator can't
+                    // perform it (no BaseUri in scope). Return the new
+                    // RequiresBasePathCheck outcome so the caller knows it
+                    // MUST perform the path-prefix check before the fetch is
+                    // safe. The previous Verdict(true) result was easy to
+                    // misuse as a complete verdict.
+                    return new Verdict(SafetyOutcome.RequiresBasePathCheck,
+                        "file: requires loader to verify the resolved path is under HtmlPdfOptions.BaseUri's subtree");
                 }
-                return new Verdict(false, "file: scheme is disabled by SecurityPolicy");
+                return new Verdict(SafetyOutcome.Unsafe, "file: scheme is disabled by SecurityPolicy");
             case "data":
                 return policy.AllowDataUri
-                    ? new Verdict(true, null)
-                    : new Verdict(false, "data: URIs are disabled by SecurityPolicy");
+                    ? new Verdict(SafetyOutcome.Safe, null)
+                    : new Verdict(SafetyOutcome.Unsafe, "data: URIs are disabled by SecurityPolicy");
             default:
-                return new Verdict(false, $"scheme '{uri.Scheme}:' is not in the allowed set");
+                return new Verdict(SafetyOutcome.Unsafe, $"scheme '{uri.Scheme}:' is not in the allowed set");
         }
     }
 

--- a/src/NetPdf/Resources/UriSafetyValidator.cs
+++ b/src/NetPdf/Resources/UriSafetyValidator.cs
@@ -1,0 +1,243 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace NetPdf;
+
+/// <summary>
+/// Per Phase B B-7 — the SSRF / SSRP gate every resource-loader implementation
+/// is expected to call before issuing an outbound fetch. Combines two checks:
+///
+/// <list type="number">
+///   <item><description><b>Scheme allowlist</b> — only schemes enabled on the
+///   active <see cref="SecurityPolicy"/> are accepted. Default policy
+///   (<see cref="SecurityPolicy.SafeDefault"/>) accepts <c>file:</c> only when
+///   the path is under <see cref="HtmlPdfOptions.BaseUri"/> + <c>data:</c>
+///   inline content; both <c>http:</c> and <c>https:</c> are off.</description></item>
+///   <item><description><b>Private / loopback / link-local IP blocklist</b> for
+///   HTTP(S) hosts. Catches the standard SSRF amplifier set: cloud-metadata
+///   endpoints (<c>169.254.169.254</c> AWS / GCE / Azure / Alibaba; <c>fd00::/8</c>
+///   IPv6 ULA), localhost (<c>127.0.0.0/8</c>, <c>::1</c>), private LAN
+///   (<c>10/8</c>, <c>172.16/12</c>, <c>192.168/16</c>, <c>fc00::/7</c>), link-local
+///   (<c>169.254/16</c>, <c>fe80::/10</c>), multicast (<c>224.0.0.0/4</c>,
+///   <c>ff00::/8</c>), and unspecified (<c>0.0.0.0</c>, <c>::</c>). Hosts that
+///   resolve via DNS are NOT validated here — the loader must resolve to
+///   IP, then re-validate to defend against DNS rebinding. <see cref="IsBlockedIp"/>
+///   exposes the IP check standalone for that use.</description></item>
+/// </list>
+///
+/// <para><b>Phase B contract.</b> NetPdf v1 ships with no default loader, so this
+/// validator's only client today is unit tests. Phase 5 wires a real
+/// <see cref="IResourceLoader"/> implementation that calls
+/// <see cref="ValidateScheme"/> at intent time + <see cref="IsBlockedIp"/>
+/// after DNS resolution, refusing the fetch on any "unsafe" verdict and
+/// emitting <c>RES-LOAD-FAILED-001</c> with the rejection reason.</para>
+///
+/// <para><b>What this does NOT do.</b> Network policy (firewalls, egress
+/// proxies, captive portals) belongs at the OS / fabric layer; this validator
+/// addresses application-level SSRF defense only. It also does not handle
+/// HTTP redirects — the loader must re-validate the redirect target host
+/// after each hop.</para>
+/// </summary>
+public static class UriSafetyValidator
+{
+    /// <summary>Result of a validation check.</summary>
+    /// <param name="IsSafe"><see langword="true"/> when the URI passes both
+    /// scheme + host policy checks.</param>
+    /// <param name="Reason">When unsafe, a human-readable reason suitable for
+    /// inclusion in a diagnostic message. <see langword="null"/> when safe.</param>
+    public readonly record struct Verdict(bool IsSafe, string? Reason);
+
+    /// <summary>Validate <paramref name="uri"/>'s scheme + host against
+    /// <paramref name="policy"/>. For host validation, the URI host is parsed
+    /// as an IP literal where applicable; symbolic hostnames pass the host
+    /// check (the loader is expected to call <see cref="IsBlockedIp"/> after
+    /// DNS resolution to defend against DNS rebinding).</summary>
+    public static Verdict Validate(Uri uri, SecurityPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        var schemeVerdict = ValidateScheme(uri, policy);
+        if (!schemeVerdict.IsSafe) return schemeVerdict;
+
+        // For HTTP(S), if the host parses as an IP literal, run the blocklist
+        // check now. Symbolic hosts defer to post-DNS validation.
+        if (uri.HostNameType is UriHostNameType.IPv4 or UriHostNameType.IPv6)
+        {
+            if (IPAddress.TryParse(uri.Host, out var ip) && IsBlockedIp(ip, out var why))
+            {
+                return new Verdict(false, $"host '{uri.Host}' is in the {why} blocklist");
+            }
+        }
+
+        // Host allowlist (when configured). Wildcards: leading "*." matches
+        // any single subdomain. The check is case-insensitive per host
+        // grammar.
+        if (policy.AllowedHosts is { Count: > 0 } allowedHosts
+            && !MatchesAllowedHost(uri.Host, allowedHosts))
+        {
+            return new Verdict(false, $"host '{uri.Host}' is not in the allowed-host list");
+        }
+
+        return new Verdict(true, null);
+    }
+
+    /// <summary>Scheme-only check (no host inspection). Useful when the caller
+    /// has not yet resolved the URL or wants to short-circuit on scheme
+    /// rejection before paying DNS cost.</summary>
+    public static Verdict ValidateScheme(Uri uri, SecurityPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        switch (uri.Scheme.ToLowerInvariant())
+        {
+            case "http":
+                return policy.AllowHttpScheme
+                    ? new Verdict(true, null)
+                    : new Verdict(false, "http: scheme is disabled by SecurityPolicy");
+            case "https":
+                return policy.AllowHttpsScheme
+                    ? new Verdict(true, null)
+                    : new Verdict(false, "https: scheme is disabled by SecurityPolicy");
+            case "file":
+                if (policy.AllowFileScheme) return new Verdict(true, null);
+                if (policy.AllowFileSchemeUnderBaseUri)
+                {
+                    // Under-baseuri matching is the loader's responsibility
+                    // — it has the BaseUri, this validator does not. Returning
+                    // safe here is OK; the loader's path-prefix check is the
+                    // actual gate.
+                    return new Verdict(true, null);
+                }
+                return new Verdict(false, "file: scheme is disabled by SecurityPolicy");
+            case "data":
+                return policy.AllowDataUri
+                    ? new Verdict(true, null)
+                    : new Verdict(false, "data: URIs are disabled by SecurityPolicy");
+            default:
+                return new Verdict(false, $"scheme '{uri.Scheme}:' is not in the allowed set");
+        }
+    }
+
+    /// <summary>True when <paramref name="ip"/> falls in any of the
+    /// well-known SSRF amplifier ranges (loopback, private, link-local,
+    /// cloud-metadata, multicast, unspecified). The <paramref name="reason"/>
+    /// out parameter names the matching range so the caller can produce a
+    /// specific diagnostic.</summary>
+    public static bool IsBlockedIp(IPAddress ip, out string reason)
+    {
+        ArgumentNullException.ThrowIfNull(ip);
+
+        if (IPAddress.IsLoopback(ip)) { reason = "loopback"; return true; }
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+        {
+            return IsBlockedV4(ip, out reason);
+        }
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            return IsBlockedV6(ip, out reason);
+        }
+        reason = "unsupported-address-family";
+        return true;
+    }
+
+    private static bool IsBlockedV4(IPAddress ip, out string reason)
+    {
+        var bytes = ip.GetAddressBytes();
+        // 0.0.0.0/8 — "this network" / unspecified.
+        if (bytes[0] == 0) { reason = "unspecified"; return true; }
+        // 10.0.0.0/8 — RFC 1918 private.
+        if (bytes[0] == 10) { reason = "private"; return true; }
+        // 100.64.0.0/10 — RFC 6598 carrier-grade NAT.
+        if (bytes[0] == 100 && (bytes[1] & 0xC0) == 64) { reason = "carrier-grade-nat"; return true; }
+        // 127.0.0.0/8 — loopback (covered by IsLoopback but defensive).
+        if (bytes[0] == 127) { reason = "loopback"; return true; }
+        // 169.254.0.0/16 — RFC 3927 link-local + cloud-metadata
+        // (169.254.169.254 is AWS / GCE / Azure / Alibaba IMDS).
+        if (bytes[0] == 169 && bytes[1] == 254) { reason = "link-local-or-metadata"; return true; }
+        // 172.16.0.0/12 — RFC 1918 private.
+        if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) { reason = "private"; return true; }
+        // 192.0.0.0/24 — IETF assignments / well-known.
+        if (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 0) { reason = "ietf-reserved"; return true; }
+        // 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 — TEST-NET.
+        if (bytes[0] == 192 && bytes[1] == 0 && bytes[2] == 2) { reason = "test-net"; return true; }
+        if (bytes[0] == 198 && bytes[1] == 51 && bytes[2] == 100) { reason = "test-net"; return true; }
+        if (bytes[0] == 203 && bytes[1] == 0 && bytes[2] == 113) { reason = "test-net"; return true; }
+        // 192.168.0.0/16 — RFC 1918 private.
+        if (bytes[0] == 192 && bytes[1] == 168) { reason = "private"; return true; }
+        // 198.18.0.0/15 — RFC 2544 benchmark.
+        if (bytes[0] == 198 && (bytes[1] == 18 || bytes[1] == 19)) { reason = "benchmark"; return true; }
+        // 224.0.0.0/4 — multicast.
+        if (bytes[0] >= 224 && bytes[0] <= 239) { reason = "multicast"; return true; }
+        // 240.0.0.0/4 — reserved (includes 255.255.255.255 broadcast).
+        if (bytes[0] >= 240) { reason = "reserved"; return true; }
+
+        reason = "";
+        return false;
+    }
+
+    private static bool IsBlockedV6(IPAddress ip, out string reason)
+    {
+        var bytes = ip.GetAddressBytes();
+        // :: — unspecified.
+        var allZero = true;
+        for (var i = 0; i < bytes.Length; i++) { if (bytes[i] != 0) { allZero = false; break; } }
+        if (allZero) { reason = "unspecified"; return true; }
+        // ::1 — loopback (covered by IsLoopback above but defensive).
+        if (IPAddress.IsLoopback(ip)) { reason = "loopback"; return true; }
+        // ::ffff:0:0/96 — IPv4-mapped; recurse into V4 check on the trailing 4 bytes.
+        if (IsIPv4MappedV6(bytes))
+        {
+            var v4 = new IPAddress(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
+            if (IPAddress.IsLoopback(v4)) { reason = "v4-mapped-loopback"; return true; }
+            if (IsBlockedV4(v4, out var v4Reason))
+            {
+                reason = "v4-mapped-" + v4Reason;
+                return true;
+            }
+        }
+        // fc00::/7 — Unique Local Addresses (RFC 4193).
+        if ((bytes[0] & 0xFE) == 0xFC) { reason = "unique-local"; return true; }
+        // fe80::/10 — link-local.
+        if (bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80) { reason = "link-local"; return true; }
+        // ff00::/8 — multicast.
+        if (bytes[0] == 0xFF) { reason = "multicast"; return true; }
+
+        reason = "";
+        return false;
+    }
+
+    private static bool IsIPv4MappedV6(byte[] bytes)
+    {
+        // ::ffff:a.b.c.d — bytes[0..9] = 0, bytes[10..11] = 0xff, 0xff.
+        for (var i = 0; i < 10; i++) { if (bytes[i] != 0) return false; }
+        return bytes[10] == 0xFF && bytes[11] == 0xFF;
+    }
+
+    private static bool MatchesAllowedHost(string host, IReadOnlyList<string> allowed)
+    {
+        foreach (var pattern in allowed)
+        {
+            if (string.IsNullOrEmpty(pattern)) continue;
+            // Wildcard form: "*.example.com" matches "foo.example.com" but
+            // not "example.com" itself (single-label wildcard, not greedy).
+            if (pattern.StartsWith("*.", StringComparison.Ordinal))
+            {
+                var suffix = pattern[1..]; // ".example.com"
+                if (host.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                    && host.Length > suffix.Length
+                    && !host[..^suffix.Length].Contains('.'))
+                {
+                    return true;
+                }
+                continue;
+            }
+            if (string.Equals(host, pattern, StringComparison.OrdinalIgnoreCase)) return true;
+        }
+        return false;
+    }
+}

--- a/tests/NetPdf.UnitTests/Phase2/PhaseBSecurityHardeningTests.cs
+++ b/tests/NetPdf.UnitTests/Phase2/PhaseBSecurityHardeningTests.cs
@@ -3,9 +3,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using NetPdf.Css.Cascade;
-using NetPdf.Css.Diagnostics;
-using NetPdf.Css.Parser;
 using Xunit;
 
 namespace NetPdf.UnitTests.Phase2;
@@ -75,8 +72,11 @@ public sealed class PhaseBSecurityHardeningTests
             d => d.Code == "HTML-DOM-LIMIT-EXCEEDED-001"
                  && d.Message.Contains("text node"));
         var pre = doc.QuerySelector("pre")!;
-        Assert.True(pre.TextContent.Length <= 4 * 1024 * 1024,
+        // Per PR #16 Copilot review #2 — clamped text now has the U+2026
+        // ellipsis appended, so allow length = cap + 1.
+        Assert.True(pre.TextContent.Length <= 4 * 1024 * 1024 + 1,
             $"expected text clamped; got {pre.TextContent.Length}");
+        Assert.EndsWith("…", pre.TextContent);
     }
 
     [Fact]
@@ -101,12 +101,13 @@ public sealed class PhaseBSecurityHardeningTests
     [Fact]
     public async Task B1_one_diagnostic_per_violation_kind()
     {
-        // 10 separate over-long attribute values across 5 elements should
-        // produce ONE attr-length diagnostic, not 10 — to keep adversarial
-        // documents from flooding the sink.
+        // 6 separate over-long attribute values across 3 elements should
+        // produce ONE attr-length diagnostic, not 6 — to keep adversarial
+        // documents from flooding the sink. (Pre-parse 16 MiB cap means
+        // we can't pile too many huge attrs into one input string.)
         var sb = new System.Text.StringBuilder("<html><body>");
-        var huge = new string('y', 2 * 1024 * 1024);
-        for (var i = 0; i < 5; i++)
+        var huge = new string('y', 1024 * 1024 + 100); // 1 MiB + 100 — just over cap
+        for (var i = 0; i < 3; i++)
         {
             sb.Append($"<div data-x=\"{huge}\" data-y=\"{huge}\">x</div>");
         }
@@ -121,12 +122,13 @@ public sealed class PhaseBSecurityHardeningTests
     }
 
     // --- B-2: CSS rule + declaration caps -----------------------------------
-
-    private sealed class CapturingCssSink : ICssDiagnosticsSink
-    {
-        public System.Collections.Generic.List<CssDiagnostic> Diagnostics { get; } = new();
-        public void Emit(CssDiagnostic d) => Diagnostics.Add(d);
-    }
+    // Per PR #16 Copilot review #11 — `CapturingCssSink` was previously
+    // declared up here but unused. The follow-up B3 test (unterminated
+    // calc()) uses CalcResolver.Resolve directly, so a small CapturingCssSink
+    // is re-introduced near that test rather than living unused at the top.
+    // CSS-side diagnostics for the rest of the suite route through the
+    // public sink (CapturingPublicSink) via PublicDiagnosticsSinkAdapter
+    // wired by Phase2Pipeline.
 
     [Fact]
     public async Task B2_excessive_rule_count_capped_per_stylesheet()
@@ -374,25 +376,56 @@ public sealed class PhaseBSecurityHardeningTests
     [InlineData("vbscript:")]      // legacy IE scripting URI
     public void B6_smoke_pdf_byte_stream_omits_dangerous_token(string token)
     {
-        var bytes = NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument();
-        // PDF tokens are ASCII; Latin1 round-trips cleanly without throwing on
-        // non-ASCII bytes from compressed streams.
-        var text = System.Text.Encoding.Latin1.GetString(bytes);
-        Assert.False(text.Contains(token, System.StringComparison.Ordinal),
-            $"PDF output unexpectedly contained dangerous token '{token}'.");
+        // Per PR #16 Copilot review #12 — search only the plaintext regions
+        // of the PDF. The byte stream contains FlateDecode'd compressed
+        // payloads (image data, content streams) where short ASCII
+        // substrings like "/JS" or "javascript:" can occur by chance,
+        // producing false-positive failures. Strip the
+        // `stream\n...\nendstream` regions before scanning so the test
+        // pins what the WRITER intentionally emits, not what compressed
+        // bytes happen to look like.
+        var plainText = ExtractPdfPlaintext(NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument());
+        Assert.False(plainText.Contains(token, System.StringComparison.Ordinal),
+            $"PDF output unexpectedly contained dangerous token '{token}' in plaintext regions.");
     }
 
     [Fact]
     public void B6_smoke_pdf_emits_no_uri_action()
     {
         // Both /URI as an action subtype and /URI as a key — the writer
-        // must not emit any link-action surfaces in v1.
-        var bytes = NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument();
-        var text = System.Text.Encoding.Latin1.GetString(bytes);
-        Assert.False(text.Contains("/Type /Action", System.StringComparison.Ordinal),
+        // must not emit any link-action surfaces in v1. Plaintext-only
+        // search per Copilot review #12.
+        var plainText = ExtractPdfPlaintext(NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument());
+        Assert.False(plainText.Contains("/Type /Action", System.StringComparison.Ordinal),
             "PDF output unexpectedly contained an Action object.");
-        Assert.False(text.Contains("/S /URI", System.StringComparison.Ordinal),
+        Assert.False(plainText.Contains("/S /URI", System.StringComparison.Ordinal),
             "PDF output unexpectedly contained a /URI action.");
+    }
+
+    /// <summary>Extract only the PDF's plaintext regions (object dictionaries,
+    /// xref table, trailer) — i.e., everything OUTSIDE
+    /// <c>stream...endstream</c> blocks. Per ISO 32000-2 §7.3.8, the
+    /// <c>stream</c> keyword starts a binary payload that ends at the
+    /// <c>endstream</c> keyword on its own line; those bytes can be
+    /// FlateDecode-compressed and contain arbitrary substrings. Searching
+    /// only the surrounding plaintext lets the B-6 contract test pin
+    /// what the WRITER emits without false positives from compressed payloads.</summary>
+    private static string ExtractPdfPlaintext(byte[] bytes)
+    {
+        var text = System.Text.Encoding.Latin1.GetString(bytes);
+        var sb = new System.Text.StringBuilder(text.Length);
+        var pos = 0;
+        while (pos < text.Length)
+        {
+            var streamIdx = text.IndexOf("\nstream\n", pos, System.StringComparison.Ordinal);
+            if (streamIdx < 0) { sb.Append(text, pos, text.Length - pos); break; }
+            sb.Append(text, pos, streamIdx - pos);
+            // Skip the binary payload — find matching endstream.
+            var endIdx = text.IndexOf("\nendstream", streamIdx, System.StringComparison.Ordinal);
+            if (endIdx < 0) break; // malformed; ignore the rest
+            pos = endIdx + "\nendstream".Length;
+        }
+        return sb.ToString();
     }
 
     // --- B-7: SafeDefaultResourceLoader / UriSafetyValidator contract -------
@@ -515,5 +548,214 @@ public sealed class PhaseBSecurityHardeningTests
         Assert.True(UriSafetyValidator.IsBlockedIp(
             System.Net.IPAddress.Parse("169.254.169.254"), out var reason));
         Assert.Equal("link-local-or-metadata", reason);
+    }
+
+    // --- PR #16 follow-up: review fixes -------------------------------------
+
+    [Fact]
+    public void B7Followup_file_uri_returns_requires_base_path_check_outcome()
+    {
+        // Per PR #16 review user-recommendation #5 + Copilot review #8 —
+        // the validator can't perform the under-baseuri check (no BaseUri
+        // in scope), so it returns the new RequiresBasePathCheck outcome
+        // rather than masquerading as Safe.
+        var verdict = UriSafetyValidator.Validate(
+            new System.Uri("file:///home/user/img.png"), SecurityPolicy.SafeDefault);
+        Assert.Equal(UriSafetyValidator.SafetyOutcome.RequiresBasePathCheck, verdict.Outcome);
+        Assert.False(verdict.IsSafe);
+        Assert.Contains("BaseUri", verdict.Reason!, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void B7Followup_file_uri_safe_when_allow_file_scheme_set()
+    {
+        // When AllowFileScheme is explicitly true, the loader is permitted
+        // to read any file:// path. No follow-up check needed.
+        var policy = new SecurityPolicy { AllowFileScheme = true, AllowFileSchemeUnderBaseUri = false };
+        var verdict = UriSafetyValidator.Validate(
+            new System.Uri("file:///etc/passwd"), policy);
+        Assert.Equal(UriSafetyValidator.SafetyOutcome.Safe, verdict.Outcome);
+    }
+
+    [Fact]
+    public void B7Followup_data_uri_skips_ip_blocklist_and_allowed_hosts()
+    {
+        // Per Copilot review #8 — IP/host policy applies only to http(s).
+        // A data: URI's "host" portion is empty/special; AllowedHosts must
+        // not reject it.
+        var policy = new SecurityPolicy
+        {
+            AllowDataUri = true,
+            AllowedHosts = new[] { "example.com" }, // would block any other host
+        };
+        var verdict = UriSafetyValidator.Validate(
+            new System.Uri("data:text/plain,hello"), policy);
+        Assert.True(verdict.IsSafe, verdict.Reason);
+    }
+
+    // PR #16 follow-up — selector alternative cap (user #3 / Copilot #6).
+    [Fact]
+    public async Task B2Followup_excessive_selector_alternatives_truncated()
+    {
+        // Build a single rule with > 1024 comma-separated alternatives.
+        // Compilation succeeds; the cascade truncates the SelectorList +
+        // emits CSS-RULE-LIMIT-EXCEEDED-001.
+        var alternatives = new System.Text.StringBuilder();
+        const int count = 1500; // > 1024
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0) alternatives.Append(", ");
+            alternatives.Append($".x{i}");
+        }
+        var html = $"<!doctype html><html><head><style>{alternatives} {{ color: red }}</style></head><body><div class='x0'>x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "CSS-RULE-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("selector-alternative cap"));
+    }
+
+    // PR #16 follow-up — per-stylesheet rule counter (user #4).
+    [Fact]
+    public async Task B2Followup_rule_cap_emitted_only_once_per_overflowing_sheet()
+    {
+        // Pre-fix: the rule-count check used the global output.Count, so
+        // sheet 1's overflow at 50k poisoned every subsequent sheet —
+        // sheet 2 (one rule) immediately hit "output.Count >= 50_000" on
+        // its first rule + emitted ITS OWN cap diagnostic. So pre-fix the
+        // diagnostic count was 2.
+        // Post-fix: sheetStartCount is captured per-sheet; sheet 2's
+        // counter starts at 0 + its single rule never overflows. So
+        // post-fix the diagnostic count is 1 (sheet 1 only).
+        var sheet1 = new System.Text.StringBuilder();
+        for (var i = 0; i < 51_000; i++) sheet1.Append($".x{i} {{ color: red }} ");
+        var html = "<!doctype html><html><head><style>" + sheet1
+            + "</style><style>.kept { color: blue }</style></head>"
+            + "<body><div class=\"kept\">x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        var ruleCapDiagnostics = sink.Diagnostics.Count(d =>
+            d.Code == "CSS-RULE-LIMIT-EXCEEDED-001"
+            && d.Message.Contains("50000-rule cap"));
+        Assert.Equal(1, ruleCapDiagnostics);
+    }
+
+    // PR #16 follow-up — pre-parse byte cap (user #1).
+    [Fact]
+    public async Task B1Followup_oversized_input_rejected_before_parse()
+    {
+        // 17 MiB string > 16 MiB cap. Parse rejected before AngleSharp
+        // materializes the DOM.
+        var huge = new string('a', 17 * 1024 * 1024);
+        var html = $"<html><body><div>{huge}</div></body></html>";
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        await Assert.ThrowsAsync<System.IO.InvalidDataException>(
+            () => host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink }));
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-INPUT-TOO-LARGE-001");
+    }
+
+    // PR #16 follow-up — wide-children DOM walk (Copilot #1).
+    [Fact]
+    public async Task B1Followup_wide_body_with_excess_children_truncated()
+    {
+        // Build a body with a moderate number of direct children, well
+        // under the input-byte cap but over the element cap (250k). The
+        // bounded-snapshot fix keeps this from materializing the full
+        // children array before EnforceDomSizeCaps fires.
+        // Use 300_000 minimal <p/> children — at 4 chars each that's
+        // ~1.2 MiB input, well under the 16 MiB cap.
+        var sb = new System.Text.StringBuilder("<html><body>");
+        for (var i = 0; i < 300_000; i++) sb.Append("<p/>");
+        sb.Append("</body></html>");
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(sb.ToString(), new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-DOM-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("element count"));
+        // Total elements left should be near or below the cap.
+        var elementsAfter = 0;
+        foreach (var _ in doc.All) elementsAfter++;
+        Assert.True(elementsAfter <= NetPdf.HtmlParsingHost.MaxElementCount + 4,
+            $"expected ≤ {NetPdf.HtmlParsingHost.MaxElementCount} + 4 elements; got {elementsAfter}");
+    }
+
+    // PR #16 follow-up — SVG animation xlink:href (user #2 / Copilot #5).
+    [Fact]
+    public async Task B5Followup_svg_animate_targeting_xlink_href_dropped()
+    {
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <a><animate attributeName="xlink:href" to="javascript:alert(1)"/>x</a>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-JAVASCRIPT-URL-IGNORED-001"
+                 && d.Message.Contains("animate"));
+        Assert.Empty(doc.QuerySelectorAll("animate"));
+    }
+
+    // PR #16 follow-up — namespace-aware attribute mutation (Copilot #3 / #4).
+    [Fact]
+    public async Task B1Followup_xlink_href_with_huge_value_clamped_correctly()
+    {
+        // An SVG element with a huge xlink:href value should be clamped to
+        // 1 MiB + ellipsis on the SAME attribute (xlink:href), not an
+        // accidental new attribute in the no-namespace bucket.
+        var hugeUrl = "https://example.com/" + new string('z', 1024 * 1024 + 100);
+        var html = $"""
+            <html><body><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <a xlink:href="{hugeUrl}">x</a>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        var anchor = doc.QuerySelector("a")!;
+        // The xlink:href should still be present (not duplicated).
+        var clamped = anchor.GetAttribute("http://www.w3.org/1999/xlink", "href");
+        Assert.NotNull(clamped);
+        Assert.True(clamped!.Length <= 1024 * 1024 + 1,
+            $"expected clamped length ≤ 1 MiB + 1; got {clamped.Length}");
+        Assert.EndsWith("…", clamped);
+    }
+
+    // PR #16 follow-up — calc() unterminated cap (user #6 / Copilot #7).
+    // The cascade pipeline can't reliably feed an unterminated calc() into
+    // the resolver because the CSS parser rejects malformed declarations
+    // earlier; test CalcResolver.Resolve directly instead.
+    [Fact]
+    public void B3Followup_unterminated_calc_with_huge_tail_emits_diagnostic()
+    {
+        // 5 KiB of digits inside an UNTERMINATED calc() — pre-fix the
+        // resolver passed unterminated bodies through verbatim with no
+        // length check; post-fix it emits CSS-CALC-INVALID-001 since the
+        // remaining length exceeds the 4 KiB cap.
+        var huge = new string('1', 5 * 1024);
+        var rawValue = $"calc({huge}"; // no closing paren
+        var sink = new CapturingCssSink();
+        var result = NetPdf.Css.Cascade.CalcResolver.Resolve(rawValue, sink, NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "CSS-CALC-INVALID-001" && d.Message.Contains("char cap"));
+        // Verbatim-pass through the original rawValue.
+        Assert.Equal(rawValue, result);
+    }
+
+    /// <summary>Per PR #16 follow-up — re-introduced for the
+    /// B3Followup direct-resolver test only. Phase B's Copilot review #11
+    /// removed the previous CapturingCssSink because no Phase B test used
+    /// it; the unterminated-calc test below needs CSS-side diagnostic
+    /// inspection without the public sink adapter.</summary>
+    private sealed class CapturingCssSink : NetPdf.Css.Diagnostics.ICssDiagnosticsSink
+    {
+        public System.Collections.Generic.List<NetPdf.Css.Diagnostics.CssDiagnostic> Diagnostics { get; } = new();
+        public void Emit(NetPdf.Css.Diagnostics.CssDiagnostic d) => Diagnostics.Add(d);
     }
 }

--- a/tests/NetPdf.UnitTests/Phase2/PhaseBSecurityHardeningTests.cs
+++ b/tests/NetPdf.UnitTests/Phase2/PhaseBSecurityHardeningTests.cs
@@ -1,0 +1,519 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Linq;
+using System.Threading.Tasks;
+using NetPdf.Css.Cascade;
+using NetPdf.Css.Diagnostics;
+using NetPdf.Css.Parser;
+using Xunit;
+
+namespace NetPdf.UnitTests.Phase2;
+
+/// <summary>
+/// Regression tests for the Phase B security-hardening tasks (B-1 through
+/// B-7). Phase B builds on Phase A's input-sanitization layer with DOM size
+/// caps, CSS rule/declaration caps, calc() complexity caps, iterative HTML
+/// strip until stable, SVG-namespace strip, PDF output hardening, and the
+/// SafeDefaultResourceLoader contract.
+/// </summary>
+public sealed class PhaseBSecurityHardeningTests
+{
+    private sealed class CapturingPublicSink : IDiagnosticsSink
+    {
+        public System.Collections.Generic.List<Diagnostic> Diagnostics { get; } = new();
+        public void Emit(Diagnostic d) => Diagnostics.Add(d);
+    }
+
+    // --- B-1: DOM size caps --------------------------------------------------
+
+    [Fact]
+    public async Task B1_huge_attribute_value_is_clamped()
+    {
+        // 2 MiB > 1 MiB cap.
+        var huge = new string('x', 2 * 1024 * 1024);
+        var html = $"<html><body><div data-x=\"{huge}\">x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-DOM-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("attribute value"));
+        var attr = doc.QuerySelector("div")!.GetAttribute("data-x")!;
+        Assert.True(attr.Length <= 1024 * 1024 + 2,
+            $"expected attribute value clamped to ≤ 1 MiB + ellipsis; got {attr.Length}");
+    }
+
+    [Fact]
+    public async Task B1_excess_attributes_per_element_are_removed()
+    {
+        var attrs = new System.Text.StringBuilder();
+        const int count = 500; // > 256 cap
+        for (var i = 0; i < count; i++) attrs.Append($"data-x{i}=\"v{i}\" ");
+        var html = $"<html><body><div {attrs}>x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-DOM-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("attributes-per-element"));
+        var div = doc.QuerySelector("div")!;
+        Assert.True(div.Attributes.Length <= 256,
+            $"expected ≤ 256 attributes after cap; got {div.Attributes.Length}");
+    }
+
+    [Fact]
+    public async Task B1_huge_text_node_is_clamped()
+    {
+        // 6 MiB text node > 4 MiB cap.
+        var huge = new string('A', 6 * 1024 * 1024);
+        var html = $"<html><body><pre>{huge}</pre></body></html>";
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-DOM-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("text node"));
+        var pre = doc.QuerySelector("pre")!;
+        Assert.True(pre.TextContent.Length <= 4 * 1024 * 1024,
+            $"expected text clamped; got {pre.TextContent.Length}");
+    }
+
+    [Fact]
+    public async Task B1_safe_documents_emit_no_dom_limit_diagnostic()
+    {
+        // Realistic doc — three nested divs with normal attributes + text.
+        var html = """
+            <html><body>
+              <div class="container">
+                <p data-id="1">Hello world.</p>
+                <span style="color:red">x</span>
+              </div>
+            </body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.DoesNotContain(sink.Diagnostics,
+            d => d.Code == "HTML-DOM-LIMIT-EXCEEDED-001");
+    }
+
+    [Fact]
+    public async Task B1_one_diagnostic_per_violation_kind()
+    {
+        // 10 separate over-long attribute values across 5 elements should
+        // produce ONE attr-length diagnostic, not 10 — to keep adversarial
+        // documents from flooding the sink.
+        var sb = new System.Text.StringBuilder("<html><body>");
+        var huge = new string('y', 2 * 1024 * 1024);
+        for (var i = 0; i < 5; i++)
+        {
+            sb.Append($"<div data-x=\"{huge}\" data-y=\"{huge}\">x</div>");
+        }
+        sb.Append("</body></html>");
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        await host.ParseAsync(sb.ToString(), new HtmlPdfOptions { Diagnostics = sink });
+        var attrLen = sink.Diagnostics.Count(d =>
+            d.Code == "HTML-DOM-LIMIT-EXCEEDED-001"
+            && d.Message.Contains("attribute value"));
+        Assert.Equal(1, attrLen);
+    }
+
+    // --- B-2: CSS rule + declaration caps -----------------------------------
+
+    private sealed class CapturingCssSink : ICssDiagnosticsSink
+    {
+        public System.Collections.Generic.List<CssDiagnostic> Diagnostics { get; } = new();
+        public void Emit(CssDiagnostic d) => Diagnostics.Add(d);
+    }
+
+    [Fact]
+    public async Task B2_excessive_rule_count_capped_per_stylesheet()
+    {
+        // 60_000 rules > 50_000 cap. Pipeline emits CSS-RULE-LIMIT-EXCEEDED-001
+        // and stops processing further rules.
+        var rules = new System.Text.StringBuilder();
+        const int count = 60_000;
+        for (var i = 0; i < count; i++) rules.Append($".x{i} {{ color: red }} ");
+        var html = $"<!doctype html><html><head><style>{rules}</style></head><body></body></html>";
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "CSS-RULE-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("50000-rule cap"));
+    }
+
+    [Fact]
+    public async Task B2_excessive_declarations_per_rule_truncated()
+    {
+        // Build a rule with 500 distinct custom-property declarations — > 256
+        // cap. Custom properties are guaranteed to preserve as separate
+        // declarations (each name is unique), unlike repeated standard
+        // properties which AngleSharp.Css collapses to last-wins.
+        var decls = new System.Text.StringBuilder();
+        for (var i = 0; i < 500; i++) decls.Append($"--p{i}: red; ");
+        var html = $"<!doctype html><html><head><style>.x {{ {decls} }}</style></head><body><div class='x'>x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "CSS-RULE-LIMIT-EXCEEDED-001"
+                 && d.Message.Contains("declaration cap"));
+    }
+
+    [Fact]
+    public async Task B2_normal_stylesheet_emits_no_rule_limit_diagnostic()
+    {
+        var html = """
+            <!doctype html><html><head><style>
+            body { margin: 0; padding: 0; font-family: sans-serif; }
+            .container { max-width: 1024px; margin: 0 auto; }
+            .header { background: #eee; padding: 1em; }
+            .content { padding: 2em; }
+            .footer { background: #333; color: white; padding: 1em; }
+            </style></head><body><div class="container"></div></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.DoesNotContain(sink.Diagnostics, d => d.Code == "CSS-RULE-LIMIT-EXCEEDED-001");
+    }
+
+    // --- B-3: calc() body-length cap ----------------------------------------
+
+    [Fact]
+    public async Task B3_huge_calc_body_capped_with_diagnostic()
+    {
+        // Build a calc() body with thousands of operands, each `+ 1px` — the
+        // depth cap (32) doesn't catch this because it's flat, not nested.
+        // The body-length cap (4 KiB) triggers and the expression is preserved
+        // verbatim.
+        var sb = new System.Text.StringBuilder("calc(1px");
+        for (var i = 0; i < 5_000; i++) sb.Append(" + 1px");
+        sb.Append(')');
+        var calcExpr = sb.ToString();
+        var html = $"<!doctype html><html><head><style>.x {{ width: {calcExpr} }}</style></head><body><div class='x'>x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "CSS-CALC-INVALID-001"
+                 && d.Message.Contains("char cap"));
+    }
+
+    [Fact]
+    public async Task B3_normal_calc_expression_reduces_cleanly()
+    {
+        var html = """
+            <!doctype html><html><head><style>
+            .x { width: calc(100% - 32px); padding: calc(1em + 4px); }
+            </style></head><body><div class="x">x</div></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        using var result = await NetPdf.Phase2.Phase2Pipeline.RunFromHtmlAsync(
+            html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.DoesNotContain(sink.Diagnostics,
+            d => d.Code == "CSS-CALC-INVALID-001" && d.Message.Contains("char cap"));
+    }
+
+    // --- B-4: iterative HTML strip until stable -----------------------------
+
+    [Fact]
+    public async Task B4_strip_loop_converges_on_first_pass_for_normal_doc()
+    {
+        // Simple doc with a script — single strip pass should remove it and
+        // the convergence check confirms nothing left, no NOT-STABLE diagnostic.
+        var html = "<html><body><script>alert(1)</script><div>x</div></body></html>";
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics, d => d.Code == "HTML-SCRIPT-IGNORED-001");
+        Assert.DoesNotContain(sink.Diagnostics, d => d.Code == "HTML-STRIP-NOT-STABLE-001");
+        Assert.Empty(doc.QuerySelectorAll("script"));
+    }
+
+    [Fact]
+    public async Task B4_strip_loop_handles_svg_foreign_object_with_handlers()
+    {
+        // SVG <foreignObject> contains HTML that AngleSharp normalizes
+        // separately. After the first strip pass the inner content is parsed
+        // and its event handlers are reachable; the iterative loop catches
+        // them on a subsequent pass.
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <foreignObject><div xmlns="http://www.w3.org/1999/xhtml" onclick="alert(1)">x</div></foreignObject>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        // Should NOT report unstable strip — convergence happens within the cap.
+        Assert.DoesNotContain(sink.Diagnostics, d => d.Code == "HTML-STRIP-NOT-STABLE-001");
+        // No surviving onclick anywhere in the tree.
+        foreach (var el in doc.All)
+        {
+            Assert.False(el.HasAttribute("onclick"),
+                $"<{el.LocalName}> retained onclick after iterative strip");
+        }
+    }
+
+    // --- B-5: SVG-namespace strip pass --------------------------------------
+
+    [Fact]
+    public async Task B5_svg_use_href_javascript_url_stripped()
+    {
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <use href="javascript:alert(1)"/>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-JAVASCRIPT-URL-IGNORED-001"
+                 && d.Message.Contains("SVG <use>"));
+        Assert.False(doc.QuerySelector("use")!.HasAttribute("href"));
+    }
+
+    [Fact]
+    public async Task B5_svg_animate_targeting_href_with_javascript_dropped()
+    {
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <a><animate attributeName="href" to="javascript:alert(1)"/>x</a>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-JAVASCRIPT-URL-IGNORED-001"
+                 && d.Message.Contains("animate"));
+        // The animation element itself should be removed.
+        Assert.Empty(doc.QuerySelectorAll("animate"));
+    }
+
+    [Fact]
+    public async Task B5_svg_set_with_dangerous_values_list_dropped()
+    {
+        // <set values="..."> with a semicolon-separated list — one segment
+        // is dangerous, others are benign; the whole element drops.
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <a><set attributeName="href" values="https://safe.example;javascript:alert(1)"/>x</a>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.Contains(sink.Diagnostics,
+            d => d.Code == "HTML-JAVASCRIPT-URL-IGNORED-001"
+                 && d.Message.Contains("set"));
+        Assert.Empty(doc.QuerySelectorAll("set"));
+    }
+
+    [Fact]
+    public async Task B5_svg_animate_with_safe_url_target_preserved()
+    {
+        // <animate attributeName="href" to="https://safe..."> is safe — the
+        // strip pass leaves it alone.
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <a><animate attributeName="href" to="https://example.com/x"/>x</a>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.NotEmpty(doc.QuerySelectorAll("animate"));
+        Assert.DoesNotContain(sink.Diagnostics,
+            d => d.Code == "HTML-JAVASCRIPT-URL-IGNORED-001" && d.Message.Contains("animate"));
+    }
+
+    [Fact]
+    public async Task B5_svg_animate_targeting_non_url_attribute_preserved()
+    {
+        // attributeName="opacity" — not in the URL-bearing set; the strip
+        // does not inspect to/from/values for opacity even if they happen
+        // to start with "javascript:" (they wouldn't render anyway).
+        var html = """
+            <html><body><svg xmlns="http://www.w3.org/2000/svg">
+              <rect><animate attributeName="opacity" to="0.5"/></rect>
+            </svg></body></html>
+            """;
+        var sink = new CapturingPublicSink();
+        var host = new HtmlParsingHost();
+        var doc = await host.ParseAsync(html, new HtmlPdfOptions { Diagnostics = sink });
+        Assert.NotEmpty(doc.QuerySelectorAll("animate"));
+    }
+
+    // --- B-6: PDF output hardening contract ---------------------------------
+    // The Phase 1 PDF writer never emits any of these dangerous PDF dictionary
+    // keys (verified by greps over src/NetPdf.Pdf at the time Phase B was
+    // landed). These tests pin the contract: if any future code path adds
+    // /OpenAction, /AA, /JavaScript, /Launch, /URI with a JS scheme,
+    // /EmbeddedFiles, etc., the test below fails immediately. SmokeDocumentFactory
+    // exercises every Phase-1 byte-emit path the AOT canary covers.
+
+    [Theory]
+    [InlineData("/OpenAction")]   // opens an action when the PDF is opened
+    [InlineData("/AA")]            // additional actions on catalog/pages/fields
+    [InlineData("/JavaScript")]    // embedded JS action
+    [InlineData("/JS")]            // JS action body key
+    [InlineData("/Launch")]        // launches an external program
+    [InlineData("/EmbeddedFile")]  // embedded file substream prefix (covers EmbeddedFile + EmbeddedFiles)
+    [InlineData("/RichMedia")]     // RichMedia annotation (Flash/3D)
+    [InlineData("/SubmitForm")]    // posts form data to a URL
+    [InlineData("/ImportData")]    // imports form data from a URL
+    [InlineData("/GoToR")]         // remote GoTo — fetches a URL
+    [InlineData("/GoToE")]         // GoTo embedded — references an embedded file
+    [InlineData("javascript:")]    // dangerous URI scheme (used by /URI actions)
+    [InlineData("vbscript:")]      // legacy IE scripting URI
+    public void B6_smoke_pdf_byte_stream_omits_dangerous_token(string token)
+    {
+        var bytes = NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument();
+        // PDF tokens are ASCII; Latin1 round-trips cleanly without throwing on
+        // non-ASCII bytes from compressed streams.
+        var text = System.Text.Encoding.Latin1.GetString(bytes);
+        Assert.False(text.Contains(token, System.StringComparison.Ordinal),
+            $"PDF output unexpectedly contained dangerous token '{token}'.");
+    }
+
+    [Fact]
+    public void B6_smoke_pdf_emits_no_uri_action()
+    {
+        // Both /URI as an action subtype and /URI as a key — the writer
+        // must not emit any link-action surfaces in v1.
+        var bytes = NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument();
+        var text = System.Text.Encoding.Latin1.GetString(bytes);
+        Assert.False(text.Contains("/Type /Action", System.StringComparison.Ordinal),
+            "PDF output unexpectedly contained an Action object.");
+        Assert.False(text.Contains("/S /URI", System.StringComparison.Ordinal),
+            "PDF output unexpectedly contained a /URI action.");
+    }
+
+    // --- B-7: SafeDefaultResourceLoader / UriSafetyValidator contract -------
+
+    [Theory]
+    [InlineData("http://127.0.0.1/x", "loopback")]
+    [InlineData("http://localhost/x", null)] // symbolic — loader handles post-DNS
+    [InlineData("http://10.0.0.1/x", "private")]
+    [InlineData("http://172.20.5.5/x", "private")]
+    [InlineData("http://192.168.1.1/x", "private")]
+    [InlineData("http://169.254.169.254/latest/meta-data/", "link-local-or-metadata")]
+    [InlineData("http://0.0.0.0/x", "unspecified")]
+    [InlineData("http://198.51.100.42/x", "test-net")]
+    [InlineData("http://224.0.0.1/x", "multicast")]
+    [InlineData("http://255.255.255.255/x", "reserved")]
+    [InlineData("https://[::1]/x", "loopback")]
+    [InlineData("https://[fc00::1]/x", "unique-local")]
+    [InlineData("https://[fe80::1]/x", "link-local")]
+    [InlineData("https://[ff00::1]/x", "multicast")]
+    // ::ffff:127.0.0.1 reports as "loopback" (IPAddress.IsLoopback recognizes
+    // v4-mapped loopback first); the validator's v4-mapped path handles the
+    // non-loopback v4-mapped ranges below.
+    [InlineData("https://[::ffff:127.0.0.1]/x", "loopback")]
+    [InlineData("https://[::ffff:169.254.169.254]/x", "v4-mapped-link-local-or-metadata")]
+    public void B7_blocked_ip_ranges_rejected_when_http_allowed(string url, string? expectedReasonFragment)
+    {
+        var policy = new SecurityPolicy { AllowHttpScheme = true, AllowHttpsScheme = true };
+        var verdict = UriSafetyValidator.Validate(new Uri(url), policy);
+        if (expectedReasonFragment is null)
+        {
+            // Symbolic hostnames (localhost) pass the validator; the loader
+            // is expected to call IsBlockedIp post-DNS.
+            Assert.True(verdict.IsSafe);
+        }
+        else
+        {
+            Assert.False(verdict.IsSafe);
+            Assert.Contains(expectedReasonFragment, verdict.Reason!, System.StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("https://example.com/foo")]
+    [InlineData("http://example.com/foo")]
+    [InlineData("https://api.example.com/v1/x.json")]
+    public void B7_safe_public_urls_accepted_when_http_allowed(string url)
+    {
+        var policy = new SecurityPolicy { AllowHttpScheme = true, AllowHttpsScheme = true };
+        var verdict = UriSafetyValidator.Validate(new Uri(url), policy);
+        Assert.True(verdict.IsSafe, verdict.Reason);
+    }
+
+    [Theory]
+    [InlineData("http://example.com/x")]
+    [InlineData("https://example.com/x")]
+    public void B7_safe_default_policy_blocks_http_and_https(string url)
+    {
+        // Default policy disables http(s); only file (under-baseuri) + data.
+        var verdict = UriSafetyValidator.Validate(new Uri(url), SecurityPolicy.SafeDefault);
+        Assert.False(verdict.IsSafe);
+        Assert.Contains("disabled by SecurityPolicy", verdict.Reason!,
+            System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void B7_unknown_scheme_rejected()
+    {
+        var verdict = UriSafetyValidator.Validate(
+            new Uri("gopher://example.com/x"), SecurityPolicy.SafeDefault);
+        Assert.False(verdict.IsSafe);
+        Assert.Contains("'gopher:'", verdict.Reason!, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void B7_data_uri_allowed_by_default()
+    {
+        var verdict = UriSafetyValidator.Validate(
+            new Uri("data:image/png;base64,iVBORw0KG..."), SecurityPolicy.SafeDefault);
+        Assert.True(verdict.IsSafe, verdict.Reason);
+    }
+
+    [Fact]
+    public void B7_data_uri_rejected_when_disabled()
+    {
+        var policy = new SecurityPolicy { AllowDataUri = false };
+        var verdict = UriSafetyValidator.Validate(
+            new Uri("data:image/png;base64,iVBORw0KG..."), policy);
+        Assert.False(verdict.IsSafe);
+        Assert.Contains("data:", verdict.Reason!, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void B7_allowed_host_list_blocks_off_list_targets()
+    {
+        var policy = new SecurityPolicy
+        {
+            AllowHttpsScheme = true,
+            AllowedHosts = new[] { "example.com", "*.cdn.example.com" },
+        };
+        Assert.True(UriSafetyValidator.Validate(
+            new Uri("https://example.com/x"), policy).IsSafe);
+        Assert.True(UriSafetyValidator.Validate(
+            new Uri("https://foo.cdn.example.com/x"), policy).IsSafe);
+        // Not on the list:
+        var verdict = UriSafetyValidator.Validate(
+            new Uri("https://attacker.com/x"), policy);
+        Assert.False(verdict.IsSafe);
+        Assert.Contains("not in the allowed-host list", verdict.Reason!,
+            System.StringComparison.Ordinal);
+        // Wildcard "*.cdn.example.com" should NOT match the bare cdn.example.com
+        // (single-label wildcard semantics).
+        var bareCdn = UriSafetyValidator.Validate(
+            new Uri("https://cdn.example.com/x"), policy);
+        Assert.False(bareCdn.IsSafe);
+    }
+
+    [Fact]
+    public void B7_is_blocked_ip_returns_specific_reason_for_aws_metadata()
+    {
+        Assert.True(UriSafetyValidator.IsBlockedIp(
+            System.Net.IPAddress.Parse("169.254.169.254"), out var reason));
+        Assert.Equal("link-local-or-metadata", reason);
+    }
+}


### PR DESCRIPTION
## Summary

Phase B continues the pre-Phase-3 hardening pass with **7 additional gates** covering DoS amplifiers (DOM size, CSS rule count, calc() complexity), mXSS-class strip stability, SVG-namespace surfaces, PDF output safety, and the SSRF/SSRP contract that Phase 5's resource loader will inherit. Builds on top of [PR #15](https://github.com/raroche/NetPdf/pull/15) (Phase A — 8 fixes).

### Phase B tasks

#### B-1 [SEC] DOM size caps ([HtmlParsingHost.cs](src/NetPdf/HtmlParsingHost.cs))

`EnforceDomSizeCaps` walks the post-strip document depth-first and clamps any region exceeding the per-document limits:

| Cap | Value | Rationale |
|---|---|---|
| `MaxElementCount` | 250_000 | Real-world large invoices < 5k; cuts off adversarial docs before per-element selector match becomes pathological |
| `MaxNestingDepth` | 1024 | Hand-authored < 50; mXSS payloads + zip-bomb HTML deliberately deep-nest |
| `MaxAttributesPerElement` | 256 | Real elements < 20; piles of `data-*` attrs make AngleSharp lookups quadratic |
| `MaxAttributeValueLength` | 1 MiB | Generous for inline base64; tight enough that one `data-x="...10MB..."` can't bloat |
| `MaxTextContentLength` | 4 MiB | Permissive for legitimate `<pre>` blocks; stops single-text-node memory bombs |

Excess elements / attributes are removed; over-long values + text-node content clamps with U+2026 ellipsis. New `HTML-DOM-LIMIT-EXCEEDED-001` emits one diagnostic per violation kind (not per node).

#### B-2 [SEC] CSS rule / declaration caps ([CascadeResolver.cs](src/NetPdf.Css/Cascade/CascadeResolver.cs))

`MaxRulesPerStylesheet = 50_000`, `MaxDeclarationsPerRule = 256`. `CollectFromRules` gates per-rule on the running output count + emits `CSS-RULE-LIMIT-EXCEEDED-001` once at overflow. `CollectStyleRule` tail-truncates declarations past the cap. 50k accommodates Tailwind's full build (~30k rules).

#### B-3 [SEC] `calc()` body-length cap ([CalcResolver.cs](src/NetPdf.Css/Cascade/CalcResolver.cs))

`MaxBodyLength = 4 KiB` catches the breadth case the existing depth cap (32) misses — a flat `calc(1px + 1px + ... 5000 times)` has depth 1 but multi-MB of work. Over-cap expressions emit `CSS-CALC-INVALID-001` + pass through verbatim.

#### B-4 [SEC] Iterative HTML strip until stable ([HtmlParsingHost.cs](src/NetPdf/HtmlParsingHost.cs))

`StripUntilStable` wraps the three strip walks (scripts / javascript-URLs / event handlers) in a fixed-point loop, max 4 iterations. `HasDangerousContent` checks for any surviving `<script>` / `on*` / dangerous-URL after each pass. On non-convergence: `HTML-STRIP-NOT-STABLE-001`. Defends against AngleSharp normalization or SVG `<foreignObject>` re-introducing stripped content.

#### B-5 [SEC] SVG-namespace strip pass ([HtmlParsingHost.cs](src/NetPdf/HtmlParsingHost.cs))

`StripSvgSpecific` walks SVG-namespace elements:
- Unprefixed `href` on any SVG element (covers `<use href>`, `<image href>`, `<pattern href>`, etc.) — strips javascript:/vbscript:/data:
- `<animate>` / `<set>` / `<animateTransform>` / `<animateMotion>` targeting URL-bearing attributes (`href`, `src`, `action`, etc.) — checks `to`/`from`/`values` (semicolon-list) for dangerous schemes; drops the entire animation element on hit (no safe partial recovery).

#### B-6 [SEC] PDF output hardening contract ([PhaseBSecurityHardeningTests.cs](tests/NetPdf.UnitTests/Phase2/PhaseBSecurityHardeningTests.cs))

Theory test pins the byte output of `NetPdf.AotSmoke.SmokeDocumentFactory.BuildSmokeDocument` against 13 dangerous PDF dictionary keys: `/OpenAction`, `/AA`, `/JavaScript`, `/JS`, `/Launch`, `/EmbeddedFile`, `/RichMedia`, `/SubmitForm`, `/ImportData`, `/GoToR`, `/GoToE`, `javascript:`, `vbscript:`, plus `/Type /Action` and `/S /URI`. Currently passes vacuously (Phase 1's writer emits none of these); the pin catches future regressions.

#### B-7 [SEC] `UriSafetyValidator` ([Resources/UriSafetyValidator.cs](src/NetPdf/Resources/UriSafetyValidator.cs))

Static utility for any future `IResourceLoader` to call before fetching:
- `ValidateScheme` — `SecurityPolicy` allowlist (file/data/http/https/data)
- `IsBlockedIp` — canonical SSRF amplifier set: loopback (`127/8`, `::1`), private (`10/8`, `172.16-31/12`, `192.168/16`, `fc00::/7`), link-local + cloud-metadata (`169.254.0.0/16` covers AWS/GCE/Azure/Alibaba IMDS; `fe80::/10`), test-net, benchmark, carrier-grade-NAT, IPv4-mapped IPv6, multicast, unspecified
- Symbolic hostnames pass scheme validation; loader calls `IsBlockedIp` post-DNS to defend against rebinding

NetPdf v1 ships no default loader, so the validator's only client today is unit tests. Phase 5 wires it into the production loader.

### Test deltas

- **57 new** [`PhaseBSecurityHardeningTests`](tests/NetPdf.UnitTests/Phase2/PhaseBSecurityHardeningTests.cs) passing (5 for B-1, 3 for B-2, 2 for B-3, 2 for B-4, 5 for B-5, 14 for B-6, 26 for B-7)
- **3344 unit tests** pass total (+57 over PR #15's 3287; 1 skipped)
- **96 `NetPdf.RealDocuments`** tests pass — full corpus runs through the new caps without flagging
- **30 `NetPdf.LayoutSnapshots`** tests pass
- AOT/JIT byte-parity verified

## Test plan

- [x] `dotnet test NetPdf.slnx -c Release` — 3344 unit / 3470 solution-wide passing
- [x] `./scripts/aot-parity.sh` — AOT/JIT byte-parity green
- [x] All 7 B-tasks have regression tests in `PhaseBSecurityHardeningTests.cs`
- [ ] Roland review cycle on this PR
- [ ] Address Copilot findings if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)