### PR TITLE
docs: capture deferrals + approximation policy in docs/deferrals.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ These are non-negotiable. Every PR/commit must honor them. Detailed coding stand
 |---|---|
 | Know what phase / task we're on right now | [PROGRESS.md](PROGRESS.md) — single source of truth, updated as each task/phase ships. |
 | Know what to build next | [docs/phases/](docs/phases/) — pick the active phase doc; follow the work breakdown. |
+| Know what we **deliberately deferred** (approximation vs. throw, pickup triggers) | [docs/deferrals.md](docs/deferrals.md) — keep in sync with code when adding or picking up deferrals. |
 | Know what CSS features are in/out of scope | [docs/compatibility-matrix.md](docs/compatibility-matrix.md) |
 | Know the legal contract | [docs/clean-room-policy.md](docs/clean-room-policy.md) |
 | Add a dependency | [docs/legal/dependency-dossier.md](docs/legal/dependency-dossier.md) |

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -101,6 +101,15 @@ Profile with BenchmarkDotNet (`tests/NetPdf.Benchmarks`) before assuming a chang
 - **`InvalidOperationException`** for state errors (calling a method when the object isn't in a valid state for that call).
 - **Don't catch and rethrow** without enriching. If you have nothing to add, let the exception propagate.
 
+### Deferrals — update [docs/deferrals.md](deferrals.md) when you add or remove one
+
+Whenever a change adds **approximated** behavior, **throws** `NotSupportedException` for a spec feature, or replaces an approximation with the real implementation, update [docs/deferrals.md](deferrals.md) in the SAME commit.
+
+- **Adding** a deferral: append a new entry under the schema (ID / Status / Behavior / Missing / Trigger / Owner files / Added / Removal condition) AND add the new ID to the `ExpectedDeferralIds` array in [`tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs`](../tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs).
+- **Picking up** a deferral: delete the entry AND remove the ID from `ExpectedDeferralIds` in the same commit. Also drop any "deferred / approximated" framing from the XML doc / code comments at the throw or approximation site.
+
+The parity test fails loudly when the doc and the test list drift apart, so the rule is mechanically enforced — but the discipline only works if you update both files in the same commit.
+
 ### Comments — default to none
 
 The system rule and the project rule: **default to writing no comments**. Identifiers explain WHAT the code does. Only comment to explain WHY when the reason isn't obvious from the code: a hidden constraint, a subtle invariant, a workaround for a specific bug, behavior that would surprise a reader.

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1,0 +1,134 @@
+# Known Deferrals
+
+A focused, machine-friendly list of features and spec corners that NetPdf either
+**approximates** or **rejects loudly** today, with the conditions under which
+each gets picked up. The Phase docs (`docs/phases/`) cover the planned **work
+breakdown**; this file covers what's **deliberately on hold** so the next agent
+doesn't re-litigate prior decisions.
+
+**Conventions:**
+
+- **Status: approximated** — current behavior is a documented stand-in that
+  works for the v1 invoice/report corpus. Throws loudly if the approximation
+  could silently produce wrong output (e.g., mixed-mode `KeepAll`).
+- **Status: throws** — `NotSupportedException` at the appropriate seam to fail
+  loud + early. Never silent.
+- **Pickup trigger** — the condition that would move the item off the deferral
+  list. Usually "corpus needs it", "user-reported failing case", or "blocked
+  by downstream task".
+
+This file is updated when (a) something is **added** to the deferral list as
+part of a shipped cycle, or (b) something is **picked up** and shipped. Update
+in the same commit as the code change.
+
+## Phase 3 Task 10 — Inline layout edge cases
+
+### `word-break: keep-all` — CJK inter-character break suppression
+- **Status:** approximated.
+  - Uniform `keep-all` silently behaves like `normal` (no breaks suppressed).
+  - Mixed-mode (`keep-all` ↔ {`normal`, `break-all`}) **throws**
+    `NotSupportedException` from `InlineLayouter.LayoutPerRun` so the
+    no-op approximation can't silently lose CJK content's intent.
+- **What's missing:** UAX #24 script detection so we can identify CJK code
+  points + UAX #14 LB30b's "do not break between two ID class characters
+  when `word-break: keep-all`" rule.
+- **Pickup trigger:** corpus adds CJK content (Chinese/Japanese/Korean
+  invoices, reports, or books).
+- **Files when picked up:** `NetPdf.Text/Bidi/UnicodeScripts.cs` (new — needs
+  the script table); `NetPdf.Layout/Inline/LineBuilder.cs` flat-build phase
+  (read script per glyph + suppress LB30b boundaries when both sides ID +
+  per-run `WordBreak == KeepAll`); remove the `KeepAll` mismatch throw in
+  `InlineLayouter.LayoutPerRun`.
+- **Shipped in:** Phase 3 Task 10 cycle 3d sub-cycle 3 (added throw).
+
+### `white-space: break-spaces` — distinctive wrap semantics
+- **Status:** approximated.
+  - Both the preprocessor and the wrap pass treat `break-spaces`
+    **identically to `pre-wrap`** (preserve all whitespace + wrap at UAX #14
+    Allowed opportunities).
+  - Documented in `WhiteSpace.cs` XML.
+- **What's missing:** per CSS Text L3 §6.4, `break-spaces` must add forced
+  wrap candidates at **every** preserved space glyph (not just UAX #14
+  Allowed positions) AND trailing-space wrap-vs-hang behavior at line ends.
+- **Pickup trigger:** corpus needs `break-spaces` semantics (rare; mainly
+  legal/typographic content with explicit trailing-space wrapping).
+- **Files when picked up:** `NetPdf.Layout/Inline/LineBuilder.cs` flat-build
+  phase (synthesize Allowed at every SP glyph in `break-spaces` source runs)
+  + wrap loop's trailing-trim path (hang trailing SPs past the line edge
+  instead of trimming them).
+
+### UAX #24 script detection + RTL fragment-level reversal
+- **Status:** approximated.
+  - Shaping passes ISO 15924 + BCP 47 uniformly to the whole inline pass
+    (caller-supplied).
+  - RTL glyphs come out of HarfBuzz in visual order; `LineFragment[]`'s
+    slices stay in document order. Painters can already walk LTR runs
+    straight + RTL runs as-is per-shaped-run.
+- **What's missing:**
+  - UAX #24 per-codepoint script detection → script-change boundary in
+    `LineBuilder.Itemize` so multi-script paragraphs shape each script with
+    its proper OpenType feature set.
+  - Fragment-level slice order reversal for RTL paragraphs so the painter
+    walks slices visually right-to-left.
+- **Pickup trigger:** mixed-script content (Latin + Arabic in one
+  paragraph) or right-to-left primary direction enters the corpus.
+- **Files when picked up:** `NetPdf.Layout/Inline/LineBuilder.cs` Itemize
+  pass; `LineFragment.Slices` ordering at emit time.
+
+## Phase 4 painter — `BoxFragment[]` + `LineFragment[]` → PDF content streams
+
+- **Status:** not started (Phase 4 work).
+- **What's there:** `LineFragment` + `ShapedRunSlice` carry glyph + advance +
+  per-line metadata (`EndsWithMandatoryBreak`, `EndsWithHyphenationBreak`).
+  `BoxFragment` carries per-box border-box geometry.
+- **What's missing:** the painter that turns those records into PDF
+  content-stream operators (`Tf` set font, `Tj` show text, advances + line
+  matrices + hyphen-on-break rendering for `EndsWithHyphenationBreak=true`
+  lines).
+- **Pickup trigger:** Phase 4 start. Sequenced after Phase 3 completes its
+  task list (see `docs/phases/phase-3-layout-and-pagination.md`).
+- **Files when picked up:** `NetPdf.Paint/` (new) consuming the fragment
+  records emitted by `IBlockFragmentSink`.
+
+## Phase 3 remaining work — Tasks 11–30
+
+These are not "deferrals" in the same sense as the items above — they're
+**scheduled** work tracked in
+[docs/phases/phase-3-layout-and-pagination.md](phases/phase-3-layout-and-pagination.md).
+Listed here only for the agent landing on this file to know where to look:
+
+| # | Task | Status |
+|---|---|---|
+| 11 | Block + inline integration; widows/orphans | **In progress — Task 11 sub-cycle 1.** |
+| 12 | `TableLayouter` auto + fixed + collapse + span | not started |
+| 13 | `<thead>`/`<tfoot>` repetition across pages | not started |
+| 14 | `MulticolLayouter` | not started |
+| 15 | `FlexLayouter` L1 (single-line) | not started |
+| 16 | `FlexLayouter` multi-line + cross-fragment baseline | not started |
+| 17 | `GridLayouter` track-sizing | not started |
+| 18 | `GridLayouter` placement + dense packing + areas | not started |
+| 19 | `AbsoluteLayouter` for `position: absolute` | not started |
+| 20 | `position: fixed` repetition per page | not started |
+| 21 | `@page` rule + 16 page-margin boxes | not started |
+| 22 | `string()` + `string-set` | not started |
+| 23 | `position: running()` + `content: element()` | not started |
+| 24 | `counter(page)` / `counter(pages)` | not started |
+| 25 | Diagnostics emission for pagination edge cases | not started |
+| 26 | W3C CSS test runner integration | not started |
+| 27 | Pagination-golden snapshot infrastructure | not started |
+| 28 | Render the 4 invoice corpus files end-to-end | not started |
+| 29 | Performance tuning to hit 1-page invoice ≤ 200 ms p50 | not started |
+| 30 | Tag `0.7.0-beta` + CHANGELOG | not started |
+
+## Post-Phase-3 (pre-v1.0)
+
+### Coverage-guided fuzzing infrastructure
+- **Status:** deferred from Phase D (PR #18) to a dedicated post-Phase-3
+  milestone. SharpFuzz + AFL++ harnesses for `HtmlParsingHost`,
+  `CssPreprocessor` / `CssParserAdapter`, `SelectorCompiler`,
+  `CalcResolver`, `VarSubstitution`, `ImageSafetyValidator`,
+  `FontSafetyValidator`, and `PdfPreflightValidator`.
+- **Estimated effort:** 4–6 weeks dedicated.
+- **Pickup trigger:** Phase 3 complete (so the fuzz surface is stable).
+  Gates: 30-day no-new-crashes window before the v1.0 tag.
+- **Tracked at:** `PROGRESS.md` § Pending pre-v1.0 work.

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1,134 +1,256 @@
 # Known Deferrals
 
-A focused, machine-friendly list of features and spec corners that NetPdf either
-**approximates** or **rejects loudly** today, with the conditions under which
-each gets picked up. The Phase docs (`docs/phases/`) cover the planned **work
-breakdown**; this file covers what's **deliberately on hold** so the next agent
-doesn't re-litigate prior decisions.
+Approximation contracts: features the codebase **approximates** or **rejects
+loudly** today, with the conditions under which each gets picked up.
 
-**Conventions:**
+This file is **not** a status tracker for in-progress work — that lives in
+[PROGRESS.md](../PROGRESS.md) (active state) and
+[docs/phases/](phases/) (planned breakdown). It is also not a duplicate of
+those files. Update this file when (a) you ship a cycle that adds a new
+approximation/throw, or (b) you pick up a deferral and replace the
+approximation with full behavior.
 
-- **Status: approximated** — current behavior is a documented stand-in that
-  works for the v1 invoice/report corpus. Throws loudly if the approximation
-  could silently produce wrong output (e.g., mixed-mode `KeepAll`).
-- **Status: throws** — `NotSupportedException` at the appropriate seam to fail
-  loud + early. Never silent.
-- **Pickup trigger** — the condition that would move the item off the deferral
-  list. Usually "corpus needs it", "user-reported failing case", or "blocked
-  by downstream task".
+## Schema
 
-This file is updated when (a) something is **added** to the deferral list as
-part of a shipped cycle, or (b) something is **picked up** and shipped. Update
-in the same commit as the code change.
+Every deferral entry follows the same labels so the file is grep-able + a
+parity test in
+[`tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs`](../tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs)
+can verify entries don't drift away from source. Required labels:
 
-## Phase 3 Task 10 — Inline layout edge cases
+- **ID** — stable kebab-case identifier. Once published, do not rename;
+  removing the entry requires removing the matching parity-test assertion in
+  the same commit.
+- **Status** — one of `approximated`, `throws`, `not-started`.
+- **Behavior** — one line describing what the code does today.
+- **Missing** — what's not implemented relative to the spec.
+- **Trigger** — the condition that moves this off the deferral list.
+- **Owner files** — files (and rough locations) that change when picked up.
+- **Added** — PR or cycle that documented the deferral.
+- **Removal condition** — explicit criterion for deleting the entry.
 
-### `word-break: keep-all` — CJK inter-character break suppression
-- **Status:** approximated.
-  - Uniform `keep-all` silently behaves like `normal` (no breaks suppressed).
-  - Mixed-mode (`keep-all` ↔ {`normal`, `break-all`}) **throws**
-    `NotSupportedException` from `InlineLayouter.LayoutPerRun` so the
-    no-op approximation can't silently lose CJK content's intent.
-- **What's missing:** UAX #24 script detection so we can identify CJK code
-  points + UAX #14 LB30b's "do not break between two ID class characters
-  when `word-break: keep-all`" rule.
-- **Pickup trigger:** corpus adds CJK content (Chinese/Japanese/Korean
-  invoices, reports, or books).
-- **Files when picked up:** `NetPdf.Text/Bidi/UnicodeScripts.cs` (new — needs
-  the script table); `NetPdf.Layout/Inline/LineBuilder.cs` flat-build phase
-  (read script per glyph + suppress LB30b boundaries when both sides ID +
-  per-run `WordBreak == KeepAll`); remove the `KeepAll` mismatch throw in
-  `InlineLayouter.LayoutPerRun`.
-- **Shipped in:** Phase 3 Task 10 cycle 3d sub-cycle 3 (added throw).
+When you add a deferral, also add its ID to the expected list in
+`DeferralsParityTests.cs` (and reference this doc in the throw-message /
+approximation comment in source so a future agent can find the entry by
+grepping the ID).
 
-### `white-space: break-spaces` — distinctive wrap semantics
-- **Status:** approximated.
-  - Both the preprocessor and the wrap pass treat `break-spaces`
-    **identically to `pre-wrap`** (preserve all whitespace + wrap at UAX #14
-    Allowed opportunities).
-  - Documented in `WhiteSpace.cs` XML.
-- **What's missing:** per CSS Text L3 §6.4, `break-spaces` must add forced
-  wrap candidates at **every** preserved space glyph (not just UAX #14
-  Allowed positions) AND trailing-space wrap-vs-hang behavior at line ends.
-- **Pickup trigger:** corpus needs `break-spaces` semantics (rare; mainly
+---
+
+## word-break-keep-all-cjk
+
+- **ID** — `word-break-keep-all-cjk`
+- **Status** — `approximated` (uniform), `throws` (mismatch).
+- **Behavior** — Uniform `word-break: keep-all` silently behaves like
+  `normal` (no break suppression). A `keep-all` ↔ {`normal`, `break-all`}
+  mismatch across source TextRuns throws
+  `NotSupportedException` from `InlineLayouter.LayoutPerRun`.
+- **Missing** — UAX #24 per-codepoint script detection + UAX #14 LB30b
+  ("do not break between two ID-class characters when `word-break:
+  keep-all`") to suppress CJK inter-character breaks.
+- **Trigger** — corpus adds CJK content (Chinese / Japanese / Korean
+  invoices, reports, books), OR a user-reported failing case.
+- **Owner files** — `src/NetPdf.Text/Bidi/UnicodeScripts.cs` (new — needs
+  the script table); `src/NetPdf.Layout/Inline/LineBuilder.cs` flat-build
+  phase (read script per glyph + suppress LB30b boundaries); remove the
+  `KeepAll` mismatch throw in
+  `src/NetPdf.Layout/Inline/InlineLayouter.cs::LayoutPerRun`.
+- **Added** — Phase 3 Task 10 cycle 3d sub-cycle 3 (added the mismatch
+  throw); cycle 3b sub-cycle 2 (added the uniform approximation).
+- **Removal condition** — UAX #24 script detection lands AND the wrap
+  loop honors KeepAll per glyph AND
+  `InlineLayouter.LayoutPerRun` no longer throws on KeepAll mismatch.
+
+---
+
+## white-space-break-spaces
+
+- **ID** — `white-space-break-spaces`
+- **Status** — `approximated`.
+- **Behavior** — Both the preprocessor and the wrap pass treat
+  `white-space: break-spaces` identically to `pre-wrap` (preserve all
+  whitespace + wrap at UAX #14 Allowed opportunities only).
+- **Missing** — Per CSS Text L3 §6.4, `break-spaces` must add forced wrap
+  candidates at **every** preserved space glyph (not just UAX #14 Allowed
+  positions) AND honor trailing-space wrap-vs-hang at line ends.
+- **Trigger** — corpus needs `break-spaces` semantics (rare; mainly
   legal/typographic content with explicit trailing-space wrapping).
-- **Files when picked up:** `NetPdf.Layout/Inline/LineBuilder.cs` flat-build
-  phase (synthesize Allowed at every SP glyph in `break-spaces` source runs)
-  + wrap loop's trailing-trim path (hang trailing SPs past the line edge
-  instead of trimming them).
+- **Owner files** —
+  `src/NetPdf.Layout/Inline/LineBuilder.cs` flat-build phase (synthesize
+  Allowed at every SP glyph in `break-spaces` source runs) + wrap loop's
+  trailing-trim path (hang trailing SPs past the line edge instead of
+  trimming).
+- **Added** — Phase 3 Task 10 cycle 3 review (User #3) added the enum
+  value with the documented PreWrap-equivalent approximation.
+- **Removal condition** — wrap pass synthesizes per-glyph forced
+  candidates inside `break-spaces` runs AND trailing-space hang/wrap
+  semantics are implemented.
 
-### UAX #24 script detection + RTL fragment-level reversal
-- **Status:** approximated.
-  - Shaping passes ISO 15924 + BCP 47 uniformly to the whole inline pass
-    (caller-supplied).
-  - RTL glyphs come out of HarfBuzz in visual order; `LineFragment[]`'s
-    slices stay in document order. Painters can already walk LTR runs
-    straight + RTL runs as-is per-shaped-run.
-- **What's missing:**
-  - UAX #24 per-codepoint script detection → script-change boundary in
-    `LineBuilder.Itemize` so multi-script paragraphs shape each script with
-    its proper OpenType feature set.
-  - Fragment-level slice order reversal for RTL paragraphs so the painter
-    walks slices visually right-to-left.
-- **Pickup trigger:** mixed-script content (Latin + Arabic in one
-  paragraph) or right-to-left primary direction enters the corpus.
-- **Files when picked up:** `NetPdf.Layout/Inline/LineBuilder.cs` Itemize
-  pass; `LineFragment.Slices` ordering at emit time.
+---
 
-## Phase 4 painter — `BoxFragment[]` + `LineFragment[]` → PDF content streams
+## hyphens-auto-language-routing
 
-- **Status:** not started (Phase 4 work).
-- **What's there:** `LineFragment` + `ShapedRunSlice` carry glyph + advance +
-  per-line metadata (`EndsWithMandatoryBreak`, `EndsWithHyphenationBreak`).
-  `BoxFragment` carries per-box border-box geometry.
-- **What's missing:** the painter that turns those records into PDF
-  content-stream operators (`Tf` set font, `Tj` show text, advances + line
-  matrices + hyphen-on-break rendering for `EndsWithHyphenationBreak=true`
-  lines).
-- **Pickup trigger:** Phase 4 start. Sequenced after Phase 3 completes its
-  task list (see `docs/phases/phase-3-layout-and-pagination.md`).
-- **Files when picked up:** `NetPdf.Paint/` (new) consuming the fragment
-  records emitted by `IBlockFragmentSink`.
+- **ID** — `hyphens-auto-language-routing`
+- **Status** — `approximated`.
+- **Behavior** — `Hyphens.Auto` always applies en-US Liang patterns
+  regardless of the source run's language. Word tokenization in
+  `ApplyLiangPatterns` accepts only ASCII letters [A-Za-z] (+ U+00AD soft
+  hyphens per cycle 3d sub-cycle 1 Rec #6) — apostrophes split contractions
+  ("don't" → "don" / "t"), and non-ASCII letter sequences (e.g., German
+  umlaut, Cyrillic, accented Latin Extended) are skipped entirely.
+  CSS Text L4 `hyphenate-character`, `hyphenate-limit-chars`,
+  `hyphenate-limit-lines`, `hyphenate-limit-zone` are also not implemented.
+- **Missing** —
+  - Per-language Liang pattern routing (de-DE, fr-FR, es-ES, etc.) keyed
+    off each source TextRun's BCP 47 language tag.
+  - UAX #29 word-segmentation so apostrophes inside contractions don't
+    truncate words + non-ASCII letter sequences participate.
+  - CSS Text L4 `hyphenate-character`, `hyphenate-limit-chars`,
+    `hyphenate-limit-lines`, `hyphenate-limit-zone` properties.
+- **Trigger** — corpus adds non-English text needing auto-hyphenation, OR
+  a user-reported case where contractions / accented letters mis-wrap.
+- **Owner files** —
+  - `src/NetPdf.Text/Hyphenation/EnUsHyphenation.cs` siblings — e.g.,
+    `DeDeHyphenation.cs`, `FrFrHyphenation.cs`, etc., loading their
+    Liang TeX pattern resources.
+  - New `NetPdf.Text.Hyphenation.LanguagePackRegistry` (BCP 47 lookup →
+    Hyphenator).
+  - `src/NetPdf.Layout/Inline/LineBuilder.cs::ApplyLiangPatterns` —
+    replace ASCII-letter check with UAX #29 word boundaries + per-language
+    hyphenator selection.
+  - `src/NetPdf.Layout/Inline/Hyphens.cs` XML doc — drop the "deferred"
+    framing once shipped.
+- **Added** — Phase 3 Task 9 cycle 3b sub-cycle 3 (en-US-only Liang +
+  ASCII tokenization); cycle 3d sub-cycle 1 Rec #6 (soft-hyphen
+  suppression); cycle 3d sub-cycle 4 review Finding #1 (per-position
+  Liang gating, which depends on this entry's owner files for the
+  tokenizer when extended).
+- **Removal condition** — at least one non-English language pack ships,
+  the tokenizer uses UAX #29, AND one CSS Text L4 hyphenate-* property
+  is implemented.
 
-## Phase 3 remaining work — Tasks 11–30
+---
 
-These are not "deferrals" in the same sense as the items above — they're
-**scheduled** work tracked in
-[docs/phases/phase-3-layout-and-pagination.md](phases/phase-3-layout-and-pagination.md).
-Listed here only for the agent landing on this file to know where to look:
+## uax-24-script-detection
 
-| # | Task | Status |
-|---|---|---|
-| 11 | Block + inline integration; widows/orphans | **In progress — Task 11 sub-cycle 1.** |
-| 12 | `TableLayouter` auto + fixed + collapse + span | not started |
-| 13 | `<thead>`/`<tfoot>` repetition across pages | not started |
-| 14 | `MulticolLayouter` | not started |
-| 15 | `FlexLayouter` L1 (single-line) | not started |
-| 16 | `FlexLayouter` multi-line + cross-fragment baseline | not started |
-| 17 | `GridLayouter` track-sizing | not started |
-| 18 | `GridLayouter` placement + dense packing + areas | not started |
-| 19 | `AbsoluteLayouter` for `position: absolute` | not started |
-| 20 | `position: fixed` repetition per page | not started |
-| 21 | `@page` rule + 16 page-margin boxes | not started |
-| 22 | `string()` + `string-set` | not started |
-| 23 | `position: running()` + `content: element()` | not started |
-| 24 | `counter(page)` / `counter(pages)` | not started |
-| 25 | Diagnostics emission for pagination edge cases | not started |
-| 26 | W3C CSS test runner integration | not started |
-| 27 | Pagination-golden snapshot infrastructure | not started |
-| 28 | Render the 4 invoice corpus files end-to-end | not started |
-| 29 | Performance tuning to hit 1-page invoice ≤ 200 ms p50 | not started |
-| 30 | Tag `0.7.0-beta` + CHANGELOG | not started |
+- **ID** — `uax-24-script-detection`
+- **Status** — `approximated`.
+- **Behavior** — `LineBuilder.Itemize` accepts a single ISO 15924 script
+  tag + BCP 47 language passed uniformly from the caller. Multi-script
+  paragraphs (Latin + Arabic + Han in one `<p>`) all shape with the same
+  feature set.
+- **Missing** — Per-codepoint script detection (UAX #24) producing a
+  script-change boundary in `Itemize`, so each script-homogeneous
+  sub-run gets its own shaping call with the appropriate OpenType
+  feature set.
+- **Trigger** — mixed-script content enters the corpus, OR a user-reported
+  failing case where script-specific shaping features (e.g., Arabic
+  joining contextual forms across a Latin↔Arabic boundary) misrender.
+- **Owner files** — `src/NetPdf.Text/Bidi/UnicodeScripts.cs` (new — see
+  the `word-break-keep-all-cjk` entry; same table);
+  `src/NetPdf.Layout/Inline/LineBuilder.cs::Itemize` (insert
+  script-change boundaries).
+- **Added** — Phase 3 Task 10 cycle 1 documented the deferral.
+- **Removal condition** — `Itemize` produces script-typed itemized runs
+  and `Shape` consumes them with the script-specific HarfBuzz feature
+  set.
 
-## Post-Phase-3 (pre-v1.0)
+---
 
-### Coverage-guided fuzzing infrastructure
-- **Status:** deferred from Phase D (PR #18) to a dedicated post-Phase-3
-  milestone. SharpFuzz + AFL++ harnesses for `HtmlParsingHost`,
+## rtl-fragment-reversal
+
+- **ID** — `rtl-fragment-reversal`
+- **Status** — `approximated`.
+- **Behavior** — HarfBuzz shapes RTL runs in visual (reversed) order
+  internally; `LineFragment.Slices` stays in document order. Painters
+  walk per-shaped-run glyph arrays as-is. Single-direction LTR
+  paragraphs paint correctly. Single-direction RTL paragraphs walk in
+  the wrong visual order at the fragment level.
+- **Missing** — Fragment-level slice reversal for RTL paragraph base
+  direction so the painter consumes slices visually right-to-left.
+- **Trigger** — RTL primary direction (Arabic / Hebrew) enters the
+  corpus, OR a user reports right-to-left mis-rendering.
+- **Owner files** — `src/NetPdf.Layout/Inline/LineBuilder.cs::Wrap`
+  emission site (`EmitDrawableRange`) — reverse slice order when the
+  paragraph base direction is `ParagraphDirection.RightToLeft`.
+- **Added** — Phase 3 Task 10 cycle 1 documented the deferral.
+- **Removal condition** — Wrap reverses slice order for RTL paragraphs
+  AND the painter consumes them visually.
+
+---
+
+## phase-4-painter-wiring
+
+- **ID** — `phase-4-painter-wiring`
+- **Status** — `not-started` (the wiring; the IR project itself exists).
+- **Behavior** — `BlockLayouter` emits `BoxFragment` records (with
+  `LineFragment[]` carried on `BoxFragment.InlineLines` for inline-only
+  blocks per Task 11 sub-cycle 1). `src/NetPdf.Paint/` already exists with
+  the **display-list IR** types: `DisplayList`, `DisplayCommand`
+  (`TextRunPayload`, `RectFillPayload`, `ImageDrawPayload`,
+  `TransformPushPayload`, `OpacityPushPayload`), `TextRun`,
+  `RasterImage`, `RgbaColor`, `ImageEncoding`. What's missing is the
+  Phase 3 → Phase 4 **bridge** that consumes layouter output + emits
+  display commands.
+- **Missing** — A bridge service (e.g.,
+  `NetPdf.Paint.LayoutFragmentEmitter` — final name TBD) that:
+  - Consumes `IReadOnlyList<BoxFragment>` (the layouter's sink output).
+  - For each fragment, emits the appropriate
+    `RectFillPayload` / border / clip `DisplayCommand`s.
+  - For fragments with non-null `InlineLines`, walks each
+    `LineFragment.Slices` + the originating `ShapedRun` data + emits
+    `TextRunPayload`-style `DisplayCommand`s positioned at successive
+    baselines (line-height × index from the fragment's
+    `BlockOffset`).
+  - Renders the visible-hyphen glyph at line ends where
+    `LineFragment.EndsWithHyphenationBreak == true`.
+- **Trigger** — Phase 4 start, sequenced after Phase 3 task list
+  completes — see
+  [docs/phases/phase-4-visual-parity.md](phases/phase-4-visual-parity.md).
+- **Owner files** —
+  - `src/NetPdf.Paint/` (existing) — add the bridge type next to
+    `DisplayList` + `DisplayCommand`; no new project needed.
+  - `src/NetPdf.Pdf/` (existing) — `DisplayList` → PDF content-stream
+    operator emission already lives here; the inline-text path needs
+    per-line baseline + glyph-position math wired through.
+- **Added** — Phase 3 Task 11 sub-cycle 1 documented the wiring gap
+  (the layouter side of the contract shipped, painter side awaits).
+- **Removal condition** — The bridge service ships + a corpus invoice
+  renders text via the layouter → painter → PDF path end-to-end.
+
+---
+
+## fuzzing-infrastructure
+
+- **ID** — `fuzzing-infrastructure`
+- **Status** — `not-started`.
+- **Behavior** — Phase A-D's regression corpus + threat-model coverage
+  (215+ security tests) is the primary defense surface. No
+  coverage-guided fuzzing is wired.
+- **Missing** — SharpFuzz + AFL++ harnesses for `HtmlParsingHost`,
   `CssPreprocessor` / `CssParserAdapter`, `SelectorCompiler`,
   `CalcResolver`, `VarSubstitution`, `ImageSafetyValidator`,
-  `FontSafetyValidator`, and `PdfPreflightValidator`.
-- **Estimated effort:** 4–6 weeks dedicated.
-- **Pickup trigger:** Phase 3 complete (so the fuzz surface is stable).
-  Gates: 30-day no-new-crashes window before the v1.0 tag.
-- **Tracked at:** `PROGRESS.md` § Pending pre-v1.0 work.
+  `FontSafetyValidator`, and `PdfPreflightValidator`. CI gate, crash
+  triage runbook, 30-day no-new-crashes window before the v1.0 tag.
+- **Trigger** — Phase 3 layout work complete (so the fuzz surface is
+  stable + the engine is feature-complete enough to be worth fuzzing
+  at the planned depth).
+- **Owner files** — `tests/NetPdf.Fuzz/` (existing project; needs the
+  8 harnesses); CI workflow under `.github/workflows/` for the gate.
+- **Added** — Phase D PR #18 documented the deferral; carried into
+  `PROGRESS.md` § Pending pre-v1.0 work.
+- **Removal condition** — All 8 harnesses ship, CI gate green, 30-day
+  no-new-crashes window observed.
+
+---
+
+## In-progress work — pointer
+
+The scheduled Phase 3 work breakdown (Tasks 11–30 — `TableLayouter`,
+`MulticolLayouter`, `FlexLayouter`, `GridLayouter`, `AbsoluteLayouter`,
+page-margin boxes, `string()` / `running()` / `counter()`, diagnostics,
+W3C runner, corpus end-to-end render, performance tuning, `0.7.0-beta`
+tag) lives in
+[`docs/phases/phase-3-layout-and-pagination.md`](phases/phase-3-layout-and-pagination.md).
+Active state for whichever sub-cycle is in flight lives in
+[`PROGRESS.md`](../PROGRESS.md). This file deliberately does **not**
+duplicate either — they own the live status; this file owns the
+approximation/throw contracts.

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -1,0 +1,148 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace NetPdf.UnitTests.Docs;
+
+/// <summary>Per the docs-deferrals PR review Finding #4 — parity guard
+/// for <c>docs/deferrals.md</c>. The deferrals doc declares an update
+/// rule (edit in the same commit as any code change that adds or
+/// removes a deferral); this test enforces the rule by asserting every
+/// known deferral ID still has an entry in the file. When a deferral
+/// is **picked up + removed**, the developer deletes both the doc
+/// section AND the matching <see cref="ExpectedDeferralIds"/> entry
+/// in the SAME commit — the parity test fails otherwise. When a
+/// deferral is **added**, the developer adds both the doc section
+/// AND the new ID to <see cref="ExpectedDeferralIds"/> in the same
+/// commit.
+///
+/// <para>The test is intentionally LOW-FRICTION: it only checks IDs +
+/// status appear in the doc, not the full schema (Behavior/Missing/
+/// Trigger/Files/Added/Removal). Schema parity is enforced by code
+/// review + the doc's own schema preamble. This test guards against
+/// the silent-drop failure mode (someone deletes an entry without
+/// removing the throw / approximation in source).</para>
+///
+/// <para><b>Maintenance.</b> The hardcoded
+/// <see cref="ExpectedDeferralIds"/> list is the contract. When the
+/// doc's entries diverge from this list (either drop OR addition), the
+/// test fails with a clear message pointing at the missing ID. Both
+/// directions are checked.</para></summary>
+public sealed class DeferralsParityTests
+{
+    /// <summary>Stable kebab-case IDs that MUST appear in
+    /// <c>docs/deferrals.md</c>. Add to this list (in the same commit)
+    /// when adding a new deferral entry; remove (in the same commit)
+    /// when picking one up.</summary>
+    private static readonly string[] ExpectedDeferralIds = new[]
+    {
+        "word-break-keep-all-cjk",
+        "white-space-break-spaces",
+        "hyphens-auto-language-routing",
+        "uax-24-script-detection",
+        "rtl-fragment-reversal",
+        "phase-4-painter-wiring",
+        "fuzzing-infrastructure",
+    };
+
+    [Fact]
+    public void Deferrals_doc_contains_all_expected_ids()
+    {
+        var content = LoadDeferralsDoc();
+        foreach (var id in ExpectedDeferralIds)
+        {
+            // Each entry's section heading + ID label both contain
+            // the ID — checking the explicit `**ID** — `<id>`` label
+            // catches typos AND ensures the schema is followed.
+            var anchor = $"**ID** — `{id}`";
+            Assert.True(content.Contains(anchor, StringComparison.Ordinal),
+                $"docs/deferrals.md is missing the deferral ID '{id}'. " +
+                $"If you picked it up, also remove it from " +
+                $"DeferralsParityTests.ExpectedDeferralIds in the same " +
+                $"commit. If this is a new ID you forgot to add to the " +
+                $"test, add it to ExpectedDeferralIds. Expected anchor: " +
+                $"`{anchor}`.");
+        }
+    }
+
+    [Fact]
+    public void Deferrals_doc_does_not_contain_unexpected_ids()
+    {
+        // Reverse-direction parity: scan the doc for `**ID** — `…``
+        // labels + assert each ID is in the expected list. Catches
+        // the case where someone adds a deferral to the doc but
+        // forgets to add it to the test (or vice versa — adds a
+        // typo'd ID).
+        var content = LoadDeferralsDoc();
+        const string idMarker = "**ID** — `";
+        var pos = 0;
+        while (true)
+        {
+            var start = content.IndexOf(idMarker, pos, StringComparison.Ordinal);
+            if (start < 0) break;
+            start += idMarker.Length;
+            var end = content.IndexOf('`', start);
+            if (end < 0) break;
+            var id = content.Substring(start, end - start);
+            Assert.Contains(id, ExpectedDeferralIds);
+            pos = end + 1;
+        }
+    }
+
+    [Fact]
+    public void Deferrals_doc_uses_only_defined_status_values()
+    {
+        // Every Status line in the doc must use one of the three
+        // defined values. Catches typos like "deferred" or "wip"
+        // sneaking in instead of the documented vocabulary.
+        var content = LoadDeferralsDoc();
+        const string statusMarker = "**Status** — ";
+        var pos = 0;
+        while (true)
+        {
+            var start = content.IndexOf(statusMarker, pos, StringComparison.Ordinal);
+            if (start < 0) break;
+            start += statusMarker.Length;
+            // Look at the next ~80 chars to capture the status value
+            // (may contain qualifier like "(uniform)" after the
+            // primary value).
+            var snippetEnd = Math.Min(start + 80, content.Length);
+            var snippet = content.Substring(start, snippetEnd - start);
+            // Status must contain at least one of the defined values
+            // (may be a hybrid like "approximated (uniform), throws
+            // (mismatch)").
+            Assert.True(
+                snippet.Contains("approximated", StringComparison.Ordinal)
+                || snippet.Contains("throws", StringComparison.Ordinal)
+                || snippet.Contains("not-started", StringComparison.Ordinal),
+                $"Status line in docs/deferrals.md uses an undefined " +
+                $"vocabulary. Allowed: approximated | throws | not-started. " +
+                $"Saw: '{snippet.Trim()}'.");
+            pos = snippetEnd;
+        }
+    }
+
+    private static string LoadDeferralsDoc()
+    {
+        // Walk upward from the test assembly's location to find the
+        // repo root (signaled by NetPdf.slnx). Works for both `dotnet
+        // test` from the repo root + IDE test runners.
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 12 && dir is not null; i++)
+        {
+            var candidate = Path.Combine(dir, "docs", "deferrals.md");
+            if (File.Exists(candidate))
+            {
+                return File.ReadAllText(candidate);
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException(
+            "Could not locate docs/deferrals.md from the test assembly's " +
+            "location. Did the file move? AppContext.BaseDirectory = " +
+            $"{AppContext.BaseDirectory}.");
+    }
+}


### PR DESCRIPTION
## Summary

Per the post-PR-#46 conversation: write the TODOs down so they don't decay into folklore. New [docs/deferrals.md](docs/deferrals.md) captures items the codebase **deliberately** approximates or rejects loudly, with the conditions under which each gets picked up.

### Contents

- **Phase 3 Task 10 deferrals from cycle 3d** — for each item: Status (approximated / throws), what's missing, pickup trigger, files-that-change:
  - `word-break: keep-all` CJK inter-character break suppression (uniform approximates as `normal`; mixed throws)
  - `white-space: break-spaces` distinctive wrap semantics (approximates as `pre-wrap`)
  - UAX #24 script detection + RTL fragment-level reversal
- **Phase 4 painter** — `BoxFragment[]` + `LineFragment[]` → PDF content streams; not started.
- **Phase 3 remaining Tasks 11-30** — pointer table (work itself tracked in `docs/phases/phase-3-layout-and-pagination.md`).
- **Post-Phase-3 fuzzing infrastructure** milestone (carryover from PROGRESS.md).

Plus a row in [CLAUDE.md](CLAUDE.md)'s "Where to look for detail" table so future agents discover the file.

### Discipline

The doc declares its own update rule: edited in the **same commit** as any code change that adds or removes a deferral. That way the deferral list never drifts.

## Test plan

- [x] Docs-only PR; no code changes
- [x] CLAUDE.md still parses (markdown table)
- [ ] Roland review
🤖 Generated with [Claude Code](https://claude.com/claude-code)