### PR TITLE
Post-Task-7 review pass: 6 P1/P2 fixes (HTTP policy, diagnostics, margin collapse, optimizer CT, checkpoint frontier, CSS extractor)

### DIFF
--- a/src/NetPdf.Css/Resources/CssResourceExtractor.cs
+++ b/src/NetPdf.Css/Resources/CssResourceExtractor.cs
@@ -180,6 +180,28 @@ internal static class CssResourceExtractor
     /// <c>background-image: image-set("https://attacker/a.png" 1x)</c>
     /// would not be reported. The fix tracks whether we're inside one
     /// of these functions + treats string literals there as URLs.</para>
+    ///
+    /// <para><b>Per post-Task-7 review — nested non-resource functions.</b>
+    /// CSS Images L4 §6 also allows resource lists to contain
+    /// <i>non-resource</i> helper functions like <c>type("image/png")</c>
+    /// or <c>format("avif")</c>. Pre-fix the parser:
+    /// <list type="bullet">
+    ///   <item>Treated string args of those helpers as URLs (so
+    ///   <c>image-set("a.png" 1x, type("image/png"))</c> would emit
+    ///   <c>"image/png"</c> as a phantom URL).</item>
+    ///   <item>Decremented the resource-fn depth when seeing the
+    ///   helper's closing <c>)</c>, prematurely exiting the
+    ///   <c>image-set</c> context (so legitimate strings AFTER the
+    ///   helper would not be captured).</item>
+    /// </list>
+    /// The fix tracks an inner non-resource paren depth separately
+    /// from the resource-fn depth: only strings at the IMMEDIATE
+    /// level of a resource fn (innerNonResourceDepth == 0) count as
+    /// URLs, and the closing <c>)</c> of a helper decrements the
+    /// inner depth, leaving the resource-fn depth intact. Nested
+    /// resource fns (<c>image-set(image-set("nested.png" 1x) 2x)</c>)
+    /// are unaffected — the inner image-set still goes through
+    /// <see cref="TryMatchResourceFunctionStart"/>.</para>
     /// </summary>
     public static IReadOnlyList<string> EnumerateUrls(string value)
     {
@@ -190,12 +212,19 @@ internal static class CssResourceExtractor
         // image-set() / cross-fade() / image() and string literals are
         // URL-bearing rather than skip-only.
         var resourceFnDepth = 0;
+        // Per post-Task-7 review — track non-resource paren nesting
+        // INSIDE the current resource fn body. While > 0 we're inside
+        // a helper like type() or format(); strings are NOT URLs
+        // and the helper's closing ) decrements this counter, NOT
+        // the resource-fn depth.
+        var innerNonResourceDepth = 0;
         var i = 0;
         while (i < value.Length)
         {
             var c = value[i];
-            // CSS string literal handling — when inside a resource fn,
-            // capture it as a URL; otherwise skip it entirely.
+            // CSS string literal handling — when inside a resource fn
+            // AT THE IMMEDIATE LEVEL (not nested in a helper), capture
+            // it as a URL; otherwise skip it entirely.
             if (c == '"' || c == '\'')
             {
                 var quote = c;
@@ -206,7 +235,9 @@ internal static class CssResourceExtractor
                     if (value[i] == '\\' && i + 1 < value.Length) i += 2;
                     else i++;
                 }
-                if (resourceFnDepth > 0 && i <= value.Length)
+                if (resourceFnDepth > 0
+                    && innerNonResourceDepth == 0
+                    && i <= value.Length)
                 {
                     var url = value[stringStart..Math.Min(i, value.Length)];
                     if (!string.IsNullOrEmpty(url)) results.Add(url);
@@ -214,7 +245,9 @@ internal static class CssResourceExtractor
                 if (i < value.Length) i++;
                 continue;
             }
-            // Match url( case-insensitively.
+            // Match url( case-insensitively. url() is captured regardless
+            // of whether we're inside a helper (its semantics are
+            // unambiguous + matches the CSS Images L4 §6 grammar).
             if (TryMatchKeywordOpenParen(value, i, "url"))
             {
                 if (i > 0 && IsIdentContinue(value[i - 1])) { i++; continue; }
@@ -234,14 +267,47 @@ internal static class CssResourceExtractor
             if (TryMatchResourceFunctionStart(value, i, out var consumed))
             {
                 resourceFnDepth++;
+                // Reset inner-non-resource depth — the new resource-fn
+                // body starts fresh at depth 0.
+                // (Nested non-resource depth is per-resource-fn — when
+                // we re-enter the outer fn after the inner closes, the
+                // outer's inner depth is whatever it was before. We
+                // track this implicitly via the close-paren branch
+                // below, which decrements innerNonResourceDepth before
+                // resourceFnDepth.)
                 i += consumed;
                 continue;
             }
-            if (resourceFnDepth > 0 && c == ')')
+            // Inside a resource fn: track nested non-resource ( and ).
+            if (resourceFnDepth > 0)
             {
-                resourceFnDepth--;
-                i++;
-                continue;
+                if (c == '(')
+                {
+                    // Some non-resource function opens. Could be type(),
+                    // format(), calc(), etc. Track its nesting so its
+                    // strings + closing ) don't pollute the outer
+                    // resource-fn state.
+                    innerNonResourceDepth++;
+                    i++;
+                    continue;
+                }
+                if (c == ')')
+                {
+                    if (innerNonResourceDepth > 0)
+                    {
+                        // Closing a helper inside the resource fn.
+                        // Resource-fn depth STAYS — we're still
+                        // collecting from its body.
+                        innerNonResourceDepth--;
+                    }
+                    else
+                    {
+                        // Closing the resource fn itself.
+                        resourceFnDepth--;
+                    }
+                    i++;
+                    continue;
+                }
             }
             i++;
         }

--- a/src/NetPdf.Css/Resources/CssResourceExtractor.cs
+++ b/src/NetPdf.Css/Resources/CssResourceExtractor.cs
@@ -208,16 +208,33 @@ internal static class CssResourceExtractor
         ArgumentNullException.ThrowIfNull(value);
         if (value.Length < 5) return Array.Empty<string>(); // shortest "url()"
         var results = new List<string>(2);
-        // Track resource-function nesting depth. > 0 means we're inside
-        // image-set() / cross-fade() / image() and string literals are
-        // URL-bearing rather than skip-only.
-        var resourceFnDepth = 0;
-        // Per post-Task-7 review — track non-resource paren nesting
-        // INSIDE the current resource fn body. While > 0 we're inside
-        // a helper like type() or format(); strings are NOT URLs
-        // and the helper's closing ) decrements this counter, NOT
-        // the resource-fn depth.
-        var innerNonResourceDepth = 0;
+        // Per post-Task-7 review (Copilot inline) — track helper-paren
+        // depth PER resource-fn level, not as a single shared counter.
+        // The pre-fix single-counter design got the wrong answer for
+        // a resource fn nested inside a helper, e.g.,
+        // `image-set(type(image-set("a.png" 1x)), "b.png" 2x)`:
+        //   - When the inner image-set was entered, the outer's helper-
+        //     depth (incremented by `type(`) was preserved, so "a.png"
+        //     looked like it was inside a helper + was NOT captured.
+        //   - Worse, the inner image-set's closing `)` decremented the
+        //     shared helper-counter instead of the resource-fn counter,
+        //     leaving subsequent state inconsistent.
+        //
+        // Stack-based design: each entry in `helperDepths` represents
+        // ONE active resource-fn level. The TOP entry is the helper-
+        // paren depth INSIDE the innermost active resource fn. When
+        // we enter a new resource fn (nested or top-level), we push 0
+        // (helper depth resets for the new level). When we close a
+        // resource fn (top entry's helper depth is 0 + we see `)`), we
+        // pop. Helper `(` increments the top; helper `)` decrements
+        // the top.
+        //
+        // Strings count as URLs iff:
+        //   helperDepths.Count > 0   (inside SOME resource fn)
+        //   AND helperDepths[^1] == 0 (at IMMEDIATE level of innermost
+        //                              resource fn — not nested in a
+        //                              helper)
+        var helperDepths = new List<int>(2);
         var i = 0;
         while (i < value.Length)
         {
@@ -235,8 +252,8 @@ internal static class CssResourceExtractor
                     if (value[i] == '\\' && i + 1 < value.Length) i += 2;
                     else i++;
                 }
-                if (resourceFnDepth > 0
-                    && innerNonResourceDepth == 0
+                if (helperDepths.Count > 0
+                    && helperDepths[^1] == 0
                     && i <= value.Length)
                 {
                     var url = value[stringStart..Math.Min(i, value.Length)];
@@ -266,44 +283,45 @@ internal static class CssResourceExtractor
             // additional treatment.
             if (TryMatchResourceFunctionStart(value, i, out var consumed))
             {
-                resourceFnDepth++;
-                // Reset inner-non-resource depth — the new resource-fn
-                // body starts fresh at depth 0.
-                // (Nested non-resource depth is per-resource-fn — when
-                // we re-enter the outer fn after the inner closes, the
-                // outer's inner depth is whatever it was before. We
-                // track this implicitly via the close-paren branch
-                // below, which decrements innerNonResourceDepth before
-                // resourceFnDepth.)
+                // Push a new resource-fn level with helper-depth 0.
+                // Per Copilot review — even when nested INSIDE a
+                // helper, the new resource fn's body starts fresh at
+                // helper-depth 0. The outer helper-depth is preserved
+                // on the lower stack entry + restored when this fn
+                // pops.
+                helperDepths.Add(0);
                 i += consumed;
                 continue;
             }
-            // Inside a resource fn: track nested non-resource ( and ).
-            if (resourceFnDepth > 0)
+            // Inside a resource fn (any level)?
+            if (helperDepths.Count > 0)
             {
                 if (c == '(')
                 {
-                    // Some non-resource function opens. Could be type(),
-                    // format(), calc(), etc. Track its nesting so its
-                    // strings + closing ) don't pollute the outer
-                    // resource-fn state.
-                    innerNonResourceDepth++;
+                    // Some non-resource function opens (type, format,
+                    // calc, etc.). Increment the INNERMOST resource
+                    // fn's helper-depth so its strings + closing `)`
+                    // don't pollute outer state.
+                    helperDepths[^1]++;
                     i++;
                     continue;
                 }
                 if (c == ')')
                 {
-                    if (innerNonResourceDepth > 0)
+                    if (helperDepths[^1] > 0)
                     {
-                        // Closing a helper inside the resource fn.
-                        // Resource-fn depth STAYS — we're still
-                        // collecting from its body.
-                        innerNonResourceDepth--;
+                        // Closing a helper inside the innermost
+                        // resource fn. Helper-depth at this level
+                        // decrements; the resource-fn level itself
+                        // stays.
+                        helperDepths[^1]--;
                     }
                     else
                     {
-                        // Closing the resource fn itself.
-                        resourceFnDepth--;
+                        // Closing the innermost resource fn itself.
+                        // Pop the level — outer level (if any) is
+                        // restored as the new top.
+                        helperDepths.RemoveAt(helperDepths.Count - 1);
                     }
                     i++;
                     continue;

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -438,8 +438,25 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             //     (what visually occupies the page)
             // The latter dominates when negative margins cancel a
             // large border box.
+            //
+            // Per post-Task-7 review (recommendation P2 #3) —
+            // collapsed-margin overcounting. After adjacent-margin
+            // collapse, the actual top contribution is `topShift`,
+            // NOT raw `marginStart`. Pre-fix used `Math.Max(0, marginStart)`
+            // which double-counts a margin that has already been
+            // collapsed away with the previous block's marginBottom.
+            // Example: prev block's marginBottom=80, current block's
+            // marginTop=10. After collapse the top contribution is 0
+            // (the 80 is already in fragmentainer.UsedBlockSize from
+            // the prior emission; the collapsed gap of 80 replaces
+            // both, so topShift = 80 - 80 = 0). Pre-fix counted +10
+            // → false page break near a boundary. Post-fix uses
+            // topShift, which is `marginStart` for the first block
+            // on a page (no collapse) and `effectiveTopGap -
+            // prevBlockMarginEnd` (= the actual additional advance)
+            // for subsequent collapsed blocks.
             var visualBlockExtent = borderBoxBlockSize
-                + Math.Max(0, marginStart)
+                + Math.Max(0, topShift)
                 + Math.Max(0, marginEnd);
             var chunkForBreakCheck = Math.Max(
                 Math.Max(0, marginBoxBlockSize),
@@ -461,7 +478,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // skipped children are not emitted.
                 lastEmittedChildIndex: lastEmittedIdx,
                 incomingContinuation: _incomingContinuation,
-                pageCounterValue: layout.ReadCounter("page"));
+                pageCounterValue: layout.ReadCounter("page"),
+                // Per post-Task-7 review (P2 #5) — capture the margin-
+                // collapse frontier on the checkpoint itself so a rewind
+                // to THIS specific checkpoint restores the right
+                // previous-block bottom margin (instead of the layouter's
+                // latest fields which may correspond to a different
+                // candidate-break boundary).
+                prevBlockMarginEnd: prevBlockMarginEnd,
+                hasAdjoiningBlockOnEntry: hasPriorAdjoiningBlock);
             resolver.RegisterCheckpoint(newLease);
             // The resolver's internal RegisterCheckpoint returns the
             // PRIOR lease to the pool via the lease-token CAS; we just
@@ -498,8 +523,19 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // that existed AT this checkpoint. Without it, the
                 // retry would reset to the page-start state +
                 // double-apply the next block's marginTop.
-                _prevBlockMarginEndAfterRewind = prevBlockMarginEnd;
-                _hasPriorAdjoiningBlockAfterRewind = hasPriorAdjoiningBlock;
+                //
+                // Per post-Task-7 review (P2 #5) — read the frontier
+                // from the chosen rewind-target checkpoint, NOT from
+                // the layouter's current state. The current state
+                // corresponds to the just-registered checkpoint
+                // (which the resolver typically picks); but if the
+                // resolver returns an OLDER checkpoint as the rewind
+                // target (a future optimizer-aware path retains
+                // multiple checkpoints), the layouter's "current"
+                // frontier is the wrong frontier. The checkpoint's
+                // own captured fields are authoritative.
+                _prevBlockMarginEndAfterRewind = decision.RewindTo.PrevBlockMarginEnd;
+                _hasPriorAdjoiningBlockAfterRewind = decision.RewindTo.HasAdjoiningBlockOnEntry;
                 _hasRewindCollapseState = true;
                 return LayoutAttemptResult.NeedsRewind(decision.RewindTo, decision.Cost);
             }
@@ -540,7 +576,14 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     // because consumers de-duplicate by code + page
                     // index, OR see the redundant emission as the
                     // signal-amplification it is.
-                    OptimizingBreakResolver.SafeEmit(_diagnostics, new PaginateDiagnostic(
+                    // Per post-Task-7 review (P1 #2) — prefer the
+                    // ambient sink on the layout context (set by the
+                    // coordinator's Run) over the constructor-injected
+                    // sink. Falls back to the constructor sink for
+                    // direct-construction callers (tests, integration
+                    // helpers) that don't go through the coordinator.
+                    var diagSink = layout.Diagnostics ?? _diagnostics;
+                    OptimizingBreakResolver.SafeEmit(diagSink, new PaginateDiagnostic(
                         PaginateDiagnosticCodes.PaginationForcedOverflow001,
                         $"BlockLayouter: forced overflow on fragmentainer page index "
                         + $"{fragmentainer.PageIndex}, child index {childIdx} — "

--- a/src/NetPdf.Paginate/LayoutCheckpoint.cs
+++ b/src/NetPdf.Paginate/LayoutCheckpoint.cs
@@ -139,6 +139,40 @@ internal sealed class LayoutCheckpoint
     /// re-attempt produces a consistent fragment sequence.</summary>
     public int FragmentOutputCursor;
 
+    /// <summary>Per post-Task-7 review (recommendation P2 #5) — the
+    /// adjacent-margin-collapse frontier captured at this checkpoint
+    /// so a rewind to THIS specific checkpoint restores the correct
+    /// previous-block bottom margin (not the layouter's latest state,
+    /// which may correspond to a different — older or newer —
+    /// candidate-break boundary).
+    ///
+    /// <para>Cycle 2's PR #26 fix #3 stored the frontier in layouter-
+    /// private fields, populated only on the rewind branch. That works
+    /// for the current resolver (always rewinds to the most-recent
+    /// checkpoint) but breaks once the resolver retains multiple
+    /// checkpoints + chooses a non-most-recent one (a future
+    /// optimizer-aware path). Storing the frontier on the checkpoint
+    /// itself decouples the layouter's "current" state from the
+    /// "rewind-target" state.</para>
+    ///
+    /// <para>Layouters that don't model adjacent-margin collapse
+    /// (inline / table / flex / grid) leave both fields at their
+    /// zero defaults; <see cref="HasAdjoiningBlockOnEntry"/> stays
+    /// <see langword="false"/>, signaling "no collapse state to
+    /// restore". The fields are public + named generically so other
+    /// future block-flow layouters (nested BlockLayouter, etc.) can
+    /// reuse the slot.</para></summary>
+    public double PrevBlockMarginEnd;
+
+    /// <summary>Per post-Task-7 review (P2 #5) — companion flag to
+    /// <see cref="PrevBlockMarginEnd"/>. <see langword="true"/> when
+    /// an adjacent block sibling was emitted before this checkpoint
+    /// (so the next block's top margin should collapse with
+    /// <see cref="PrevBlockMarginEnd"/>); <see langword="false"/>
+    /// when this is the first block on the page or a non-block
+    /// child broke adjacency.</summary>
+    public bool HasAdjoiningBlockOnEntry;
+
     /// <summary>Per Phase 3 Task 4 review fix #7 — lease token stamped
     /// at <see cref="LayoutCheckpointPool.Rent"/> time + cleared by
     /// <see cref="LayoutCheckpointPool.Return"/> via atomic CAS. A
@@ -173,13 +207,20 @@ internal sealed class LayoutCheckpoint
         int fragmentOutputCursor,
         int lastEmittedChildIndex,
         LayoutContinuation? incomingContinuation,
-        int pageCounterValue)
+        int pageCounterValue,
+        double prevBlockMarginEnd = 0,
+        bool hasAdjoiningBlockOnEntry = false)
     {
         PageIndex = fragmentainer.PageIndex;
         UsedBlockSize = fragmentainer.UsedBlockSize;
         LastEmittedChildIndex = lastEmittedChildIndex;
         IncomingContinuation = incomingContinuation;
         PageCounterValue = pageCounterValue;
+        // Per post-Task-7 review (P2 #5) — capture the margin-collapse
+        // frontier so a rewind to THIS checkpoint restores the right
+        // prior-block bottom margin.
+        PrevBlockMarginEnd = prevBlockMarginEnd;
+        HasAdjoiningBlockOnEntry = hasAdjoiningBlockOnEntry;
 
         // Deep-copy mutable tables so the live layout can mutate them
         // without aliasing the snapshot.
@@ -295,6 +336,11 @@ internal sealed class LayoutCheckpoint
         CapturedFragmentainerRef = null;
         FloatManagerStateSnapshot = null;
         FragmentOutputCursor = 0;
+        // Per post-Task-7 review (P2 #5) — clear margin-collapse
+        // frontier on return-to-pool so a stale value doesn't leak
+        // into a fresh rent.
+        PrevBlockMarginEnd = 0;
+        HasAdjoiningBlockOnEntry = false;
         // Per fix #7 — _leaseToken intentionally NOT touched here.
     }
 }

--- a/src/NetPdf.Paginate/LayoutContext.cs
+++ b/src/NetPdf.Paginate/LayoutContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using NetPdf.Paginate.Diagnostics;
 
 namespace NetPdf.Paginate;
 
@@ -62,6 +63,27 @@ internal ref struct LayoutContext
     /// is allocated.</summary>
     public FragmentainerContext Fragmentainer;
 
+    /// <summary>Per post-Task-7 review (recommendation P1 #2) —
+    /// ambient pagination diagnostics sink. Pre-fix, the
+    /// <see cref="LayoutRetryCoordinator"/> + each layouter received
+    /// their OWN <see cref="IPaginateDiagnosticsSink"/> at construction.
+    /// A composition root that wired only the coordinator's sink would
+    /// miss <c>PAGINATION-FORCED-OVERFLOW-001</c> emitted from a
+    /// layouter's own forward-progress path on the Strict attempt
+    /// (because LastResort never fires when Strict commits).
+    ///
+    /// <para>Post-fix, the sink lives on the layout context — the
+    /// natural ambient holder. The coordinator's <c>Run</c> threads
+    /// its sink through to <c>layout.Diagnostics</c> on entry; the
+    /// layouter reads from <c>layout.Diagnostics</c> rather than
+    /// from a constructor-injected field. Wiring once at the
+    /// composition root reaches both sides.</para>
+    ///
+    /// <para><see langword="null"/> means "no diagnostic sink wired";
+    /// emission sites use the <c>OptimizingBreakResolver.SafeEmit</c>
+    /// helper which is null-safe.</para></summary>
+    public IPaginateDiagnosticsSink? Diagnostics;
+
     /// <summary>Document-scoped counter values per CSS Lists L3 §4.
     /// Keys are counter names (<c>page</c>, <c>pages</c>, author-defined);
     /// values are integer counter readings at the current layout
@@ -81,6 +103,7 @@ internal ref struct LayoutContext
         WritingMode = WritingMode.HorizontalTb;
         IsRtl = false;
         Fragmentainer = fragmentainer;
+        Diagnostics = null;
         _counters = null;
     }
 

--- a/src/NetPdf.Paginate/LayoutRetryCoordinator.cs
+++ b/src/NetPdf.Paginate/LayoutRetryCoordinator.cs
@@ -126,6 +126,22 @@ internal sealed class LayoutRetryCoordinator
         ArgumentNullException.ThrowIfNull(fragmentainer);
         ArgumentNullException.ThrowIfNull(resolver);
 
+        // Per post-Task-7 review (recommendation P1 #2) — thread the
+        // coordinator's diagnostic sink into the layout context so the
+        // layouter's forced-overflow path emits via the same sink.
+        // Pre-fix, the coordinator's sink + each layouter's sink were
+        // wired separately; a composition root that wired only the
+        // coordinator could miss PAGINATION-FORCED-OVERFLOW-001 from
+        // a layouter's Strict-attempt forward-progress path.
+        //
+        // Only sets layout.Diagnostics when it's null on entry —
+        // respects the caller's choice to override (e.g., a test
+        // wrapping with a recording sink).
+        if (Diagnostics is not null && layout.Diagnostics is null)
+        {
+            layout.Diagnostics = Diagnostics;
+        }
+
         // Capture the original page index for diagnostic messaging —
         // RestoreInto on a partially-captured checkpoint can reset
         // PageIndex to 0, which would mislead the consumer about

--- a/src/NetPdf.Paginate/Optimizer.cs
+++ b/src/NetPdf.Paginate/Optimizer.cs
@@ -166,20 +166,36 @@ internal static class Optimizer
             return OptimizerResult.Empty;
         }
 
-        // Per-opportunity validation. EnsureValid catches NaN /
-        // negative geometry — the DP's arithmetic depends on finite
-        // values to compare costs deterministically.
-        for (var i = 0; i < n; i++)
-        {
-            opportunities[i].EnsureValid();
-        }
-
-        // Whole-window budget cap.
+        // Per post-Task-7 review (recommendation P2 #4) — budget cap
+        // checked BEFORE the per-opportunity validation loop. Pathological
+        // inputs (10k+ candidates) used to burn the validation cycles
+        // even though the next step would discard the DP path entirely
+        // and fall back to greedy. Greedy's own loop validates each
+        // opportunity individually as it consumes them, so the
+        // up-front validation is wasted work in the over-budget case.
         if (n > MaxCandidatesBeforeFallback)
         {
             return Greedy(opportunities, contentBlockSize, orphansRequired, widowsRequired,
                 fallbackReason:
-                    $"Candidate set size {n} exceeds DP budget {MaxCandidatesBeforeFallback}; greedy fallback.");
+                    $"Candidate set size {n} exceeds DP budget {MaxCandidatesBeforeFallback}; greedy fallback.",
+                cancellationToken: cancellationToken);
+        }
+
+        // Per-opportunity validation. EnsureValid catches NaN /
+        // negative geometry — the DP's arithmetic depends on finite
+        // values to compare costs deterministically.
+        // Per post-Task-7 review (P2 #4) — cancellation check at every
+        // 64-opportunity boundary. A pre-cancelled token + a 1024-element
+        // input would otherwise still walk all 1024 EnsureValid calls
+        // before checking. 64 was chosen so the wasted work per check
+        // is bounded in microseconds.
+        for (var i = 0; i < n; i++)
+        {
+            if ((i & 0x3F) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+            opportunities[i].EnsureValid();
         }
 
         // Monotonicity check — UsedBlockSize must be non-decreasing.
@@ -193,7 +209,8 @@ internal static class Optimizer
                 return Greedy(opportunities, contentBlockSize, orphansRequired, widowsRequired,
                     fallbackReason:
                         "UsedBlockSize is not monotonically non-decreasing; the DP requires "
-                        + "cumulative block-axis position. Greedy fallback.");
+                        + "cumulative block-axis position. Greedy fallback.",
+                    cancellationToken: cancellationToken);
             }
         }
 
@@ -252,7 +269,8 @@ internal static class Optimizer
                 return Greedy(opportunities, contentBlockSize, orphansRequired, widowsRequired,
                     fallbackReason:
                         $"Per-page candidate count {inPageCount} exceeds MaxCandidatesPerPage="
-                        + $"{MaxCandidatesPerPage}; greedy fallback.");
+                        + $"{MaxCandidatesPerPage}; greedy fallback.",
+                    cancellationToken: cancellationToken);
             }
 
             // ---- Step 2 (review fix #4): if a forced break is
@@ -382,7 +400,8 @@ internal static class Optimizer
                     {
                         return Greedy(opportunities, contentBlockSize, orphansRequired, widowsRequired,
                             fallbackReason:
-                                $"DP exceeded MaxPairEvaluations={MaxPairEvaluations}; greedy fallback.");
+                                $"DP exceeded MaxPairEvaluations={MaxPairEvaluations}; greedy fallback.",
+                            cancellationToken: cancellationToken);
                     }
 
                     var oppB2 = opportunities[b2];
@@ -412,7 +431,8 @@ internal static class Optimizer
                 return Greedy(opportunities, contentBlockSize, orphansRequired, widowsRequired,
                     fallbackReason:
                         $"DP could not find a feasible (b1, b2) pair starting at index {i2}: "
-                        + "every in-window candidate was avoid-break + not forced. Greedy fallback.");
+                        + "every in-window candidate was avoid-break + not forced. Greedy fallback.",
+                    cancellationToken: cancellationToken);
             }
 
             breaks.Add(bestB1);
@@ -514,7 +534,8 @@ internal static class Optimizer
         double contentBlockSize,
         int orphansRequired,
         int widowsRequired,
-        string fallbackReason)
+        string fallbackReason,
+        CancellationToken cancellationToken = default)
     {
         var breaks = new List<int>(capacity: Math.Min(64, opportunities.Count));
         double totalCost = 0;
@@ -522,6 +543,15 @@ internal static class Optimizer
 
         for (var i = 0; i < opportunities.Count; i++)
         {
+            // Per post-Task-7 review (P2 #4) — greedy fallback on a
+            // pathological window (the over-budget path) can still
+            // burn cycles on a pre-cancelled token. Check at every
+            // 64-opportunity boundary so the wasted-work bound is
+            // microseconds.
+            if ((i & 0x3F) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
             var opp = opportunities[i];
             opp.EnsureValid();
 

--- a/src/NetPdf/Resources/SafeHttpResourceLoader.cs
+++ b/src/NetPdf/Resources/SafeHttpResourceLoader.cs
@@ -60,10 +60,31 @@ public sealed class SafeHttpResourceLoader : IResourceLoader, IDisposable
     private readonly HttpClient _httpClient;
     private readonly SecurityPolicy _policy;
 
+    /// <summary>Per post-Task-7 review (recommendation P1 #1) — the
+    /// <see cref="SecurityPolicy"/> this loader captured at construction.
+    /// Exposed so <see cref="SafeResourceLoader"/>'s constructor can
+    /// detect a policy-divergence misconfig (the wrapper's
+    /// <see cref="ResourceFetchContext.Policy"/> differing from the
+    /// inner HTTP loader's policy) + reject it at construction rather
+    /// than letting redirects / AllowedHosts / per-resource-bytes
+    /// validation use one policy while scheme / IP-blocklist
+    /// validation uses another. Read-only — set once at construction.</summary>
+    public SecurityPolicy Policy => _policy;
+
     /// <summary>Construct with the active <see cref="SecurityPolicy"/>.
     /// The loader captures the policy at construction so the configured
     /// IP blocklist + redirect cap + per-resource size cap apply
-    /// uniformly across every fetch issued by this loader instance.</summary>
+    /// uniformly across every fetch issued by this loader instance.
+    ///
+    /// <para>Per post-Task-7 review (P1 #1) — when this loader is
+    /// wrapped by a <see cref="SafeResourceLoader"/> whose
+    /// <see cref="ResourceFetchContext.Policy"/> differs from the
+    /// policy passed here, the wrapper's constructor throws
+    /// <see cref="ArgumentException"/> to surface the misconfig before
+    /// any divergent decisions are made. To keep them in sync, prefer
+    /// <see cref="SafeResourceLoader.CreateWithSafeHttp"/>, which
+    /// constructs both with the context's policy as the single source
+    /// of truth.</para></summary>
     public SafeHttpResourceLoader(SecurityPolicy? policy = null)
     {
         _policy = policy ?? SecurityPolicy.SafeDefault;

--- a/src/NetPdf/Resources/SafeResourceLoader.cs
+++ b/src/NetPdf/Resources/SafeResourceLoader.cs
@@ -60,8 +60,59 @@ public sealed class SafeResourceLoader
     public SafeResourceLoader(IResourceLoader? inner, ResourceFetchContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
+        // Per post-Task-7 review (recommendation P1 #1) — when the
+        // inner loader is a SafeHttpResourceLoader, both this wrapper
+        // AND the inner loader make policy-dependent decisions
+        // (scheme / IP / AllowedHosts at the wrapper layer; redirect
+        // hops / per-resource bytes inside the loader). If the two
+        // policies diverge, redirects / AllowedHosts could be checked
+        // against a different rule set than the initial URI — a
+        // silent security-correctness gap.
+        //
+        // Reject the misconfig fail-fast at construction. The factory
+        // CreateWithSafeHttp wires both with the same policy.
+        // ReferenceEquals (not value equality) is intentional: callers
+        // that genuinely want to share a policy SHOULD share the
+        // instance; constructing two distinct SecurityPolicy objects
+        // with identical fields is almost always an oversight.
+        if (inner is SafeHttpResourceLoader safeHttp
+            && !ReferenceEquals(safeHttp.Policy, context.Policy))
+        {
+            throw new ArgumentException(
+                "SafeHttpResourceLoader's SecurityPolicy must be the same "
+                + "instance as ResourceFetchContext.Policy. Pre-fix the two "
+                + "could diverge silently — the wrapper would validate "
+                + "scheme / IP / AllowedHosts against context.Policy while "
+                + "the loader validated redirects + per-resource-bytes "
+                + "against its own policy. Use "
+                + "SafeResourceLoader.CreateWithSafeHttp(context) to "
+                + "construct both with the context's policy.",
+                nameof(inner));
+        }
         _inner = inner; // null is valid — see class docs
         _context = context;
+    }
+
+    /// <summary>Per post-Task-7 review (recommendation P1 #1) — factory
+    /// that constructs a <see cref="SafeHttpResourceLoader"/> using the
+    /// <paramref name="context"/>'s <see cref="SecurityPolicy"/> + wraps
+    /// it in a <see cref="SafeResourceLoader"/> bound to the same
+    /// context. Single source of truth for the policy across both
+    /// layers; eliminates the divergence risk entirely.
+    ///
+    /// <para>The returned wrapper does NOT take ownership of the
+    /// returned HTTP loader's lifetime. Callers who construct via this
+    /// factory should track the underlying loader separately if they
+    /// need <see cref="IDisposable.Dispose"/> on shutdown — typically
+    /// by reading the <c>UnderlyingHttpLoader</c> property off the
+    /// returned <see cref="SafeResourceLoaderWithHttp"/> bundle. (For
+    /// most v1 use cases the loader lives for the process lifetime.)</para></summary>
+    public static SafeResourceLoaderWithHttp CreateWithSafeHttp(ResourceFetchContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var http = new SafeHttpResourceLoader(context.Policy);
+        var wrapper = new SafeResourceLoader(http, context);
+        return new SafeResourceLoaderWithHttp(wrapper, http);
     }
 
     /// <summary>Fetch a resource with all the Phase D defenses applied.
@@ -458,6 +509,33 @@ public sealed class SafeResourceLoader
         if (message.Length > maxLen) sb.Append("...");
         return sb.ToString();
     }
+}
+
+/// <summary>Per post-Task-7 review (recommendation P1 #1) — bundle
+/// returned by <see cref="SafeResourceLoader.CreateWithSafeHttp"/>.
+/// Holds the constructed wrapper + the underlying HTTP loader so the
+/// caller can dispose the loader at shutdown without losing the
+/// wrapper's reference.</summary>
+public sealed class SafeResourceLoaderWithHttp : IDisposable
+{
+    /// <summary>The wrapper. Pass this to <c>HtmlPdfOptions.ResourceLoader</c>
+    /// + every pipeline-internal fetch routes through here.</summary>
+    public SafeResourceLoader Wrapper { get; }
+
+    /// <summary>The underlying HTTP loader. Exposed so the caller
+    /// can <see cref="IDisposable.Dispose"/> it at shutdown — the
+    /// wrapper does NOT take ownership of the loader's lifecycle.</summary>
+    public SafeHttpResourceLoader UnderlyingHttpLoader { get; }
+
+    internal SafeResourceLoaderWithHttp(SafeResourceLoader wrapper, SafeHttpResourceLoader http)
+    {
+        Wrapper = wrapper;
+        UnderlyingHttpLoader = http;
+    }
+
+    /// <summary>Disposes the underlying HTTP loader. The wrapper has
+    /// no native resources of its own — only the loader's HttpClient.</summary>
+    public void Dispose() => UnderlyingHttpLoader.Dispose();
 }
 
 /// <summary>Result of a <see cref="SafeResourceLoader.FetchAsync"/>.

--- a/tests/NetPdf.UnitTests/Phase2/PhaseDSecurityHardeningTests.cs
+++ b/tests/NetPdf.UnitTests/Phase2/PhaseDSecurityHardeningTests.cs
@@ -819,14 +819,58 @@ public sealed class PhaseDSecurityHardeningTests
     {
         // Pathological but legal — image-set inside cross-fade. Both
         // are resource-list functions, so strings at either level are
-        // URLs. The fix must not break this: nested resource-fn
-        // depths still count as resource-fn level (innerNonResourceDepth
-        // stays at 0 because the inner is opened via
-        // TryMatchResourceFunctionStart, not as a non-resource paren).
+        // URLs. The fix must not break this: nested resource-fn levels
+        // still count as resource-fn level (the per-level helper-depth
+        // stack pushes a new 0 entry on each resource-fn entry, so
+        // strings at that new level are captured).
         var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
             "background-image",
             "cross-fade(image-set(\"a.png\" 1x), \"b.png\", 50%)",
             NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("a.png", refs[0].Url);
+        Assert.Equal("b.png", refs[1].Url);
+    }
+
+    [Fact]
+    public void PostTask7_resource_fn_nested_inside_helper_extracts_strings_correctly()
+    {
+        // Per Copilot inline review — the pre-fix single-counter design
+        // got the wrong answer when a resource fn appeared INSIDE a
+        // helper:
+        //   image-set(type(image-set("a.png" 1x)), "b.png" 2x)
+        //
+        // Pre-fix walk:
+        //   - outer image-set( → resourceFnDepth=1
+        //   - type(            → innerNonResourceDepth=1
+        //   - inner image-set( → resourceFnDepth=2 (helper-depth NOT
+        //                        reset → still 1)
+        //   - "a.png"          → innerNonResourceDepth=1 → NOT captured
+        //                        (incorrect — image-set IS a resource
+        //                        fn even when nested in a helper)
+        //   - ) of inner       → innerNonResourceDepth=0 (decrements
+        //                        WRONG counter — should be the inner
+        //                        image-set's level popping)
+        //   - ) of type        → resourceFnDepth=1 (innerNonResourceDepth
+        //                        was already 0 → decrements wrong field)
+        //   - "b.png"          → captured (lucky — state happened to
+        //                        end up consistent)
+        //   - ) of outer       → resourceFnDepth=0
+        //
+        // Post-fix per-level stack:
+        //   - outer image-set( → helperDepths=[0]
+        //   - type(            → helperDepths=[1]  (helper inside outer)
+        //   - inner image-set( → helperDepths=[1, 0]  (push fresh level)
+        //   - "a.png"          → top=0 → captured ✓
+        //   - ) of inner       → top=0, popped → helperDepths=[1]
+        //   - ) of type        → top=1>0, decrement → helperDepths=[0]
+        //   - "b.png"          → top=0 → captured ✓
+        //   - ) of outer       → top=0, popped → helperDepths=[]
+        var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
+            "background-image",
+            "image-set(type(image-set(\"a.png\" 1x)), \"b.png\" 2x)",
+            NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        // Both URLs captured. Pre-fix would have missed "a.png".
         Assert.Equal(2, refs.Count);
         Assert.Equal("a.png", refs[0].Url);
         Assert.Equal("b.png", refs[1].Url);

--- a/tests/NetPdf.UnitTests/Phase2/PhaseDSecurityHardeningTests.cs
+++ b/tests/NetPdf.UnitTests/Phase2/PhaseDSecurityHardeningTests.cs
@@ -740,6 +740,196 @@ public sealed class PhaseDSecurityHardeningTests
         Assert.Empty(refs);
     }
 
+    // Post-Task-7 review — nested non-resource helper functions inside
+    // image-set / cross-fade / image. Pre-fix bugs:
+    //   (1) String args of helpers like type() / format() were captured
+    //       as phantom URLs (e.g., "image/png" extracted from
+    //       `image-set("a.png" 1x, type("image/png"))`).
+    //   (2) The helper's closing ) decremented the resource-fn depth,
+    //       prematurely closing the image-set context so legitimate
+    //       strings AFTER the helper would not be captured.
+    // The fix tracks an inner-non-resource paren depth separately; only
+    // strings at the IMMEDIATE level of the resource fn (innerNonResourceDepth
+    // == 0) count as URLs, and helper close-parens decrement the inner
+    // depth, leaving the resource-fn context intact.
+
+    [Fact]
+    public void PostTask7_image_set_with_type_helper_does_not_extract_helper_string()
+    {
+        // CSS Images L4 §6 — type("image/png") is a helper inside
+        // image-set, NOT a URL-bearing entry. Pre-fix the parser
+        // captured "image/png" as a phantom URL.
+        var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
+            "background-image",
+            "image-set(\"a.png\" 1x, type(\"image/png\"))",
+            NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        // Only "a.png" is a URL; "image/png" is a MIME type argument.
+        Assert.Single(refs);
+        Assert.Equal("a.png", refs[0].Url);
+    }
+
+    [Fact]
+    public void PostTask7_image_set_with_format_helper_does_not_extract_helper_string()
+    {
+        // url(...) format("png") inside image-set — format() is a
+        // helper hint, "png" is its arg, NOT a URL.
+        var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
+            "background-image",
+            "image-set(url(\"a.png\") format(\"png\"))",
+            NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        // Only the url() emits a URL; format("png") does NOT.
+        Assert.Single(refs);
+        Assert.Equal("a.png", refs[0].Url);
+    }
+
+    [Fact]
+    public void PostTask7_image_set_helper_close_paren_does_not_close_resource_fn()
+    {
+        // Pre-fix: the closing ) of type() decremented resourceFnDepth,
+        // so the SECOND legitimate string ("c.png") AFTER the helper was
+        // outside the resource-fn context and not captured.
+        // Post-fix: helper ) decrements innerNonResourceDepth; the
+        // image-set context survives until its OWN closing ).
+        var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
+            "background-image",
+            "image-set(\"a.png\" 1x, type(\"image/png\") , \"c.png\" 2x)",
+            NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        // BOTH "a.png" + "c.png" are real URLs; "image/png" is NOT.
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("a.png", refs[0].Url);
+        Assert.Equal("c.png", refs[1].Url);
+    }
+
+    [Fact]
+    public void PostTask7_image_set_with_calc_helper_does_not_extract_helper_string()
+    {
+        // calc() is a helper that may appear in resource-fn args; its
+        // own contents are arithmetic, not URLs. (calc rarely contains
+        // strings, but cover the safety case so we don't regress later.)
+        var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
+            "background-image",
+            "image-set(\"a.png\" calc(1 * 1x))",
+            NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        Assert.Single(refs);
+        Assert.Equal("a.png", refs[0].Url);
+    }
+
+    [Fact]
+    public void PostTask7_nested_resource_fns_still_extract_strings()
+    {
+        // Pathological but legal — image-set inside cross-fade. Both
+        // are resource-list functions, so strings at either level are
+        // URLs. The fix must not break this: nested resource-fn
+        // depths still count as resource-fn level (innerNonResourceDepth
+        // stays at 0 because the inner is opened via
+        // TryMatchResourceFunctionStart, not as a non-resource paren).
+        var refs = NetPdf.Css.Resources.CssResourceExtractor.ExtractFromDeclaration(
+            "background-image",
+            "cross-fade(image-set(\"a.png\" 1x), \"b.png\", 50%)",
+            NetPdf.Css.Parser.CssSourceLocation.Unknown);
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("a.png", refs[0].Url);
+        Assert.Equal("b.png", refs[1].Url);
+    }
+
+    // ====================================================================
+    //  Post-Task-7 review #1 (P1 #1) — HTTP loader policy unification.
+    //  SafeHttpResourceLoader's constructor-captured policy + the
+    //  SafeResourceLoader's ResourceFetchContext.Policy were independent
+    //  decisions; the wrapper validated scheme/IP/AllowedHosts against
+    //  context.Policy while the inner loader validated redirects +
+    //  per-resource bytes against its own policy. Mismatch = silent
+    //  security gap. Post-fix: detect ReferenceEquals divergence at
+    //  wrapper construction + throw, plus a CreateWithSafeHttp factory
+    //  that wires both with the context's policy as the single source.
+    // ====================================================================
+
+    [Fact]
+    public void PostTask7_safe_resource_loader_throws_when_inner_http_loader_has_divergent_policy()
+    {
+        // Two distinct SecurityPolicy instances (even with identical
+        // fields) → divergence. Pre-fix, this constructed silently +
+        // redirect/AllowedHosts validation could use a different
+        // policy than the wrapper's URI safety check. Post-fix throws.
+        var policyA = new SecurityPolicy { AllowHttpsScheme = true };
+        var policyB = new SecurityPolicy { AllowHttpsScheme = true };
+        using var http = new SafeHttpResourceLoader(policyA);
+        var ctx = new ResourceFetchContext(policyB, baseUri: null,
+            cancellationToken: System.Threading.CancellationToken.None);
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new SafeResourceLoader(http, ctx));
+        Assert.Contains("same instance", ex.Message,
+            System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("CreateWithSafeHttp", ex.Message,
+            System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PostTask7_safe_resource_loader_accepts_inner_http_loader_with_same_policy_instance()
+    {
+        // Same SecurityPolicy instance shared between both layers →
+        // no divergence; constructor accepts.
+        var policy = new SecurityPolicy { AllowHttpsScheme = true };
+        using var http = new SafeHttpResourceLoader(policy);
+        var ctx = new ResourceFetchContext(policy, baseUri: null,
+            cancellationToken: System.Threading.CancellationToken.None);
+
+        var loader = new SafeResourceLoader(http, ctx);
+        Assert.NotNull(loader);
+    }
+
+    [Fact]
+    public void PostTask7_safe_resource_loader_accepts_non_http_inner_loader()
+    {
+        // The divergence check applies ONLY to SafeHttpResourceLoader
+        // inners (the only well-known policy-aware type). A custom
+        // user-supplied IResourceLoader is opaque — the wrapper can't
+        // know what policy it uses, so the check is skipped.
+        var policy = new SecurityPolicy();
+        var ctx = new ResourceFetchContext(policy, baseUri: null,
+            cancellationToken: System.Threading.CancellationToken.None);
+        var customInner = new InvocationCountingLoader();
+
+        var loader = new SafeResourceLoader(customInner, ctx);
+        Assert.NotNull(loader);
+    }
+
+    [Fact]
+    public void PostTask7_create_with_safe_http_wires_both_layers_with_context_policy()
+    {
+        // The factory ensures both the wrapper + the inner HTTP loader
+        // see the SAME SecurityPolicy instance (= context.Policy).
+        var policy = new SecurityPolicy { AllowHttpsScheme = true };
+        var ctx = new ResourceFetchContext(policy, baseUri: null,
+            cancellationToken: System.Threading.CancellationToken.None);
+
+        using var bundle = SafeResourceLoader.CreateWithSafeHttp(ctx);
+        Assert.NotNull(bundle.Wrapper);
+        Assert.NotNull(bundle.UnderlyingHttpLoader);
+        // The HTTP loader's Policy is the context's policy.
+        Assert.Same(policy, bundle.UnderlyingHttpLoader.Policy);
+    }
+
+    [Fact]
+    public void PostTask7_safe_http_resource_loader_policy_property_returns_constructor_value()
+    {
+        // Sanity: the new public Policy getter exposes the
+        // constructor-captured value.
+        var policy = new SecurityPolicy { MaxRedirectHops = 7 };
+        using var http = new SafeHttpResourceLoader(policy);
+        Assert.Same(policy, http.Policy);
+    }
+
+    [Fact]
+    public void PostTask7_safe_http_resource_loader_policy_property_defaults_to_safe_default()
+    {
+        // When constructed without an explicit policy, Policy returns
+        // SecurityPolicy.SafeDefault.
+        using var http = new SafeHttpResourceLoader();
+        Assert.Same(SecurityPolicy.SafeDefault, http.Policy);
+    }
+
     // P2 #5: Symlink-aware file sandbox.
     [Fact]
     public void DReview_symlink_traversal_test_doc()

--- a/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
@@ -1012,6 +1012,290 @@ public sealed class BlockLayouterTests
         Assert.True(result.Cost >= CostModel.BreakInsideAvoidViolation);
     }
 
+    // --- Post-Task-7 review #3: collapsed margins don't overcount in overflow check --
+
+    [Fact]
+    public void PostTask7_collapsed_margins_do_not_trigger_false_page_break()
+    {
+        // Post-Task-7 review (recommendation P2 #3) — `visualBlockExtent`
+        // pre-fix used raw `marginStart`. After collapse the actual top
+        // contribution is `topShift`, NOT `marginStart`. With a previous
+        // block bottom-margin of 80 + current block top-margin of 10,
+        // the collapsed gap = max(80, 10) = 80, which is already in
+        // fragmentainer.UsedBlockSize (the prior block's emission added
+        // it). topShift = 80 - 80 = 0 — current block's top contributes
+        // 0 additional space. Pre-fix counted +10, which on a fragmentainer
+        // boundary would create a false page break.
+        //
+        // Test scenario:
+        //   page block size = 800
+        //   block 1: height=100, marginBottom=80 → cursor goes 0→180
+        //     (border-box top=0, border-box bottom=100, +80 marginBottom = 180)
+        //   block 2: height=620, marginTop=10
+        //     - collapsed gap = max(80, 10) = 80 (already counted)
+        //     - topShift = 0
+        //     - actual visual top contribution = 0
+        //     - block 2's border-box top = 180; bottom = 800 — fits exactly.
+        //   Total page contribution = 800. NO overflow.
+        //
+        // Pre-fix: visualBlockExtent = 620 + max(0,10) + max(0,0) = 630.
+        //   chunkForBreakCheck = max(620, 630) = 630.
+        //   UsedBlockSize at decision = 180. 180 + 630 = 810 > 800 → BreakHere
+        //   → false page break (block 2 spuriously fails to fit).
+        // Post-fix: visualBlockExtent = 620 + max(0,topShift=0) + max(0,0) = 620.
+        //   chunkForBreakCheck = max(620, 620) = 620.
+        //   180 + 620 = 800 ≤ 800 → Continue. Block fits.
+        var sink = new RecordingFragmentSink();
+        var (root, _) = BuildTree(
+            (height: 100, marginTop: 0, marginBottom: 80),
+            (height: 620, marginTop: 10, marginBottom: 0));
+
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+
+        var result = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        // Both blocks fit; layouter returns AllDone (no continuation needed).
+        Assert.Equal(LayoutAttemptOutcome.AllDone, result.Outcome);
+        Assert.Equal(2, sink.Fragments.Count);
+        // Block 1: BlockOffset=0, BlockSize=100.
+        Assert.Equal(0, sink.Fragments[0].BlockOffset);
+        Assert.Equal(100, sink.Fragments[0].BlockSize);
+        // Block 2: collapsed-with-prior. effectiveTopGap=80, topShift=0.
+        // BlockOffset = UsedBlockSize-after-block-1 (180) + topShift (0) = 180.
+        Assert.Equal(180, sink.Fragments[1].BlockOffset);
+        Assert.Equal(620, sink.Fragments[1].BlockSize);
+    }
+
+    // --- Post-Task-7 review #5: checkpoint-owned margin-collapse frontier ---
+
+    [Fact]
+    public void PostTask7_rewind_to_older_checkpoint_uses_that_checkpoints_frontier()
+    {
+        // Post-Task-7 review (recommendation P2 #5) — pre-fix, the
+        // layouter stored the margin-collapse frontier in private
+        // fields populated AT REWIND TIME with the LAYOUTER'S CURRENT
+        // state. That works for the current single-slot resolver
+        // (always rewinds to the most-recent checkpoint), but would
+        // break a future resolver that retains multiple checkpoints +
+        // rewinds to an OLDER one (e.g., DP-optimal rewind across a
+        // window).
+        //
+        // Post-fix, the frontier is captured ON THE CHECKPOINT at
+        // capture time, and the rewind branch reads from
+        // `decision.RewindTo` rather than the layouter's "now" state.
+        //
+        // This test simulates the retained-multiple-checkpoints case
+        // with a resolver that:
+        //   - Stashes the FIRST checkpoint it sees (block 1 boundary —
+        //     no prior adjoining block, no collapse state).
+        //   - Continues through blocks 1, 2.
+        //   - At block 3, returns Rewind targeting the STASHED first
+        //     checkpoint (NOT the just-registered block-3 one).
+        // The layouter should resume with:
+        //   - LastEmittedChildIndex from the stashed checkpoint
+        //     (= -1 or 0 depending on capture timing — see resolver).
+        //   - The FRONTIER captured at the stashed checkpoint
+        //     (`hasAdjoiningBlockOnEntry: false`,
+        //      `prevBlockMarginEnd: 0`).
+        // Pre-fix would (incorrectly) restore the LAYOUTER'S state at
+        // rewind-call time — which corresponds to AFTER block 2 was
+        // emitted, so prevBlockMarginEnd != 0.
+        var sink = new RecordingFragmentSink();
+        var (root, _) = BuildTree(
+            (height: 100, marginTop: 0, marginBottom: 50),  // block 0 — bottom=50
+            (height: 100, marginTop: 0, marginBottom: 80),  // block 1 — bottom=80
+            (height: 100, marginTop: 0, marginBottom: 30)); // block 2 — bottom=30
+
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new RewindToFirstCheckpointResolver();
+
+        // First attempt: resolver stashes the first checkpoint (block 0
+        // boundary), continues through blocks 0+1, then rewinds to the
+        // stashed first checkpoint at block 2 boundary.
+        var firstResult = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+        Assert.Equal(LayoutAttemptOutcome.NeedsRewind, firstResult.Outcome);
+
+        // The stashed checkpoint's frontier should reflect the BLOCK 0
+        // boundary state: hasAdjoiningBlockOnEntry=false (no block emitted
+        // yet at that point), prevBlockMarginEnd=0.
+        Assert.NotNull(firstResult.RewindTo);
+        Assert.False(firstResult.RewindTo!.HasAdjoiningBlockOnEntry);
+        Assert.Equal(0, firstResult.RewindTo.PrevBlockMarginEnd);
+
+        // Restore + retry. The retry should resume from the stashed
+        // checkpoint's LastEmittedChildIndex+1 = 0 (since
+        // LastEmittedChildIndex = -1 — nothing emitted before block 0).
+        firstResult.RewindTo.RestoreInto(ctx, ref layoutCtx);
+        sink.RollbackTo(firstResult.RewindTo.FragmentOutputCursor);
+        resolver.SuppressNextRewind = true;
+
+        var secondResult = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+        Assert.Equal(LayoutAttemptOutcome.AllDone, secondResult.Outcome);
+        // 3 blocks emitted on the retry. Block 0 starts at offset 0
+        // (no collapse — frontier was hasAdjoiningBlock=false). If pre-
+        // fix had restored the wrong frontier (block 2's state), block 0
+        // on retry would have collapsed against a phantom prior margin.
+        Assert.Equal(3, sink.Fragments.Count);
+        Assert.Equal(0, sink.Fragments[0].BlockOffset);
+    }
+
+    /// <summary>Resolver that retains the FIRST checkpoint it sees +
+    /// rewinds to it on the third Consider call. Simulates the future
+    /// retained-multiple-checkpoints resolver scenario for the P2 #5
+    /// regression.</summary>
+    private sealed class RewindToFirstCheckpointResolver : IBreakResolver
+    {
+        public bool SuppressNextRewind;
+        private int _calls;
+        private CheckpointLease _firstLease;
+        private CheckpointLease _latestLease;
+
+        public BreakDecision ConsiderBreakAt(BreakOpportunity opportunity, FragmentainerContext ctx)
+        {
+            _calls++;
+            // On call 3 (block 2 boundary), rewind to the FIRST
+            // captured checkpoint (block 0 boundary).
+            if (_calls == 3 && !SuppressNextRewind)
+            {
+                return new BreakDecision(BreakAction.Rewind, 0, _firstLease.Checkpoint);
+            }
+            return BreakDecision.Continue;
+        }
+
+        public OptimizerResult ResolveBreaks(
+            IReadOnlyList<BreakOpportunity> opportunities, FragmentainerContext ctx, CancellationToken cancellationToken = default)
+            => OptimizerResult.Empty;
+
+        public void RegisterCheckpoint(CheckpointLease lease)
+        {
+            // Stash the FIRST checkpoint we ever see.
+            if (_firstLease.Checkpoint is null)
+            {
+                _firstLease = lease;
+                return;
+            }
+            // Subsequent checkpoints — return the prior LATEST (NOT the
+            // first; we want to keep the first alive for the rewind).
+            if (_latestLease.Checkpoint is not null
+                && !ReferenceEquals(_latestLease.Checkpoint, lease.Checkpoint)
+                && !ReferenceEquals(_latestLease.Checkpoint, _firstLease.Checkpoint))
+            {
+                LayoutCheckpointPool.Return(_latestLease);
+            }
+            _latestLease = lease;
+        }
+
+        public LayoutCheckpoint? GetLastCheckpoint() => _latestLease.Checkpoint ?? _firstLease.Checkpoint;
+
+        public void Dispose()
+        {
+            if (_firstLease.Checkpoint is not null)
+            {
+                LayoutCheckpointPool.Return(_firstLease);
+                _firstLease = default;
+            }
+            if (_latestLease.Checkpoint is not null)
+            {
+                LayoutCheckpointPool.Return(_latestLease);
+                _latestLease = default;
+            }
+        }
+    }
+
+    // --- Post-Task-7 review #1 (P1 #2): diagnostics flow through ---
+    // --- LayoutContext from coordinator to layouter --------------
+
+    [Fact]
+    public void PostTask7_coordinator_diagnostics_reach_layouter_via_layout_context()
+    {
+        // Post-Task-7 review (recommendation P1 #2) — pre-fix the
+        // coordinator + layouter each had their own diagnostic sink
+        // wired separately. A composition root that wired ONLY the
+        // coordinator's sink would miss
+        // PAGINATION-FORCED-OVERFLOW-001 emitted from the layouter's
+        // forward-progress path on the Strict attempt (LastResort
+        // never fires when Strict commits).
+        //
+        // Post-fix, the coordinator threads its sink into
+        // layout.Diagnostics on entry; the layouter reads from
+        // layout.Diagnostics. Wiring once at the coordinator reaches
+        // both sides.
+        //
+        // Test: oversized block (taller than the page) on fragmentainer
+        // 0. Strict path: resolver returns BreakHere (block too tall);
+        // layouter's forward-progress hits the forced-overflow path
+        // BEFORE LastResort. Pre-fix this would emit nothing on the
+        // coordinator's sink (layouter's _diagnostics was null —
+        // we never set it via constructor); post-fix it emits because
+        // the coordinator pushes its sink to layout.Diagnostics.
+        var diagSink = new RecordingDiagnosticsSink();
+        var sink = new RecordingFragmentSink();
+
+        var style = MakeStyle();
+        SetLengthPx(style, PropertyId.Height, 2000);  // taller than page
+        var root = Box.CreateRoot(MakeStyle());
+        root.AppendChild(Box.ForElement(BoxKind.BlockContainer, style, MakeElement()));
+
+        // Layouter constructed WITHOUT a diagnostics arg — the
+        // coordinator's sink is the only one wired.
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        var coordinator = new LayoutRetryCoordinator(diagnostics: diagSink, fragmentSink: sink);
+        using var resolver = new BreakResolver();
+
+        var result = coordinator.Run(layouter, ctx, ref layoutCtx, resolver);
+
+        // Layouter's Strict-path forward-progress emits the diagnostic.
+        // Pre-fix: nothing emitted (layouter._diagnostics was null).
+        // Post-fix: emitted via layout.Diagnostics.
+        Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+        Assert.Single(diagSink.Diagnostics);
+        Assert.Equal(PaginateDiagnosticCodes.PaginationForcedOverflow001,
+            diagSink.Diagnostics[0].Code);
+        Assert.Contains("forced overflow", diagSink.Diagnostics[0].Message,
+            System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PostTask7_constructor_injected_sink_still_works_for_direct_construction()
+    {
+        // Backward-compat sanity: tests / direct callers that pass an
+        // IPaginateDiagnosticsSink to the BlockLayouter constructor
+        // (without going through the coordinator) still get diagnostics.
+        // The lookup is `layout.Diagnostics ?? _diagnostics` so the
+        // constructor sink wins when the ambient one isn't set.
+        var diagSink = new RecordingDiagnosticsSink();
+        var sink = new RecordingFragmentSink();
+
+        var style = MakeStyle();
+        SetLengthPx(style, PropertyId.Height, 2000);
+        var root = Box.CreateRoot(MakeStyle());
+        root.AppendChild(Box.ForElement(BoxKind.BlockContainer, style, MakeElement()));
+
+        using var layouter = new BlockLayouter(
+            root, sink, incomingContinuation: null, diagnostics: diagSink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);  // layoutCtx.Diagnostics = null
+        using var resolver = new BreakResolver();
+
+        var result = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+        Assert.Single(diagSink.Diagnostics);
+        Assert.Equal(PaginateDiagnosticCodes.PaginationForcedOverflow001,
+            diagSink.Diagnostics[0].Code);
+    }
+
     /// <summary>Recording sink for diagnostics — captures all emitted
     /// PaginateDiagnostics for assertion. Per the IPaginateDiagnosticsSink
     /// contract: must not throw.</summary>

--- a/tests/NetPdf.UnitTests/Phase3/PaginationOptimizerTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/PaginationOptimizerTests.cs
@@ -1388,13 +1388,15 @@ public sealed class PaginationOptimizerTests
     // ====================================================================
 
     [Fact]
-    public void PostTask7_optimize_pre_cancelled_token_throws_for_over_budget_input()
+    public void PostTask7_optimize_pre_cancelled_token_throws_at_method_entry_for_over_budget_input()
     {
-        // Build a candidate set just above MaxCandidatesBeforeFallback
-        // (16384). Pre-fix would walk all 16385 EnsureValid calls before
-        // checking the cancellation token. Post-fix: budget cap precedes
-        // validation, falls into Greedy, which polls the token on its
-        // first 64-element boundary and throws.
+        // Per Copilot inline review — Optimize calls
+        // ThrowIfCancellationRequested at method entry, so a
+        // pre-cancelled token throws BEFORE either the validation loop
+        // or the budget cap is reached. This test pins that
+        // entry-check regression guard for over-budget inputs;
+        // PostTask7_optimize_cancellation_during_greedy_fallback below
+        // exercises the new in-loop polling path.
         var n = Optimizer.MaxCandidatesBeforeFallback + 1;
         var opps = new List<BreakOpportunity>(n);
         for (var i = 0; i < n; i++)
@@ -1410,13 +1412,12 @@ public sealed class PaginationOptimizerTests
     }
 
     [Fact]
-    public void PostTask7_optimize_pre_cancelled_token_throws_during_validation_under_budget()
+    public void PostTask7_optimize_pre_cancelled_token_throws_at_method_entry_under_budget()
     {
-        // Under-budget input — the DP path runs. Per post-Task-7 fix,
-        // the validation loop polls the token at every 64-element
-        // boundary; a pre-cancelled token must throw on the very
-        // first check (i == 0).
-        var n = 256;  // well under MaxCandidatesBeforeFallback
+        // Pre-cancelled token throws at method entry (regression guard
+        // for the entry-check). The new in-loop polling is exercised
+        // by PostTask7_optimize_cancellation_during_validation below.
+        var n = 256;
         var opps = new List<BreakOpportunity>(n);
         for (var i = 0; i < n; i++)
         {
@@ -1449,5 +1450,121 @@ public sealed class PaginationOptimizerTests
         Assert.NotNull(result.FallbackReason);
         Assert.Contains("greedy fallback", result.FallbackReason!,
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PostTask7_optimize_cancellation_during_validation_under_budget()
+    {
+        // Per Copilot inline review — exercise the NEW in-loop polling
+        // (not the entry-check). Use an IReadOnlyList wrapper that
+        // cancels its CTS when the optimizer's validation loop accesses
+        // the Nth element. The 64-boundary CT poll inside the validation
+        // loop must catch the cancellation + throw.
+        //
+        // Setup: 256 elements (under MaxCandidatesBeforeFallback so the
+        // DP path runs the validation loop). Cancel on access #100.
+        // The validation loop accesses opportunities[i] sequentially;
+        // after access 100 (which happens during EnsureValid for
+        // opportunities[99]), the CTS is cancelled. The CT poll fires
+        // at i=128 (next 64-boundary after 99) and throws.
+        using var cts = new CancellationTokenSource();
+        var inner = new List<BreakOpportunity>(256);
+        for (var i = 0; i < 256; i++)
+        {
+            inner.Add(BreakOpportunity.Block(usedBlockSize: i * 10.0, chunkBlockSize: 10));
+        }
+        var cancelOnAccess = new CancelOnNthAccessList(inner, cts, cancelAfterAccesses: 100);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            Optimizer.Optimize(
+                cancelOnAccess, contentBlockSize: 800, orphansRequired: 2, widowsRequired: 2,
+                cancellationToken: cts.Token));
+        // Verify cancellation actually happened MID-EXECUTION (access
+        // count > 100), not at method entry where access count would
+        // still be 0.
+        Assert.True(cancelOnAccess.AccessCount > 100,
+            $"Expected cancellation during validation (access count > 100), got {cancelOnAccess.AccessCount}");
+    }
+
+    [Fact]
+    public void PostTask7_optimize_cancellation_during_greedy_fallback_over_budget()
+    {
+        // Exercise the NEW CancellationToken plumbing into Greedy.
+        // Pre-fix Greedy did not accept a CT and the over-budget path
+        // could burn CPU on a cancelled token. Post-fix: the CT is
+        // threaded into Greedy + polled at every 64-element boundary.
+        //
+        // Setup: over-budget input (16385 elements) + cancellation on
+        // access #100 (which lands inside Greedy's iteration since the
+        // DP path is bypassed by the budget cap). Greedy's 64-boundary
+        // poll catches the cancellation + throws.
+        using var cts = new CancellationTokenSource();
+        var n = Optimizer.MaxCandidatesBeforeFallback + 1;
+        var inner = new List<BreakOpportunity>(n);
+        for (var i = 0; i < n; i++)
+        {
+            inner.Add(BreakOpportunity.Block(usedBlockSize: i * 10.0, chunkBlockSize: 10));
+        }
+        var cancelOnAccess = new CancelOnNthAccessList(inner, cts, cancelAfterAccesses: 100);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            Optimizer.Optimize(
+                cancelOnAccess, contentBlockSize: 800, orphansRequired: 2, widowsRequired: 2,
+                cancellationToken: cts.Token));
+        // Verify cancellation happened mid-fallback (access count > 100),
+        // not at method entry.
+        Assert.True(cancelOnAccess.AccessCount > 100,
+            $"Expected cancellation during greedy fallback (access count > 100), got {cancelOnAccess.AccessCount}");
+    }
+
+    /// <summary>Per post-Task-7 review (Copilot inline) — IReadOnlyList
+    /// wrapper that triggers a CancellationTokenSource on the Nth
+    /// indexer access. Lets unit tests exercise the optimizer's
+    /// IN-LOOP cancellation polling (not just the method-entry check)
+    /// without timing-based flakiness.</summary>
+    private sealed class CancelOnNthAccessList : IReadOnlyList<BreakOpportunity>
+    {
+        private readonly IReadOnlyList<BreakOpportunity> _inner;
+        private readonly CancellationTokenSource _cts;
+        private readonly int _cancelAfterAccesses;
+        private int _accessCount;
+
+        public CancelOnNthAccessList(
+            IReadOnlyList<BreakOpportunity> inner,
+            CancellationTokenSource cts,
+            int cancelAfterAccesses)
+        {
+            _inner = inner;
+            _cts = cts;
+            _cancelAfterAccesses = cancelAfterAccesses;
+        }
+
+        public int AccessCount => Volatile.Read(ref _accessCount);
+
+        public BreakOpportunity this[int index]
+        {
+            get
+            {
+                var c = Interlocked.Increment(ref _accessCount);
+                if (c == _cancelAfterAccesses)
+                {
+                    _cts.Cancel();
+                }
+                return _inner[index];
+            }
+        }
+
+        public int Count => _inner.Count;
+
+        public IEnumerator<BreakOpportunity> GetEnumerator()
+        {
+            for (var i = 0; i < _inner.Count; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            => GetEnumerator();
     }
 }

--- a/tests/NetPdf.UnitTests/Phase3/PaginationOptimizerTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/PaginationOptimizerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NetPdf.Paginate;
 using Xunit;
 
@@ -1374,5 +1375,79 @@ public sealed class PaginationOptimizerTests
         Assert.Equal(1, layout.ReadCounter("page"));
         // Speculative ctx is left alone (caller-discarded; its mutated
         // state is irrelevant to layout going forward).
+    }
+
+    // ====================================================================
+    //  Post-Task-7 review (recommendation P2 #4) — Optimizer cancellation /
+    //  budget timing. Pre-fix Optimize validated every opportunity BEFORE
+    //  applying MaxCandidatesBeforeFallback (so a 10k-element pre-cancelled
+    //  input would still walk all 10k validations); Greedy didn't accept
+    //  a CancellationToken at all. Post-fix: budget cap precedes per-
+    //  opportunity validation; both validation + greedy fallback poll
+    //  the token at every 64-opportunity boundary.
+    // ====================================================================
+
+    [Fact]
+    public void PostTask7_optimize_pre_cancelled_token_throws_for_over_budget_input()
+    {
+        // Build a candidate set just above MaxCandidatesBeforeFallback
+        // (16384). Pre-fix would walk all 16385 EnsureValid calls before
+        // checking the cancellation token. Post-fix: budget cap precedes
+        // validation, falls into Greedy, which polls the token on its
+        // first 64-element boundary and throws.
+        var n = Optimizer.MaxCandidatesBeforeFallback + 1;
+        var opps = new List<BreakOpportunity>(n);
+        for (var i = 0; i < n; i++)
+        {
+            opps.Add(BreakOpportunity.Block(usedBlockSize: i * 10.0, chunkBlockSize: 10));
+        }
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        Assert.Throws<OperationCanceledException>(() =>
+            Optimizer.Optimize(
+                opps, contentBlockSize: 800, orphansRequired: 2, widowsRequired: 2,
+                cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public void PostTask7_optimize_pre_cancelled_token_throws_during_validation_under_budget()
+    {
+        // Under-budget input — the DP path runs. Per post-Task-7 fix,
+        // the validation loop polls the token at every 64-element
+        // boundary; a pre-cancelled token must throw on the very
+        // first check (i == 0).
+        var n = 256;  // well under MaxCandidatesBeforeFallback
+        var opps = new List<BreakOpportunity>(n);
+        for (var i = 0; i < n; i++)
+        {
+            opps.Add(BreakOpportunity.Block(usedBlockSize: i * 10.0, chunkBlockSize: 10));
+        }
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        Assert.Throws<OperationCanceledException>(() =>
+            Optimizer.Optimize(
+                opps, contentBlockSize: 800, orphansRequired: 2, widowsRequired: 2,
+                cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public void PostTask7_optimize_uncancelled_over_budget_input_falls_back_to_greedy_without_throwing()
+    {
+        // Sanity: the budget-first reorder didn't break the fallback
+        // semantics. An over-budget input + uncancelled token should
+        // still succeed via the greedy path (FellBackToGreedy = true).
+        var n = Optimizer.MaxCandidatesBeforeFallback + 1;
+        var opps = new List<BreakOpportunity>(n);
+        for (var i = 0; i < n; i++)
+        {
+            opps.Add(BreakOpportunity.Block(usedBlockSize: i * 10.0, chunkBlockSize: 10));
+        }
+        var result = Optimizer.Optimize(
+            opps, contentBlockSize: 800, orphansRequired: 2, widowsRequired: 2,
+            cancellationToken: CancellationToken.None);
+        Assert.True(result.FellBackToGreedy);
+        Assert.NotNull(result.FallbackReason);
+        Assert.Contains("greedy fallback", result.FallbackReason!,
+            StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary

Per the post-Task-7 audit, this pass closes 6 issues spanning security
correctness, pagination correctness, and architectural fragility. Each
fix has 1-5 dedicated regression tests.

**18 new regression tests** across `BlockLayouterTests.cs` (8 new),
`PaginationOptimizerTests.cs` (3 new), and `PhaseDSecurityHardeningTests.cs`
(11 new — 5 CssResourceExtractor + 6 HTTP-loader policy).

**Solution-wide:** 3863 passing / 4 skipped. AOT/JIT byte-parity green.

## Fixes

### P1 #1 — HTTP loader policy unification

`SafeHttpResourceLoader` captured its own `SecurityPolicy` at construction
while `SafeResourceLoader` validated against `ResourceFetchContext.Policy`
per-fetch. Two independent policy decisions for one fetch → silent
security gap when they diverged.

- `SafeHttpResourceLoader.Policy` is now a public read-only property.
- `SafeResourceLoader`'s constructor detects `ReferenceEquals` divergence and throws `ArgumentException`.
- New `SafeResourceLoader.CreateWithSafeHttp(context)` factory wires both layers with `context.Policy` as the single source.

### P1 #2 — Diagnostics flow through `LayoutContext`

`LayoutRetryCoordinator` + `BlockLayouter` had separate diagnostic sinks. A composition root that wired only the coordinator's sink would miss `PAGINATION-FORCED-OVERFLOW-001` from a layouter's Strict-attempt forward-progress path (LastResort never fires when Strict commits).

- Added ambient `IPaginateDiagnosticsSink? Diagnostics` to `LayoutContext`.
- Coordinator's `Run` threads its sink into `layout.Diagnostics` on entry.
- `BlockLayouter` prefers `layout.Diagnostics` over its constructor-injected fallback.

### P2 #3 — Collapsed margins overcounted in overflow check

`visualBlockExtent` used raw `marginStart`. After collapse, the actual top contribution is `topShift`. Pre-fix: 80px marginBottom + 10px marginTop on a 800px page → spurious page break (counted +10 that was already in the cursor); post-fix continues correctly.

- Replace `Math.Max(0, marginStart)` with `Math.Max(0, topShift)`.

### P2 #4 — Optimizer cancellation/budget timing

(a) Per-opportunity validation ran BEFORE the budget cap so a 16385-element pre-cancelled input still walked all 16385 `EnsureValid` calls.
(b) `Greedy` fallback didn't accept a `CancellationToken` at all.

- Reorder: budget cap before validation loop.
- CT polling at every 64-element boundary in both the validation loop and the greedy fallback.
- Thread CT through every `Greedy()` call site.

### P2 #5 — Margin-collapse frontier persisted in checkpoint

Pre-fix the layouter stored frontier in private fields populated AT REWIND TIME with the layouter's CURRENT state. Works for the current single-slot resolver but breaks once the resolver retains multiple checkpoints and rewinds to an OLDER one.

- `LayoutCheckpoint` now carries `PrevBlockMarginEnd` + `HasAdjoiningBlockOnEntry` populated by `Capture` at every candidate-break boundary.
- `BlockLayouter`'s rewind branch reads these from `decision.RewindTo` (the chosen target), not from the layouter's "now" state.
- `LayoutCheckpoint.Reset` clears the new fields on return-to-pool.

### `CssResourceExtractor` — nested non-resource functions

Pre-fix, when a non-resource helper like `type("image/png")` or `format("png")` appeared inside `image-set()` / `cross-fade()` / `image()`:
- The helper's string args were captured as phantom URLs.
- The helper's closing `)` decremented the resource-fn depth, prematurely closing the image-set context.

Fix: track an inner-non-resource paren depth separately. Strings only count as URLs at the IMMEDIATE level (`innerNonResourceDepth == 0`). Helper close-parens decrement the inner depth.

## Test plan

- [x] Each fix has 1-5 dedicated regression tests asserting the pre-fix bug + the post-fix behavior
- [x] `dotnet test NetPdf.slnx -c Release` — 3863 passing / 4 skipped
- [x] `./scripts/aot-parity.sh` — AOT/JIT byte-parity green
- [x] All Phase 3 tests still passing (no regressions in margin-collapse, rewind, or optimizer paths)
- [ ] Roland review cycle on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)