### PR TITLE
Phase 3 Task 17 cycle 7a: grid-template-areas + named-area placement

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2328,3 +2328,58 @@ flags the categories):
   behavior (e.g., `grid-row: auto / 4; height: 50px` in a
   4-row grid + 2 prior rows occupied → item lands at row 3
   not row 2).
+
+---
+
+## grid-named-line-placement-deferral
+
+- **ID** — `grid-named-line-placement-deferral`
+- **Status** — `approximated`. Phase 3 Task 18 cycle 7a (post-
+  PR-#105 review F11).
+- **Behavior** — Cycle 7a `GridSizing.ReadPlacement` resolves
+  `<custom-ident>` references on `grid-row-start` /
+  `grid-row-end` / `grid-column-start` / `grid-column-end`
+  against the parent grid's `grid-template-areas` map. Idents
+  that don't match a named area fall back to auto-placement
+  with `LAYOUT-GRID-PLACEMENT-APPROXIMATED-001`. Per CSS Grid L1
+  §8.4, the cycle-7a path misses three spec-correct behaviors:
+  - **Author-declared named lines** in `grid-template-rows` /
+    `grid-template-columns` (e.g., `grid-template-rows: [head-start]
+    100px [head-end main-start] 100px [main-end]`). The current
+    `TrackList` AST carries `TrackListNamedLine` items but
+    `ReadPlacement` doesn't consume them.
+  - **Implicit `*-start` / `*-end` lines** auto-generated from
+    `grid-template-areas` area names (per §8.4 — for area `head`,
+    implicit lines `head-start` and `head-end` are created on
+    both axes; `grid-row-start: head-start` is equivalent to
+    `grid-row-start: head`). Currently `head-start` falls through
+    to auto.
+  - **Implicit `*-start` / `*-end` area names** auto-generated
+    from author-declared named lines with matching `-start` /
+    `-end` suffixes — the reverse contract from §8.4.
+- **Missing** — A named-line lookup map per grid container that
+  combines:
+  - explicit lines from `grid-template-rows` / `-columns`
+    TrackListNamedLine items;
+  - implicit `<area>-start` / `<area>-end` lines from
+    `grid-template-areas`;
+  - implicit `<line>-start` / `<line>-end` areas from suffix-
+    matching author lines.
+  `ReadPlacement` would consult this map when a NamedLine
+  reference fails the direct-area lookup.
+- **Trigger** — corpus invoice / report uses
+  `grid-template-rows: [foo] 100px` named lines, OR a user-
+  reported case where `grid-row-start: foo-start` doesn't
+  resolve against a declared `grid-template-areas` area named
+  `foo`.
+- **Owner files** —
+  - `src/NetPdf.Layout/Layouters/GridSizing.cs` —
+    `ReadPlacement` + a new named-line lookup helper.
+  - `src/NetPdf.Css/ComputedValues/Grid.cs` — possibly a new
+    `NamedLineMap` AST stored alongside `GridTemplateAreas` /
+    `TrackList`.
+- **Added** — Phase 3 Task 18 cycle 7a (this branch).
+- **Removal condition** — cycle 7b ships the named-line lookup;
+  the placement-approximated diagnostic no longer fires for
+  authored named lines or auto-generated `*-start` / `*-end`
+  lines from area names + lines.

--- a/src/NetPdf.Css/ComputedValues/Grid.cs
+++ b/src/NetPdf.Css/ComputedValues/Grid.cs
@@ -573,3 +573,71 @@ internal enum GridAutoFlowValue : byte
     /// row-axis is exhausted.</summary>
     Column = 1,
 }
+
+/// <summary>Per Phase 3 Task 18 cycle 7a + CSS Grid L1 §7.3 — the
+/// parsed AST for a <c>grid-template-areas</c> declaration. Stores
+/// both the source rectangle of cell names (row-major) AND the
+/// derived name → rectangle map so placement-time lookups by area
+/// name are O(1).
+///
+/// <para><b>Validation invariants</b> (per §7.3 + the resolver's
+/// validation pass):</para>
+/// <list type="bullet">
+///   <item><see cref="RowCount"/> ≥ 1 (each row is one CSS string;
+///   the empty AST <see cref="None"/> represents the property default
+///   <c>none</c>).</item>
+///   <item>All rows have the same column count (= ragged rows are
+///   rejected at parse time).</item>
+///   <item>For each named cell, every occurrence in the grid forms
+///   a single rectangle (= same-name cells must be adjacent in both
+///   axes; non-rectangular shapes are rejected).</item>
+///   <item><c>.</c> tokens are NULL cells (no entry in
+///   <see cref="NameToRect"/>).</item>
+/// </list>
+///
+/// <para><b>Coordinate system</b>: <see cref="Cells"/> is indexed
+/// <c>[row, column]</c> 0-based. <see cref="GridAreaRect"/>'s
+/// <c>RowStart</c> / <c>ColumnStart</c> are 1-based grid LINE
+/// numbers (matching the convention used by GridLineValue);
+/// <c>RowEnd</c> / <c>ColumnEnd</c> are exclusive (= start + span).</para></summary>
+internal sealed record GridTemplateAreas(
+    int RowCount,
+    int ColumnCount,
+    System.Collections.Immutable.ImmutableArray<string?> Cells,
+    System.Collections.Immutable.ImmutableDictionary<string, GridAreaRect> NameToRect)
+{
+    /// <summary>Per CSS Grid L1 §7.3 — the property-default value
+    /// (<c>none</c>). No named areas; the placement service treats
+    /// any <c>&lt;custom-ident&gt;</c> placement against this as
+    /// "unknown name" (= falls back to auto per cycle-6a's existing
+    /// approximated-and-fall-to-auto path).</summary>
+    public static readonly GridTemplateAreas None = new(
+        RowCount: 0,
+        ColumnCount: 0,
+        Cells: System.Collections.Immutable.ImmutableArray<string?>.Empty,
+        NameToRect: System.Collections.Immutable.ImmutableDictionary<string, GridAreaRect>.Empty);
+
+    /// <summary>Indexer for the <c>[row, column]</c> cell name.
+    /// Returns <see langword="null"/> for null cells (= <c>.</c>) or
+    /// out-of-bounds queries.</summary>
+    public string? this[int row, int column]
+    {
+        get
+        {
+            if (row < 0 || row >= RowCount || column < 0 || column >= ColumnCount)
+                return null;
+            return Cells[row * ColumnCount + column];
+        }
+    }
+}
+
+/// <summary>Per Phase 3 Task 18 cycle 7a + CSS Grid L1 §7.3 — the
+/// derived rectangle for one named grid area.
+///
+/// <para>Line numbers are 1-based (matching <see cref="GridLineValue"/>
+/// convention). <see cref="RowEnd"/> / <see cref="ColumnEnd"/> are
+/// EXCLUSIVE end lines (= the line AFTER the last occupied row /
+/// column). So an area spanning rows 1-3 has <c>RowStart=1</c> +
+/// <c>RowEnd=4</c> (= span 3).</para></summary>
+internal readonly record struct GridAreaRect(
+    int RowStart, int RowEnd, int ColumnStart, int ColumnEnd);

--- a/src/NetPdf.Css/ComputedValues/GridReaders.cs
+++ b/src/NetPdf.Css/ComputedValues/GridReaders.cs
@@ -109,6 +109,23 @@ internal static class GridReaders
         return ReadTrackListPropertyWithAutoDefault(style, PropertyId.GridAutoColumns);
     }
 
+    /// <summary>Per Phase 3 Task 18 cycle 7a — read the parsed
+    /// <c>grid-template-areas</c> AST. Returns
+    /// <see cref="GridTemplateAreas.None"/> when the property is
+    /// unset, declared as <c>none</c> (= default), or the side-table
+    /// entry is missing / wrong-typed.</summary>
+    public static GridTemplateAreas ReadGridTemplateAreas(this ComputedStyle style)
+    {
+        var slot = style.Get(PropertyId.GridTemplateAreas);
+        if (slot.Tag == ComputedSlotTag.SideTableIndex
+            && style.TryGetSideTablePayload<GridTemplateAreas>(
+                PropertyId.GridTemplateAreas, out var areas))
+        {
+            return areas;
+        }
+        return GridTemplateAreas.None;
+    }
+
     /// <summary>Per Phase 3 Task 18 cycle 6 — read the
     /// <c>grid-auto-flow</c> keyword. Returns <see cref="GridAutoFlowValue.Row"/>
     /// for the unset / default / wrong-typed path (= the CSS-spec

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/GridTemplateAreasResolver.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/GridTemplateAreasResolver.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
 using NetPdf.Css.Diagnostics;
 using NetPdf.Css.Parser;
 using NetPdf.Css.Properties;
@@ -38,6 +40,19 @@ namespace NetPdf.Css.ComputedValues.PropertyResolvers;
 ///   <see cref="GridTemplateAreas.None"/>.</item>
 /// </list>
 ///
+/// <para><b>Per PR-#105 review F1 — DoS guards</b>: the resolver caps
+/// the source-text length, max rows, max columns, and max total cells
+/// it will process before emitting a truncation diagnostic + Invalid
+/// result. Hostile CSS like 100,000 rows × 1 cell or a 50,000-char
+/// area-name string cannot exhaust memory or CPU.</para>
+///
+/// <para><b>Per PR-#105 review F1 — single-pass rectangle validation</b>:
+/// instead of the original cycle-7a O(uniqueNames × cells) outside-
+/// scan, the resolver walks the cells once tracking per-name
+/// <c>(minRow, maxRow, minCol, maxCol, count)</c>. At the end each
+/// name's bounding-rectangle area must equal its cell count — both
+/// conditions detect L-shapes and disjoint regions.</para>
+///
 /// <para><b>Invalid input</b> emits
 /// <see cref="CssDiagnosticCodes.CssPropertyValueInvalid001"/> with a
 /// spec-referencing reason. The cascade falls back to the property's
@@ -47,6 +62,34 @@ internal static class GridTemplateAreasResolver
 {
     public const int KeywordIdNone = 0;
 
+    // ---- PR-#105 review F1 — DoS guards ----
+    /// <summary>Maximum source-text length the resolver will tokenize.
+    /// 16 KiB is generous for hand-authored CSS but blocks the
+    /// pathological 100,000-character input.</summary>
+    internal const int MaxSourceLength = 16 * 1024;
+
+    /// <summary>Maximum rows (= number of CSS strings). 256 is well
+    /// above any realistic invoice / report template (typically ≤ 10).
+    /// Combined with <see cref="MaxColumns"/> the total cells stay
+    /// bounded.</summary>
+    internal const int MaxRows = 256;
+
+    /// <summary>Maximum columns per row. Same rationale as
+    /// <see cref="MaxRows"/>.</summary>
+    internal const int MaxColumns = 256;
+
+    /// <summary>Hard ceiling on total cells across all rows. Even with
+    /// <see cref="MaxRows"/> × <see cref="MaxColumns"/> = 65536, this
+    /// ceiling is enforced separately because the typical template is
+    /// much smaller and we'd rather diagnose 32K cells (which is
+    /// already suspect) than allocate it.</summary>
+    internal const int MaxTotalCells = 16 * 1024;
+
+    /// <summary>Maximum length of an area-name custom-ident. CSS
+    /// identifiers are essentially unbounded in spec, but a 64-char
+    /// cap is well above realistic use + blocks DoS via long names.</summary>
+    internal const int MaxIdentLength = 64;
+
     public static ResolverResult Resolve(
         string value,
         PropertyId propertyId,
@@ -54,178 +97,101 @@ internal static class GridTemplateAreasResolver
         ICssDiagnosticsSink? diagnostics,
         CssSourceLocation location)
     {
+        // Per PR-#105 review F1 — pre-check source length before any
+        // allocation.
+        if (value is not null && value.Length > MaxSourceLength)
+        {
+            EmitInvalid(diagnostics, propertyName, value,
+                $"source length {value.Length} exceeds the "
+                + $"grid-template-areas cap of {MaxSourceLength} chars",
+                location);
+            return ResolverResult.Invalid();
+        }
+
         // Defense in depth: CSS-wide keywords cannot serve as a
         // grid-template-areas value at this resolver (the cascade
         // should have intercepted them). Mirrors the pattern from
         // GridLineResolver / GridTemplateListResolver.
-        if (GridLineResolver.IsCssWideKeyword(value))
+        if (GridLineResolver.IsCssWideKeyword(value ?? string.Empty))
         {
-            EmitInvalid(diagnostics, propertyName, value,
+            EmitInvalid(diagnostics, propertyName, value ?? string.Empty,
                 "CSS-wide keyword reached the grid-template-areas resolver "
                 + "(cycle-7a defense-in-depth path)",
                 location);
             return ResolverResult.Invalid();
         }
 
-        var trimmed = value.AsSpan().Trim();
+        var span = (value ?? string.Empty).AsSpan();
+        var trimmed = span.Trim();
         if (trimmed.IsEmpty
             || trimmed.Equals("none", StringComparison.OrdinalIgnoreCase))
         {
             return ResolverResult.Resolved(ComputedSlot.FromKeyword(KeywordIdNone));
         }
 
-        // Tokenize as a sequence of CSS strings. Each <string> token is
-        // enclosed in single or double quotes per CSS Values L4 §3.2.
-        // Whitespace between strings is permitted; anything else is an
-        // error.
-        var rowStrings = new List<string>();
-        if (!TryTokenizeRowStrings(value, rowStrings, out var tokenizeError))
+        // Tokenize quoted-string rows + split each into cell tokens
+        // in a single pass. Cells flatten directly into a row-major
+        // array; we also accumulate per-name bounds for the single-
+        // pass rectangle validation (per PR-#105 review F1).
+        var parseResult = ParseCells(value!);
+        if (!parseResult.Ok)
         {
-            EmitInvalid(diagnostics, propertyName, value, tokenizeError, location);
+            EmitInvalid(diagnostics, propertyName, value!,
+                parseResult.Error, location);
             return ResolverResult.Invalid();
         }
 
-        if (rowStrings.Count == 0)
+        var cellsBuilder = ImmutableArray.CreateBuilder<string?>(
+            parseResult.RowCount * parseResult.ColumnCount);
+        for (var i = 0; i < parseResult.Cells.Count; i++)
         {
-            EmitInvalid(diagnostics, propertyName, value,
-                "grid-template-areas requires at least one <string> row "
-                + "per CSS Grid L1 §7.3", location);
-            return ResolverResult.Invalid();
+            cellsBuilder.Add(parseResult.Cells[i]);
         }
+        var flatCells = cellsBuilder.ToImmutable();
 
-        // Split each row string on whitespace into cell tokens.
-        var cellsByRow = new List<string?[]>(rowStrings.Count);
-        var columnCount = -1;
-        for (var r = 0; r < rowStrings.Count; r++)
-        {
-            var cells = SplitRowIntoCells(rowStrings[r]);
-            if (cells.Length == 0)
-            {
-                EmitInvalid(diagnostics, propertyName, value,
-                    $"grid-template-areas row {r + 1} is empty — each "
-                    + "row string must contain at least one cell token "
-                    + "(<custom-ident> or .) per CSS Grid L1 §7.3",
-                    location);
-                return ResolverResult.Invalid();
-            }
-            if (columnCount < 0)
-            {
-                columnCount = cells.Length;
-            }
-            else if (cells.Length != columnCount)
-            {
-                EmitInvalid(diagnostics, propertyName, value,
-                    $"grid-template-areas row {r + 1} has {cells.Length} "
-                    + $"cell tokens but row 1 has {columnCount} (= ragged "
-                    + "rows are invalid per CSS Grid L1 §7.3)",
-                    location);
-                return ResolverResult.Invalid();
-            }
-            cellsByRow.Add(cells);
-        }
-
-        // Validate every named cell forms a single rectangle.
-        var rowCount = cellsByRow.Count;
-        var flatCells = ImmutableArray.CreateBuilder<string?>(rowCount * columnCount);
-        for (var r = 0; r < rowCount; r++)
-        {
-            for (var c = 0; c < columnCount; c++)
-            {
-                flatCells.Add(cellsByRow[r][c]);
-            }
-        }
-        var flat = flatCells.ToImmutable();
-
+        // Derive name → rectangle from the per-name accumulators.
+        // Validate: bounding-rect area must equal count (= no holes,
+        // no outside-rectangle occurrences).
         var nameToRect = ImmutableDictionary.CreateBuilder<string, GridAreaRect>(
             StringComparer.Ordinal);
-        for (var r = 0; r < rowCount; r++)
+        foreach (var (name, bounds) in parseResult.NameBounds)
         {
-            for (var c = 0; c < columnCount; c++)
+            var rowSpan = bounds.MaxRow - bounds.MinRow + 1;
+            var colSpan = bounds.MaxCol - bounds.MinCol + 1;
+            if ((long)rowSpan * colSpan != bounds.Count)
             {
-                var name = flat[r * columnCount + c];
-                if (name is null) continue;
-                if (nameToRect.ContainsKey(name)) continue;
-
-                // Find the rectangle extent of this name. Walk right
-                // along this row to find the column extent; then walk
-                // down to find the row extent. Then verify EVERY cell
-                // in the rectangle has the same name AND no cell with
-                // this name exists outside the rectangle.
-                var colEnd = c + 1;
-                while (colEnd < columnCount
-                    && flat[r * columnCount + colEnd] == name)
-                {
-                    colEnd++;
-                }
-                var rowEnd = r + 1;
-                while (rowEnd < rowCount
-                    && flat[rowEnd * columnCount + c] == name)
-                {
-                    rowEnd++;
-                }
-                // Validate rectangle interior.
-                for (var rr = r; rr < rowEnd; rr++)
-                {
-                    for (var cc = c; cc < colEnd; cc++)
-                    {
-                        if (flat[rr * columnCount + cc] != name)
-                        {
-                            EmitInvalid(diagnostics, propertyName, value,
-                                $"grid-template-areas named area '{name}' "
-                                + $"does not form a rectangle (cell at row "
-                                + $"{rr + 1}, column {cc + 1} is "
-                                + (flat[rr * columnCount + cc] is null
-                                    ? "null"
-                                    : $"'{flat[rr * columnCount + cc]}'")
-                                + $" instead of '{name}') per CSS Grid L1 §7.3",
-                                location);
-                            return ResolverResult.Invalid();
-                        }
-                    }
-                }
-                // Validate no cell with this name exists OUTSIDE the
-                // rectangle. Scan the full grid.
-                for (var rr = 0; rr < rowCount; rr++)
-                {
-                    for (var cc = 0; cc < columnCount; cc++)
-                    {
-                        var outside = rr < r || rr >= rowEnd
-                            || cc < c || cc >= colEnd;
-                        if (outside && flat[rr * columnCount + cc] == name)
-                        {
-                            EmitInvalid(diagnostics, propertyName, value,
-                                $"grid-template-areas named area '{name}' "
-                                + "occupies non-rectangular cells (cell at "
-                                + $"row {rr + 1}, column {cc + 1} is "
-                                + "outside the area's bounding rectangle) "
-                                + "per CSS Grid L1 §7.3",
-                                location);
-                            return ResolverResult.Invalid();
-                        }
-                    }
-                }
-                // 1-based line numbers; end is exclusive.
-                nameToRect[name] = new GridAreaRect(
-                    RowStart: r + 1, RowEnd: rowEnd + 1,
-                    ColumnStart: c + 1, ColumnEnd: colEnd + 1);
+                EmitInvalid(diagnostics, propertyName, value!,
+                    $"named area '{name}' is not a rectangle (= cells "
+                    + $"with this name don't fill a contiguous bounding "
+                    + $"box of {rowSpan}×{colSpan}={rowSpan * colSpan} "
+                    + $"cells; saw {bounds.Count} occurrences)",
+                    location);
+                return ResolverResult.Invalid();
             }
+            nameToRect[name] = new GridAreaRect(
+                RowStart: bounds.MinRow + 1, RowEnd: bounds.MaxRow + 2,
+                ColumnStart: bounds.MinCol + 1, ColumnEnd: bounds.MaxCol + 2);
         }
 
         var ast = new GridTemplateAreas(
-            RowCount: rowCount,
-            ColumnCount: columnCount,
-            Cells: flat,
+            RowCount: parseResult.RowCount,
+            ColumnCount: parseResult.ColumnCount,
+            Cells: flatCells,
             NameToRect: nameToRect.ToImmutable());
         return ResolverResult.ResolvedSideTable((object)ast);
     }
 
-    /// <summary>Validates a <c>grid-template-areas</c> value without
-    /// emitting a diagnostic. Mirrors
-    /// <see cref="GridLineResolver.TryValidate"/>; used by the
-    /// CSS-shorthand expanders for cycle-7 features.</summary>
+    /// <summary>Side-effect-free validation for shorthand expanders.
+    /// Per PR-#105 review F2, shares the full validation logic
+    /// (including rectangle invariants) with <see cref="Resolve"/> so
+    /// invalid templates can't pass pre-validation. Differs from
+    /// <see cref="Resolve"/> only in that it doesn't allocate the
+    /// flat-cells immutable array OR the side-table payload + doesn't
+    /// emit diagnostics.</summary>
     internal static bool TryValidate(string value)
     {
         if (value is null) return false;
+        if (value.Length > MaxSourceLength) return false;
         if (GridLineResolver.IsCssWideKeyword(value)) return false;
         var trimmed = value.AsSpan().Trim();
         if (trimmed.IsEmpty
@@ -233,37 +199,63 @@ internal static class GridTemplateAreasResolver
         {
             return true;
         }
-        var rowStrings = new List<string>();
-        if (!TryTokenizeRowStrings(value, rowStrings, out _)) return false;
-        if (rowStrings.Count == 0) return false;
-        var columnCount = -1;
-        var cellsByRow = new List<string?[]>(rowStrings.Count);
-        foreach (var rowString in rowStrings)
+        var parseResult = ParseCells(value);
+        if (!parseResult.Ok) return false;
+        // Per PR-#105 review F2 — apply the same rectangle validation
+        // as Resolve. Without this, invalid L-shaped / disjoint
+        // templates would pass pre-validation in shorthand expanders.
+        foreach (var (_, bounds) in parseResult.NameBounds)
         {
-            var cells = SplitRowIntoCells(rowString);
-            if (cells.Length == 0) return false;
-            if (columnCount < 0) columnCount = cells.Length;
-            else if (cells.Length != columnCount) return false;
-            cellsByRow.Add(cells);
+            var rowSpan = bounds.MaxRow - bounds.MinRow + 1;
+            var colSpan = bounds.MaxCol - bounds.MinCol + 1;
+            if ((long)rowSpan * colSpan != bounds.Count) return false;
         }
-        // Skip the rectangle-validation pass; this is a lighter
-        // pre-validation for shorthand expanders. The full resolver
-        // does the strict pass.
         return true;
     }
 
-    /// <summary>Tokenize the input as a sequence of CSS strings
-    /// (quoted single or double). Returns <see langword="false"/> with
-    /// a <paramref name="error"/> describing the failure on bad
-    /// input.</summary>
-    private static bool TryTokenizeRowStrings(
-        string value, List<string> rowStrings, out string error)
+    // =================================================================
+    //  Single-pass parser. Tokenizes + cell-splits + name-bounds
+    //  accumulation in one pass. Returns a `ParseResult` that the
+    //  caller turns into either the side-table payload (Resolve) or
+    //  a bool (TryValidate).
+    // =================================================================
+
+    private readonly struct NameBounds(int minRow, int maxRow, int minCol, int maxCol, int count)
     {
-        error = string.Empty;
-        var i = 0;
+        public int MinRow { get; } = minRow;
+        public int MaxRow { get; } = maxRow;
+        public int MinCol { get; } = minCol;
+        public int MaxCol { get; } = maxCol;
+        public int Count { get; } = count;
+
+        public NameBounds Extend(int row, int col) => new(
+            Math.Min(MinRow, row), Math.Max(MaxRow, row),
+            Math.Min(MinCol, col), Math.Max(MaxCol, col),
+            Count + 1);
+    }
+
+    private sealed class ParseResult
+    {
+        public bool Ok;
+        public string Error = string.Empty;
+        public int RowCount;
+        public int ColumnCount;
+        public List<string?> Cells = new();
+        public Dictionary<string, NameBounds> NameBounds =
+            new(StringComparer.Ordinal);
+    }
+
+    private static ParseResult ParseCells(string value)
+    {
+        var result = new ParseResult();
         var span = value.AsSpan();
+        var i = 0;
+        var rowIndex = 0;
+        var firstRowColumnCount = -1;
+
         while (i < span.Length)
         {
+            // Skip whitespace between row strings.
             var c = span[i];
             if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f')
             {
@@ -272,55 +264,234 @@ internal static class GridTemplateAreasResolver
             }
             if (c != '"' && c != '\'')
             {
-                error = $"grid-template-areas expects a sequence of CSS "
-                    + $"strings but found unexpected character '{c}' at "
-                    + $"position {i}";
-                return false;
+                result.Error = $"expected a CSS string (quoted with \"…\" "
+                    + $"or '…') but found '{c}' at position {i}";
+                return result;
             }
-            var quote = c;
-            i++;
-            var start = i;
-            while (i < span.Length && span[i] != quote)
+
+            if (rowIndex >= MaxRows)
             {
-                // Reject embedded newlines per CSS Syntax §4.3.5 (bad
-                // string token). The author should use one quoted
-                // string per row.
-                if (span[i] == '\n' || span[i] == '\r' || span[i] == '\f')
-                {
-                    error = $"grid-template-areas row string contains a "
-                        + $"raw newline at position {i}; each row must be "
-                        + "a single-line CSS string";
-                    return false;
-                }
-                i++;
+                result.Error = $"row count exceeds MaxRows={MaxRows} cap "
+                    + "(grid-template-areas DoS guard)";
+                return result;
             }
-            if (i >= span.Length)
+
+            // Read the quoted string with escape handling
+            // (PR-#105 review F3). Returns the decoded string + the
+            // new cursor position.
+            if (!TryReadCssString(span, ref i, out var rowString, out var stringError))
             {
-                error = $"grid-template-areas row string starting at "
-                    + $"position {start - 1} is missing its closing "
-                    + $"quote '{quote}'";
-                return false;
+                result.Error = stringError;
+                return result;
             }
-            rowStrings.Add(span.Slice(start, i - start).ToString());
-            i++; // skip closing quote
+
+            // Split the row string into cell tokens with proper error
+            // reporting (PR-#105 review F10 — actual reason instead
+            // of empty-array sentinel).
+            var rowCellsStart = result.Cells.Count;
+            var splitError = SplitRowIntoCellsInto(
+                rowString, rowIndex, result.Cells, result.NameBounds);
+            if (splitError is not null)
+            {
+                result.Error = splitError;
+                return result;
+            }
+            var thisRowCellCount = result.Cells.Count - rowCellsStart;
+            if (thisRowCellCount == 0)
+            {
+                result.Error = $"row {rowIndex + 1} is empty — each "
+                    + "row string must contain at least one cell token "
+                    + "(<custom-ident> or .) per CSS Grid L1 §7.3";
+                return result;
+            }
+            if (thisRowCellCount > MaxColumns)
+            {
+                result.Error = $"row {rowIndex + 1} has {thisRowCellCount} "
+                    + $"cells, exceeding MaxColumns={MaxColumns} cap";
+                return result;
+            }
+            if (firstRowColumnCount < 0)
+            {
+                firstRowColumnCount = thisRowCellCount;
+            }
+            else if (thisRowCellCount != firstRowColumnCount)
+            {
+                result.Error = $"row {rowIndex + 1} has {thisRowCellCount} "
+                    + $"cell tokens but row 1 has {firstRowColumnCount} "
+                    + "(= ragged rows are invalid per CSS Grid L1 §7.3)";
+                return result;
+            }
+            if (result.Cells.Count > MaxTotalCells)
+            {
+                result.Error = $"total cell count exceeds "
+                    + $"MaxTotalCells={MaxTotalCells} cap";
+                return result;
+            }
+            rowIndex++;
         }
-        return true;
+
+        if (rowIndex == 0)
+        {
+            result.Error = "grid-template-areas requires at least one "
+                + "<string> row per CSS Grid L1 §7.3";
+            return result;
+        }
+
+        result.Ok = true;
+        result.RowCount = rowIndex;
+        result.ColumnCount = firstRowColumnCount;
+        return result;
     }
 
-    /// <summary>Split a row string on whitespace into cell tokens.
-    /// Each token is either <c>&lt;custom-ident&gt;</c> (= returned
-    /// verbatim) or one or more <c>.</c> characters (= null cell —
-    /// returned as <see langword="null"/>). Multiple <c>.</c>
-    /// characters in a row count as a single null cell per §7.3
-    /// (= same effect as a single <c>.</c>).</summary>
-    private static string?[] SplitRowIntoCells(string row)
+    /// <summary>Per PR-#105 review F3 — read one CSS string token per
+    /// CSS Syntax L3 §4.3.5 with escape handling. Decodes the four
+    /// escape forms per §4.3.7: hex escape (up to 6 hex digits +
+    /// optional whitespace), line continuation (backslash + newline,
+    /// ignored), literal-next-char escape, and null/surrogate fallback
+    /// to U+FFFD. Rejects raw newlines (per spec §4.3.5 a CSS string
+    /// is terminated at a raw newline; we treat that as parse error
+    /// to surface the issue rather than producing a "bad string"
+    /// token).</summary>
+    private static bool TryReadCssString(
+        ReadOnlySpan<char> span, ref int cursor,
+        out string decoded, out string error)
     {
-        var cells = new List<string?>();
+        decoded = string.Empty;
+        error = string.Empty;
+        if (cursor >= span.Length)
+        {
+            error = "expected a CSS string but reached end of input";
+            return false;
+        }
+        var quote = span[cursor];
+        if (quote != '"' && quote != '\'')
+        {
+            error = $"expected quote character but saw '{span[cursor]}' "
+                + $"at position {cursor}";
+            return false;
+        }
+        cursor++; // skip opening quote
+        var startPos = cursor - 1;
+        var sb = new StringBuilder();
+        while (cursor < span.Length)
+        {
+            var c = span[cursor];
+            if (c == quote)
+            {
+                cursor++; // skip closing quote
+                decoded = sb.ToString();
+                return true;
+            }
+            if (c == '\n' || c == '\r' || c == '\f')
+            {
+                error = $"row string starting at position {startPos} "
+                    + $"contains a raw newline (forbidden per CSS Syntax "
+                    + "L3 §4.3.5; each row must be a single-line CSS "
+                    + "string)";
+                return false;
+            }
+            if (c == '\\')
+            {
+                cursor++;
+                if (cursor >= span.Length)
+                {
+                    error = $"row string starting at position {startPos} "
+                        + "ends with a dangling backslash escape";
+                    return false;
+                }
+                var next = span[cursor];
+                // Line continuation: backslash + newline → empty.
+                if (next == '\n' || next == '\r' || next == '\f')
+                {
+                    // Consume CR/LF/CRLF pair as a single newline.
+                    if (next == '\r' && cursor + 1 < span.Length && span[cursor + 1] == '\n')
+                    {
+                        cursor += 2;
+                    }
+                    else
+                    {
+                        cursor++;
+                    }
+                    continue;
+                }
+                // Hex escape: 1..6 hex digits + optional whitespace.
+                if (IsHexDigit(next))
+                {
+                    var hexStart = cursor;
+                    var hexLen = 0;
+                    while (hexLen < 6 && cursor < span.Length
+                        && IsHexDigit(span[cursor]))
+                    {
+                        cursor++;
+                        hexLen++;
+                    }
+                    // Optional trailing whitespace consumed (per §4.3.7).
+                    if (cursor < span.Length)
+                    {
+                        var ws = span[cursor];
+                        if (ws == ' ' || ws == '\t' || ws == '\n' || ws == '\r' || ws == '\f')
+                        {
+                            // CRLF → consume both.
+                            if (ws == '\r' && cursor + 1 < span.Length && span[cursor + 1] == '\n')
+                            {
+                                cursor += 2;
+                            }
+                            else
+                            {
+                                cursor++;
+                            }
+                        }
+                    }
+                    var hexStr = span.Slice(hexStart, hexLen).ToString();
+                    if (uint.TryParse(hexStr, NumberStyles.HexNumber,
+                        CultureInfo.InvariantCulture, out var cp))
+                    {
+                        // Per §4.3.7: null code point and surrogates →
+                        // U+FFFD; values > U+10FFFF → U+FFFD.
+                        if (cp == 0 || (cp >= 0xD800 && cp <= 0xDFFF) || cp > 0x10FFFF)
+                        {
+                            sb.Append('�');
+                        }
+                        else
+                        {
+                            sb.Append(char.ConvertFromUtf32((int)cp));
+                        }
+                    }
+                    continue;
+                }
+                // Literal-next-char escape (= \X for any non-hex, non-
+                // newline char). Append the literal character.
+                sb.Append(next);
+                cursor++;
+                continue;
+            }
+            sb.Append(c);
+            cursor++;
+        }
+        error = $"row string starting at position {startPos} is missing "
+            + $"its closing quote '{quote}'";
+        return false;
+    }
+
+    private static bool IsHexDigit(char c)
+        => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+
+    /// <summary>Per PR-#105 review F10 — split a row string into cell
+    /// tokens, appending each token to <paramref name="cells"/> and
+    /// updating <paramref name="nameBounds"/> in a single pass.
+    /// Returns <see langword="null"/> on success; an error message
+    /// (with the offending character and its row-relative position)
+    /// on failure.</summary>
+    private static string? SplitRowIntoCellsInto(
+        string row, int rowIndex,
+        List<string?> cells,
+        Dictionary<string, NameBounds> nameBounds)
+    {
         var span = row.AsSpan();
         var i = 0;
+        var colInRow = 0;
         while (i < span.Length)
         {
-            // Skip whitespace.
             if (span[i] == ' ' || span[i] == '\t')
             {
                 i++;
@@ -331,29 +502,51 @@ internal static class GridTemplateAreasResolver
             {
                 while (i < span.Length && span[i] == '.') i++;
                 cells.Add(null);
+                colInRow++;
                 continue;
             }
-            // A custom-ident: run of identifier characters (= per
-            // cycle-6a's GridLineResolver tokenizer convention,
-            // alphanumeric + dash + underscore is sufficient for the
-            // custom-ident grammar at this layer).
-            var start = i;
-            while (i < span.Length && IsIdentChar(span[i])) i++;
-            if (i == start)
+            if (IsIdentStart(span[i]))
             {
-                // Unrecognized character — return an empty array to
-                // signal failure to the caller (= caller will emit a
-                // diagnostic via the "row is empty" check).
-                return System.Array.Empty<string?>();
+                var start = i;
+                while (i < span.Length && IsIdentContinue(span[i])) i++;
+                var len = i - start;
+                if (len > MaxIdentLength)
+                {
+                    return $"row {rowIndex + 1} contains a custom-ident "
+                        + $"of length {len} (exceeds MaxIdentLength="
+                        + $"{MaxIdentLength} cap)";
+                }
+                var name = span.Slice(start, len).ToString();
+                cells.Add(name);
+                if (nameBounds.TryGetValue(name, out var existing))
+                {
+                    nameBounds[name] = existing.Extend(rowIndex, colInRow);
+                }
+                else
+                {
+                    nameBounds[name] = new NameBounds(
+                        rowIndex, rowIndex, colInRow, colInRow, 1);
+                }
+                colInRow++;
+                continue;
             }
-            cells.Add(span.Slice(start, i - start).ToString());
+            // Unrecognized character — report with row-relative position.
+            return $"row {rowIndex + 1} contains an unexpected character "
+                + $"'{span[i]}' at row position {i} (expected "
+                + "<custom-ident>, '.', or whitespace)";
         }
-        return cells.ToArray();
+        return null;
     }
 
-    private static bool IsIdentChar(char c)
-        => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
-        || (c >= '0' && c <= '9') || c == '-' || c == '_';
+    private static bool IsIdentStart(char c)
+        => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
+            // Per CSS Syntax §4.4 — non-ASCII identifier code points are
+            // allowed. Cycle-7a accepts U+0080+ as ident-start so escaped
+            // / Unicode area names parse.
+            || c >= 0x80;
+
+    private static bool IsIdentContinue(char c)
+        => IsIdentStart(c) || (c >= '0' && c <= '9') || c == '-';
 
     private static void EmitInvalid(
         ICssDiagnosticsSink? sink, string propertyName, string value,

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/GridTemplateAreasResolver.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/GridTemplateAreasResolver.cs
@@ -1,0 +1,370 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using NetPdf.Css.Diagnostics;
+using NetPdf.Css.Parser;
+using NetPdf.Css.Properties;
+
+namespace NetPdf.Css.ComputedValues.PropertyResolvers;
+
+/// <summary>
+/// Per Phase 3 Task 18 cycle 7a — resolves the
+/// <see cref="PropertyType.GridTemplateAreas"/> property
+/// (<c>grid-template-areas</c>) per CSS Grid L1 §7.3.
+///
+/// <para><b>Grammar accepted</b>:</para>
+/// <code>
+/// grid-template-areas = none | &lt;string&gt;+
+/// </code>
+///
+/// <para>Each <c>&lt;string&gt;</c> declares one row of the area
+/// template. The string is split on whitespace into cell tokens:</para>
+/// <list type="bullet">
+///   <item><c>&lt;custom-ident&gt;</c> tokens — name a cell.
+///   Same-name adjacent cells merge into one rectangular area.</item>
+///   <item><c>.</c> (one or more periods) — a null cell (no name).</item>
+/// </list>
+///
+/// <para><b>Validation</b> per §7.3:</para>
+/// <list type="bullet">
+///   <item>Every row string must produce the same column count
+///   (= ragged rows are invalid).</item>
+///   <item>Every named area must form a SINGLE rectangle. A name
+///   appearing in non-rectangular positions is invalid.</item>
+///   <item>The empty string OR <c>none</c> resolves to
+///   <see cref="GridTemplateAreas.None"/>.</item>
+/// </list>
+///
+/// <para><b>Invalid input</b> emits
+/// <see cref="CssDiagnosticCodes.CssPropertyValueInvalid001"/> with a
+/// spec-referencing reason. The cascade falls back to the property's
+/// initial value (= <c>none</c>) on Invalid.</para>
+/// </summary>
+internal static class GridTemplateAreasResolver
+{
+    public const int KeywordIdNone = 0;
+
+    public static ResolverResult Resolve(
+        string value,
+        PropertyId propertyId,
+        string propertyName,
+        ICssDiagnosticsSink? diagnostics,
+        CssSourceLocation location)
+    {
+        // Defense in depth: CSS-wide keywords cannot serve as a
+        // grid-template-areas value at this resolver (the cascade
+        // should have intercepted them). Mirrors the pattern from
+        // GridLineResolver / GridTemplateListResolver.
+        if (GridLineResolver.IsCssWideKeyword(value))
+        {
+            EmitInvalid(diagnostics, propertyName, value,
+                "CSS-wide keyword reached the grid-template-areas resolver "
+                + "(cycle-7a defense-in-depth path)",
+                location);
+            return ResolverResult.Invalid();
+        }
+
+        var trimmed = value.AsSpan().Trim();
+        if (trimmed.IsEmpty
+            || trimmed.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            return ResolverResult.Resolved(ComputedSlot.FromKeyword(KeywordIdNone));
+        }
+
+        // Tokenize as a sequence of CSS strings. Each <string> token is
+        // enclosed in single or double quotes per CSS Values L4 §3.2.
+        // Whitespace between strings is permitted; anything else is an
+        // error.
+        var rowStrings = new List<string>();
+        if (!TryTokenizeRowStrings(value, rowStrings, out var tokenizeError))
+        {
+            EmitInvalid(diagnostics, propertyName, value, tokenizeError, location);
+            return ResolverResult.Invalid();
+        }
+
+        if (rowStrings.Count == 0)
+        {
+            EmitInvalid(diagnostics, propertyName, value,
+                "grid-template-areas requires at least one <string> row "
+                + "per CSS Grid L1 §7.3", location);
+            return ResolverResult.Invalid();
+        }
+
+        // Split each row string on whitespace into cell tokens.
+        var cellsByRow = new List<string?[]>(rowStrings.Count);
+        var columnCount = -1;
+        for (var r = 0; r < rowStrings.Count; r++)
+        {
+            var cells = SplitRowIntoCells(rowStrings[r]);
+            if (cells.Length == 0)
+            {
+                EmitInvalid(diagnostics, propertyName, value,
+                    $"grid-template-areas row {r + 1} is empty — each "
+                    + "row string must contain at least one cell token "
+                    + "(<custom-ident> or .) per CSS Grid L1 §7.3",
+                    location);
+                return ResolverResult.Invalid();
+            }
+            if (columnCount < 0)
+            {
+                columnCount = cells.Length;
+            }
+            else if (cells.Length != columnCount)
+            {
+                EmitInvalid(diagnostics, propertyName, value,
+                    $"grid-template-areas row {r + 1} has {cells.Length} "
+                    + $"cell tokens but row 1 has {columnCount} (= ragged "
+                    + "rows are invalid per CSS Grid L1 §7.3)",
+                    location);
+                return ResolverResult.Invalid();
+            }
+            cellsByRow.Add(cells);
+        }
+
+        // Validate every named cell forms a single rectangle.
+        var rowCount = cellsByRow.Count;
+        var flatCells = ImmutableArray.CreateBuilder<string?>(rowCount * columnCount);
+        for (var r = 0; r < rowCount; r++)
+        {
+            for (var c = 0; c < columnCount; c++)
+            {
+                flatCells.Add(cellsByRow[r][c]);
+            }
+        }
+        var flat = flatCells.ToImmutable();
+
+        var nameToRect = ImmutableDictionary.CreateBuilder<string, GridAreaRect>(
+            StringComparer.Ordinal);
+        for (var r = 0; r < rowCount; r++)
+        {
+            for (var c = 0; c < columnCount; c++)
+            {
+                var name = flat[r * columnCount + c];
+                if (name is null) continue;
+                if (nameToRect.ContainsKey(name)) continue;
+
+                // Find the rectangle extent of this name. Walk right
+                // along this row to find the column extent; then walk
+                // down to find the row extent. Then verify EVERY cell
+                // in the rectangle has the same name AND no cell with
+                // this name exists outside the rectangle.
+                var colEnd = c + 1;
+                while (colEnd < columnCount
+                    && flat[r * columnCount + colEnd] == name)
+                {
+                    colEnd++;
+                }
+                var rowEnd = r + 1;
+                while (rowEnd < rowCount
+                    && flat[rowEnd * columnCount + c] == name)
+                {
+                    rowEnd++;
+                }
+                // Validate rectangle interior.
+                for (var rr = r; rr < rowEnd; rr++)
+                {
+                    for (var cc = c; cc < colEnd; cc++)
+                    {
+                        if (flat[rr * columnCount + cc] != name)
+                        {
+                            EmitInvalid(diagnostics, propertyName, value,
+                                $"grid-template-areas named area '{name}' "
+                                + $"does not form a rectangle (cell at row "
+                                + $"{rr + 1}, column {cc + 1} is "
+                                + (flat[rr * columnCount + cc] is null
+                                    ? "null"
+                                    : $"'{flat[rr * columnCount + cc]}'")
+                                + $" instead of '{name}') per CSS Grid L1 §7.3",
+                                location);
+                            return ResolverResult.Invalid();
+                        }
+                    }
+                }
+                // Validate no cell with this name exists OUTSIDE the
+                // rectangle. Scan the full grid.
+                for (var rr = 0; rr < rowCount; rr++)
+                {
+                    for (var cc = 0; cc < columnCount; cc++)
+                    {
+                        var outside = rr < r || rr >= rowEnd
+                            || cc < c || cc >= colEnd;
+                        if (outside && flat[rr * columnCount + cc] == name)
+                        {
+                            EmitInvalid(diagnostics, propertyName, value,
+                                $"grid-template-areas named area '{name}' "
+                                + "occupies non-rectangular cells (cell at "
+                                + $"row {rr + 1}, column {cc + 1} is "
+                                + "outside the area's bounding rectangle) "
+                                + "per CSS Grid L1 §7.3",
+                                location);
+                            return ResolverResult.Invalid();
+                        }
+                    }
+                }
+                // 1-based line numbers; end is exclusive.
+                nameToRect[name] = new GridAreaRect(
+                    RowStart: r + 1, RowEnd: rowEnd + 1,
+                    ColumnStart: c + 1, ColumnEnd: colEnd + 1);
+            }
+        }
+
+        var ast = new GridTemplateAreas(
+            RowCount: rowCount,
+            ColumnCount: columnCount,
+            Cells: flat,
+            NameToRect: nameToRect.ToImmutable());
+        return ResolverResult.ResolvedSideTable((object)ast);
+    }
+
+    /// <summary>Validates a <c>grid-template-areas</c> value without
+    /// emitting a diagnostic. Mirrors
+    /// <see cref="GridLineResolver.TryValidate"/>; used by the
+    /// CSS-shorthand expanders for cycle-7 features.</summary>
+    internal static bool TryValidate(string value)
+    {
+        if (value is null) return false;
+        if (GridLineResolver.IsCssWideKeyword(value)) return false;
+        var trimmed = value.AsSpan().Trim();
+        if (trimmed.IsEmpty
+            || trimmed.Equals("none", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        var rowStrings = new List<string>();
+        if (!TryTokenizeRowStrings(value, rowStrings, out _)) return false;
+        if (rowStrings.Count == 0) return false;
+        var columnCount = -1;
+        var cellsByRow = new List<string?[]>(rowStrings.Count);
+        foreach (var rowString in rowStrings)
+        {
+            var cells = SplitRowIntoCells(rowString);
+            if (cells.Length == 0) return false;
+            if (columnCount < 0) columnCount = cells.Length;
+            else if (cells.Length != columnCount) return false;
+            cellsByRow.Add(cells);
+        }
+        // Skip the rectangle-validation pass; this is a lighter
+        // pre-validation for shorthand expanders. The full resolver
+        // does the strict pass.
+        return true;
+    }
+
+    /// <summary>Tokenize the input as a sequence of CSS strings
+    /// (quoted single or double). Returns <see langword="false"/> with
+    /// a <paramref name="error"/> describing the failure on bad
+    /// input.</summary>
+    private static bool TryTokenizeRowStrings(
+        string value, List<string> rowStrings, out string error)
+    {
+        error = string.Empty;
+        var i = 0;
+        var span = value.AsSpan();
+        while (i < span.Length)
+        {
+            var c = span[i];
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f')
+            {
+                i++;
+                continue;
+            }
+            if (c != '"' && c != '\'')
+            {
+                error = $"grid-template-areas expects a sequence of CSS "
+                    + $"strings but found unexpected character '{c}' at "
+                    + $"position {i}";
+                return false;
+            }
+            var quote = c;
+            i++;
+            var start = i;
+            while (i < span.Length && span[i] != quote)
+            {
+                // Reject embedded newlines per CSS Syntax §4.3.5 (bad
+                // string token). The author should use one quoted
+                // string per row.
+                if (span[i] == '\n' || span[i] == '\r' || span[i] == '\f')
+                {
+                    error = $"grid-template-areas row string contains a "
+                        + $"raw newline at position {i}; each row must be "
+                        + "a single-line CSS string";
+                    return false;
+                }
+                i++;
+            }
+            if (i >= span.Length)
+            {
+                error = $"grid-template-areas row string starting at "
+                    + $"position {start - 1} is missing its closing "
+                    + $"quote '{quote}'";
+                return false;
+            }
+            rowStrings.Add(span.Slice(start, i - start).ToString());
+            i++; // skip closing quote
+        }
+        return true;
+    }
+
+    /// <summary>Split a row string on whitespace into cell tokens.
+    /// Each token is either <c>&lt;custom-ident&gt;</c> (= returned
+    /// verbatim) or one or more <c>.</c> characters (= null cell —
+    /// returned as <see langword="null"/>). Multiple <c>.</c>
+    /// characters in a row count as a single null cell per §7.3
+    /// (= same effect as a single <c>.</c>).</summary>
+    private static string?[] SplitRowIntoCells(string row)
+    {
+        var cells = new List<string?>();
+        var span = row.AsSpan();
+        var i = 0;
+        while (i < span.Length)
+        {
+            // Skip whitespace.
+            if (span[i] == ' ' || span[i] == '\t')
+            {
+                i++;
+                continue;
+            }
+            // A run of '.' characters → one null cell.
+            if (span[i] == '.')
+            {
+                while (i < span.Length && span[i] == '.') i++;
+                cells.Add(null);
+                continue;
+            }
+            // A custom-ident: run of identifier characters (= per
+            // cycle-6a's GridLineResolver tokenizer convention,
+            // alphanumeric + dash + underscore is sufficient for the
+            // custom-ident grammar at this layer).
+            var start = i;
+            while (i < span.Length && IsIdentChar(span[i])) i++;
+            if (i == start)
+            {
+                // Unrecognized character — return an empty array to
+                // signal failure to the caller (= caller will emit a
+                // diagnostic via the "row is empty" check).
+                return System.Array.Empty<string?>();
+            }
+            cells.Add(span.Slice(start, i - start).ToString());
+        }
+        return cells.ToArray();
+    }
+
+    private static bool IsIdentChar(char c)
+        => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+        || (c >= '0' && c <= '9') || c == '-' || c == '_';
+
+    private static void EmitInvalid(
+        ICssDiagnosticsSink? sink, string propertyName, string value,
+        string reason, CssSourceLocation location)
+    {
+        var safeValue = DiagnosticTextSanitizer.Sanitize(value);
+        var safeReason = DiagnosticTextSanitizer.Sanitize(reason);
+        sink?.Emit(new CssDiagnostic(
+            CssDiagnosticCodes.CssPropertyValueInvalid001,
+            $"Could not parse '{propertyName}: {safeValue}' — {safeReason}.",
+            CssDiagnosticSeverity.Warning,
+            location));
+    }
+}

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/PropertyResolverDispatch.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/PropertyResolverDispatch.cs
@@ -121,6 +121,8 @@ internal static class PropertyResolverDispatch
                 trimmed, propertyId, meta.Name, diagnostics, location),
             PropertyType.GridLine => GridLineResolver.Resolve(
                 trimmed, propertyId, meta.Name, diagnostics, location),
+            PropertyType.GridTemplateAreas => GridTemplateAreasResolver.Resolve(
+                trimmed, propertyId, meta.Name, diagnostics, location),
 
             // Cycle-2 PropertyTypes — return UnsupportedUnvalidated (NOT Deferred)
             // because the dispatch hasn't validated the value text against the

--- a/src/NetPdf.Css/Properties/PropertyType.cs
+++ b/src/NetPdf.Css/Properties/PropertyType.cs
@@ -79,6 +79,15 @@ internal enum PropertyType : byte
     /// named lines. The 4-arg <c>grid-area</c> shorthand expands into four
     /// of these (= one per longhand).</summary>
     GridLine = 25,
+    /// <summary>A CSS Grid L1 §7.3 grid-template-areas value — the
+    /// multi-string syntax <c>"head head" "main side" "foot foot"</c>
+    /// declaring a 2-D map of named cell regions. Stores the parsed
+    /// AST (= rows × columns of cell-names + a derived name → rectangle
+    /// map) via the ComputedSlot side-table pattern. Each named region
+    /// must form a rectangle in the grid; <c>.</c> tokens are null
+    /// cells. Resolution at placement time turns <c>grid-row-start:
+    /// head</c> into the named area's row-start line.</summary>
+    GridTemplateAreas = 26,
     /// <summary>A custom property type — value is opaque to the parser dispatch table.</summary>
     Custom = 255,
 }

--- a/src/NetPdf.Css/properties.json
+++ b/src/NetPdf.Css/properties.json
@@ -47,6 +47,7 @@
     { "name": "grid-column-start", "id": "GridColumnStart", "type": "GridLine", "default": "auto", "inherit": false, "applies_to": "GridItems", "computed": "Specified" },
     { "name": "grid-row-end", "id": "GridRowEnd", "type": "GridLine", "default": "auto", "inherit": false, "applies_to": "GridItems", "computed": "Specified" },
     { "name": "grid-row-start", "id": "GridRowStart", "type": "GridLine", "default": "auto", "inherit": false, "applies_to": "GridItems", "computed": "Specified" },
+    { "name": "grid-template-areas", "id": "GridTemplateAreas", "type": "GridTemplateAreas", "default": "none", "inherit": false, "applies_to": "GridContainers", "computed": "Specified" },
     { "name": "grid-template-columns", "id": "GridTemplateColumns", "type": "GridTemplateList", "default": "none", "inherit": false, "applies_to": "GridContainers", "computed": "Specified" },
     { "name": "grid-template-rows", "id": "GridTemplateRows", "type": "GridTemplateList", "default": "none", "inherit": false, "applies_to": "GridContainers", "computed": "Specified" },
     { "name": "font-family", "id": "FontFamily", "type": "FontFamilyList", "default": "serif", "inherit": true, "applies_to": "All", "computed": "Specified" },

--- a/src/NetPdf.Layout/Layouters/GridSizing.cs
+++ b/src/NetPdf.Layout/Layouters/GridSizing.cs
@@ -165,12 +165,17 @@ internal static class GridSizing
         // initial PlacedItem.RowSpan / ColSpan mirror RowSpec.Span /
         // ColSpec.Span so the layouter's emission loop can size
         // multi-cell rectangles without re-reading the CSS values.
+        // Per Phase 3 Task 18 cycle 7a — read the parent's
+        // grid-template-areas map so item placement can resolve
+        // named-area references (e.g., `grid-row-start: head`).
+        var gridAreas = gridBox.Style.ReadGridTemplateAreas();
+
         var placedItems = new List<PlacedItem>(gridBox.Children.Count);
         foreach (var child in gridBox.Children)
         {
             if (!IsGridItem(child)) continue;
-            var rowSpec = ReadPlacement(child.Style, isRow: true, ctx);
-            var colSpec = ReadPlacement(child.Style, isRow: false, ctx);
+            var rowSpec = ReadPlacement(child.Style, isRow: true, gridAreas, ctx);
+            var colSpec = ReadPlacement(child.Style, isRow: false, gridAreas, ctx);
             placedItems.Add(new PlacedItem
             {
                 Box = child,
@@ -1870,7 +1875,7 @@ internal static class GridSizing
     ///   algorithm is cycle 7 scope)</item>
     /// </list></summary>
     private static PlacementSpec ReadPlacement(
-        ComputedStyle style, bool isRow, SizingContext ctx)
+        ComputedStyle style, bool isRow, GridTemplateAreas areas, SizingContext ctx)
     {
         var start = isRow ? style.ReadGridRowStart() : style.ReadGridColumnStart();
         var end = isRow ? style.ReadGridRowEnd() : style.ReadGridColumnEnd();
@@ -1881,19 +1886,35 @@ internal static class GridSizing
             if (start.NamedLine is not null)
             {
                 return EmitPlacementApproximatedAndFallToAuto(ctx,
-                    "span <named-line> (named lines are cycle-7 scope)");
+                    "span <named-line> (named lines are cycle-7b scope)");
             }
             // Per §8.3.1 — `span 0` normalizes to `span 1`.
             var span = Math.Max(1, start.LineNumber);
             return new PlacementSpec(PlacementKind.Auto, 0, span);
         }
 
-        // (2) start: named-line — cycle 7 scope
-        if (start.Kind == GridLineKind.NamedLine
-            || (start.Kind == GridLineKind.LineNumber && start.NamedLine is not null))
+        // (2) start: named-line (= bare custom-ident) — cycle 7a
+        // resolves this against grid-template-areas when the ident
+        // matches an area name.
+        if (start.Kind == GridLineKind.NamedLine && start.NamedLine is not null)
+        {
+            var areaName = start.NamedLine;
+            if (areas.NameToRect.TryGetValue(areaName, out var areaRect))
+            {
+                return ResolveNamedAreaPlacement(
+                    areaRect, end, isRow, areas, ctx);
+            }
+            return EmitPlacementApproximatedAndFallToAuto(ctx,
+                $"named line '{areaName}' in grid-*-start does not match "
+                + "any grid-template-areas area (cycle-7b will ship "
+                + "<line-names> in grid-template-rows/columns)");
+        }
+
+        // (3) start: LineNumber + NamedLine qualifier — cycle 7b scope
+        if (start.Kind == GridLineKind.LineNumber && start.NamedLine is not null)
         {
             return EmitPlacementApproximatedAndFallToAuto(ctx,
-                "named lines in grid-row-start / grid-column-start (cycle-7 scope)");
+                "named-line qualifier with integer (cycle-7b scope)");
         }
 
         // (3) start: auto — let end drive
@@ -1908,10 +1929,31 @@ internal static class GridSizing
                 if (end.NamedLine is not null)
                 {
                     return EmitPlacementApproximatedAndFallToAuto(ctx,
-                        "span <named-line> in grid-*-end (cycle-7 scope)");
+                        "span <named-line> in grid-*-end (cycle-7b scope)");
                 }
                 var span = Math.Max(1, end.LineNumber);
                 return new PlacementSpec(PlacementKind.Auto, 0, span);
+            }
+            if (end.Kind == GridLineKind.NamedLine && end.NamedLine is not null)
+            {
+                // Per Phase 3 Task 18 cycle 7a — end-only named-area
+                // reference. Place at the area's end line minus one
+                // (= the cell BEFORE the end line) as a single cell.
+                // The spec's full reverse-auto-placement search is
+                // tracked in grid-reverse-auto-placement-deferral.
+                if (areas.NameToRect.TryGetValue(end.NamedLine, out var areaRect))
+                {
+                    var endLine = isRow ? areaRect.RowEnd : areaRect.ColumnEnd;
+                    EmitPlacementApproximatedDiagnostic(ctx,
+                        $"auto-start with named-area-end '{end.NamedLine}' "
+                        + "uses single-cell placement at end-1 (= the "
+                        + "grid-reverse-auto-placement-deferral simplification)");
+                    return new PlacementSpec(
+                        PlacementKind.Definite, endLine - 1, 1);
+                }
+                return EmitPlacementApproximatedAndFallToAuto(ctx,
+                    $"named line '{end.NamedLine}' in grid-*-end does not "
+                    + "match any grid-template-areas area (cycle-7b scope)");
             }
             if (end.Kind == GridLineKind.LineNumber
                 && end.NamedLine is null
@@ -1989,10 +2031,111 @@ internal static class GridSizing
                 "negative line numbers in placement (cycle-7 scope)");
         }
 
-        // end is named — cycle 7 scope.
+        // end is named — cycle 7a resolves against grid-template-areas
+        // when the ident matches an area name.
+        if (end.Kind == GridLineKind.NamedLine && end.NamedLine is not null
+            && areas.NameToRect.TryGetValue(end.NamedLine, out var endAreaRect))
+        {
+            var endLine = isRow ? endAreaRect.RowEnd : endAreaRect.ColumnEnd;
+            // Span from startLine to endLine. Apply the §8.3 swap rule.
+            if (endLine == startLine)
+            {
+                return new PlacementSpec(PlacementKind.Definite, startLine, 1);
+            }
+            if (endLine < startLine)
+            {
+                return new PlacementSpec(
+                    PlacementKind.Definite, endLine, startLine - endLine);
+            }
+            return new PlacementSpec(
+                PlacementKind.Definite, startLine, endLine - startLine);
+        }
         EmitPlacementApproximatedAndFallToAuto(ctx,
             "named line in grid-*-end — using start with span 1");
         return new PlacementSpec(PlacementKind.Definite, startLine, 1);
+    }
+
+    /// <summary>Per Phase 3 Task 18 cycle 7a — resolve a named-area
+    /// start placement (start ident matched an area name). Examines
+    /// the end line to determine the placement extent:
+    /// <list type="bullet">
+    ///   <item>end = Auto → span the full area on this axis.</item>
+    ///   <item>end = NamedLine matching another area → span from this
+    ///   area's start to that area's end (applying §8.3 swap if
+    ///   needed).</item>
+    ///   <item>end = NamedLine matching SAME area → span the full area
+    ///   (= equivalent to `grid-area: name` shorthand).</item>
+    ///   <item>end = integer line number → span from this area's start
+    ///   to that line.</item>
+    ///   <item>end = span N → use this area's start + span N.</item>
+    /// </list></summary>
+    private static PlacementSpec ResolveNamedAreaPlacement(
+        GridAreaRect areaRect, GridLineValue end, bool isRow,
+        GridTemplateAreas areas, SizingContext ctx)
+    {
+        var areaStartLine = isRow ? areaRect.RowStart : areaRect.ColumnStart;
+        var areaEndLine = isRow ? areaRect.RowEnd : areaRect.ColumnEnd;
+        var areaSpan = areaEndLine - areaStartLine;
+
+        if (end.Kind == GridLineKind.Auto)
+        {
+            // Per CSS Grid §8.4 — a single named-area start with auto
+            // end spans the FULL area (= the area's implicit end line
+            // is the same area).
+            return new PlacementSpec(
+                PlacementKind.Definite, areaStartLine, Math.Max(1, areaSpan));
+        }
+        if (end.Kind == GridLineKind.Span)
+        {
+            if (end.NamedLine is not null)
+            {
+                EmitPlacementApproximatedAndFallToAuto(ctx,
+                    "span <named-line> in grid-*-end — using area span");
+                return new PlacementSpec(
+                    PlacementKind.Definite, areaStartLine, Math.Max(1, areaSpan));
+            }
+            var span = Math.Max(1, end.LineNumber);
+            return new PlacementSpec(PlacementKind.Definite, areaStartLine, span);
+        }
+        if (end.Kind == GridLineKind.LineNumber && end.NamedLine is null
+            && end.LineNumber > 0)
+        {
+            var endLine = end.LineNumber;
+            if (endLine == areaStartLine)
+            {
+                return new PlacementSpec(PlacementKind.Definite, areaStartLine, 1);
+            }
+            if (endLine < areaStartLine)
+            {
+                return new PlacementSpec(
+                    PlacementKind.Definite, endLine, areaStartLine - endLine);
+            }
+            return new PlacementSpec(
+                PlacementKind.Definite, areaStartLine, endLine - areaStartLine);
+        }
+        if (end.Kind == GridLineKind.NamedLine && end.NamedLine is not null
+            && areas.NameToRect.TryGetValue(end.NamedLine, out var endAreaRect))
+        {
+            var endLine = isRow ? endAreaRect.RowEnd : endAreaRect.ColumnEnd;
+            if (endLine == areaStartLine)
+            {
+                return new PlacementSpec(PlacementKind.Definite, areaStartLine, 1);
+            }
+            if (endLine < areaStartLine)
+            {
+                return new PlacementSpec(
+                    PlacementKind.Definite, endLine, areaStartLine - endLine);
+            }
+            return new PlacementSpec(
+                PlacementKind.Definite, areaStartLine, endLine - areaStartLine);
+        }
+        // Unknown / unsupported end shape — span the full area on
+        // this axis. The diagnostic surfaces the deviation.
+        EmitPlacementApproximatedDiagnostic(ctx,
+            $"named-area-start with grid-*-end kind {end.Kind} "
+            + "(named line / negative line) uses the area's full span");
+        return new PlacementSpec(
+            PlacementKind.Definite, areaStartLine, Math.Max(1, areaSpan));
     }
 
     private static PlacementSpec EmitPlacementApproximatedAndFallToAuto(

--- a/src/NetPdf.SourceGen/CssPropertyGenerator.cs
+++ b/src/NetPdf.SourceGen/CssPropertyGenerator.cs
@@ -76,7 +76,10 @@ public sealed class CssPropertyGenerator : IIncrementalGenerator
         // (= grid-template-rows / grid-template-columns); GridLine
         // encodes grid-row-start / -end / grid-column-start / -end
         // (= auto / <integer> / span <integer> / <ident>).
-        "GridTemplateList", "GridLine",
+        // Phase 3 Task 18 cycle 7a — GridTemplateAreas stores the
+        // parsed AST for the multi-string `grid-template-areas` value
+        // (= 2-D map of named cell regions).
+        "GridTemplateList", "GridLine", "GridTemplateAreas",
         "Custom",
     };
 

--- a/tests/NetPdf.RealDocuments/Css/PropertyCoverageCorpusTests.cs
+++ b/tests/NetPdf.RealDocuments/Css/PropertyCoverageCorpusTests.cs
@@ -113,10 +113,11 @@ public sealed class PropertyCoverageCorpusTests
         // grid-auto-columns / grid-auto-rows / grid-auto-flow promoted
         // out of the allowlist by Phase 3 Task 18 cycle 6 (span +
         // implicit tracks + auto-flow direction).
+        // grid-template-areas promoted by Phase 3 Task 18 cycle 7a.
         "grid-area",
         "grid-column", "grid-column-gap",
         "grid-row", "grid-row-gap",
-        "grid-template", "grid-template-areas",
+        "grid-template",
         "gap", "row-gap",
         // column-gap promoted out of the allowlist by Phase 3 Task 14
         // cycle 1 — the property is now registered + resolves via the

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/PropertyDefaultsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/PropertyDefaultsParityTests.cs
@@ -144,6 +144,13 @@ public sealed class PropertyDefaultsParityTests
             // wiring in cycle 0b promotes them to Resolved.
             PropertyType.GridTemplateList,
             PropertyType.GridLine,
+            // Per Phase 3 Task 18 cycle 7a — GridTemplateAreas joined
+            // the resolved family. Routes through
+            // GridTemplateAreasResolver; the default `none` resolves
+            // to Keyword(0) (= no side-table entry), and any non-
+            // default value lands the parsed 2-D map in the
+            // side-table.
+            PropertyType.GridTemplateAreas,
         };
 
         var failures = new List<string>();
@@ -205,6 +212,13 @@ public sealed class PropertyDefaultsParityTests
             // wiring in cycle 0b promotes them to Resolved.
             PropertyType.GridTemplateList,
             PropertyType.GridLine,
+            // Per Phase 3 Task 18 cycle 7a — GridTemplateAreas joined
+            // the resolved family. Routes through
+            // GridTemplateAreasResolver; the default `none` resolves
+            // to Keyword(0) (= no side-table entry), and any non-
+            // default value lands the parsed 2-D map in the
+            // side-table.
+            PropertyType.GridTemplateAreas,
         };
 
         var failures = new List<string>();

--- a/tests/NetPdf.UnitTests/Css/Properties/GridTemplateAreasResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/Properties/GridTemplateAreasResolverTests.cs
@@ -171,4 +171,147 @@ public sealed class GridTemplateAreasResolverTests
         using var style = Materialize("inherit", out var sink);
         Assert.NotEmpty(sink.Diagnostics);
     }
+
+    // =================================================================
+    //  PR-#105 review F1 — DoS guard caps.
+    // =================================================================
+
+    [Fact]
+    public void F1_source_exceeding_max_length_rejected()
+    {
+        var huge = new string('a', GridTemplateAreasResolver.MaxSourceLength + 1);
+        using var style = Materialize($"\"{huge}\"", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        Assert.Contains("source length", sink.Diagnostics[0].Message);
+    }
+
+    [Fact]
+    public void F1_too_many_rows_rejected()
+    {
+        var sb = new System.Text.StringBuilder();
+        for (var i = 0; i < GridTemplateAreasResolver.MaxRows + 1; i++)
+        {
+            sb.Append("\"a\" ");
+        }
+        using var style = Materialize(sb.ToString(), out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        Assert.Contains("MaxRows", sink.Diagnostics[0].Message);
+    }
+
+    [Fact]
+    public void F1_too_many_columns_rejected()
+    {
+        var sb = new System.Text.StringBuilder("\"");
+        for (var i = 0; i < GridTemplateAreasResolver.MaxColumns + 1; i++)
+        {
+            sb.Append("a ");
+        }
+        sb.Append("\"");
+        using var style = Materialize(sb.ToString(), out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        Assert.Contains("MaxColumns", sink.Diagnostics[0].Message);
+    }
+
+    [Fact]
+    public void F1_long_ident_rejected()
+    {
+        var longIdent = new string('a', GridTemplateAreasResolver.MaxIdentLength + 1);
+        using var style = Materialize($"\"{longIdent}\"", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        Assert.Contains("MaxIdentLength", sink.Diagnostics[0].Message);
+    }
+
+    // =================================================================
+    //  PR-#105 review F2 — TryValidate shares rectangle validation.
+    // =================================================================
+
+    [Fact]
+    public void F2_TryValidate_rejects_non_rectangular_template()
+    {
+        // Pre-fix TryValidate skipped the rectangle pass + would have
+        // admitted L-shaped templates.
+        Assert.False(GridTemplateAreasResolver.TryValidate(
+            "\"head head\" \"head .\""));
+    }
+
+    [Fact]
+    public void F2_TryValidate_accepts_valid_template()
+    {
+        Assert.True(GridTemplateAreasResolver.TryValidate(
+            "\"head head\" \"main side\" \"foot foot\""));
+    }
+
+    [Fact]
+    public void F2_TryValidate_accepts_none_and_empty()
+    {
+        Assert.True(GridTemplateAreasResolver.TryValidate("none"));
+        Assert.True(GridTemplateAreasResolver.TryValidate(""));
+        Assert.True(GridTemplateAreasResolver.TryValidate("   "));
+    }
+
+    [Fact]
+    public void F2_TryValidate_rejects_oversized_source()
+    {
+        var huge = new string('a', GridTemplateAreasResolver.MaxSourceLength + 1);
+        Assert.False(GridTemplateAreasResolver.TryValidate($"\"{huge}\""));
+    }
+
+    // =================================================================
+    //  PR-#105 review F3 — CSS string escape handling.
+    // =================================================================
+
+    [Fact]
+    public void F3_hex_escape_in_area_name_decodes()
+    {
+        // \61 = 'a'. So "\\61bc" decodes to "abc".
+        using var style = Materialize("\"\\61 bc\"", out var sink);
+        Assert.Empty(sink.Diagnostics);
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Single(areas.NameToRect);
+        Assert.Contains("abc", areas.NameToRect.Keys);
+    }
+
+    [Fact]
+    public void F3_literal_escape_in_area_name()
+    {
+        // "\\zhead" → "zhead" (= backslash + next-char escape for
+        // non-hex characters appends the literal next char).
+        using var style = Materialize("\"\\zhead\"", out var sink);
+        Assert.Empty(sink.Diagnostics);
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Contains("zhead", areas.NameToRect.Keys);
+    }
+
+    [Fact]
+    public void F3_non_ascii_ident_accepted()
+    {
+        // Per CSS Syntax §4.4 — non-ASCII identifier code points are
+        // allowed.
+        using var style = Materialize("\"α α\" \"β γ\"", out var sink);
+        Assert.Empty(sink.Diagnostics);
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Equal(3, areas.NameToRect.Count);
+        Assert.Contains("α", areas.NameToRect.Keys);
+    }
+
+    [Fact]
+    public void F3_dangling_backslash_rejected()
+    {
+        using var style = Materialize("\"a\\", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+    }
+
+    // =================================================================
+    //  PR-#105 review F10 — invalid cell character reports actual reason.
+    // =================================================================
+
+    [Fact]
+    public void F10_invalid_cell_character_reports_position()
+    {
+        using var style = Materialize("\"head @ side\"", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        var msg = sink.Diagnostics[0].Message;
+        Assert.Contains("@", msg);
+        Assert.Contains("row 1", msg);
+    }
 }

--- a/tests/NetPdf.UnitTests/Css/Properties/GridTemplateAreasResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/Properties/GridTemplateAreasResolverTests.cs
@@ -1,0 +1,174 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.ComputedValues.PropertyResolvers;
+using NetPdf.Css.Diagnostics;
+using NetPdf.Css.Properties;
+using Xunit;
+
+namespace NetPdf.UnitTests.Css.Properties;
+
+/// <summary>
+/// Phase 3 Task 18 cycle 7a — CSS parser/resolver tests for
+/// <see cref="GridTemplateAreasResolver"/>. Covers the multi-string
+/// syntax + name → rectangle map derivation + validation invariants
+/// per CSS Grid L1 §7.3.
+/// </summary>
+public sealed class GridTemplateAreasResolverTests
+{
+    private sealed class CapturingSink : ICssDiagnosticsSink
+    {
+        public List<CssDiagnostic> Diagnostics { get; } = new();
+        public void Emit(CssDiagnostic d) => Diagnostics.Add(d);
+    }
+
+    private static ComputedStyle Materialize(string value, out CapturingSink sink)
+    {
+        sink = new CapturingSink();
+        var result = PropertyResolverDispatch.Resolve(
+            PropertyId.GridTemplateAreas, value, sink);
+        var style = ComputedStyle.Rent();
+        result.MaterializeInto(style, PropertyId.GridTemplateAreas);
+        return style;
+    }
+
+    [Fact]
+    public void None_keyword_resolves_to_default_without_side_table()
+    {
+        using var style = Materialize("none", out var sink);
+        Assert.Empty(sink.Diagnostics);
+
+        var slot = style.Get(PropertyId.GridTemplateAreas);
+        Assert.Equal(ComputedSlotTag.Keyword, slot.Tag);
+        Assert.Equal(GridTemplateAreasResolver.KeywordIdNone, slot.AsKeyword());
+        Assert.Equal(GridTemplateAreas.None, style.ReadGridTemplateAreas());
+    }
+
+    [Fact]
+    public void Single_row_single_name_builds_one_area()
+    {
+        using var style = Materialize("\"head\"", out var sink);
+        Assert.Empty(sink.Diagnostics);
+
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Equal(1, areas.RowCount);
+        Assert.Equal(1, areas.ColumnCount);
+        Assert.Single(areas.NameToRect);
+        Assert.Equal(new GridAreaRect(1, 2, 1, 2), areas.NameToRect["head"]);
+        Assert.Equal("head", areas[0, 0]);
+    }
+
+    [Fact]
+    public void Multi_row_invoice_template_builds_three_areas()
+    {
+        // Classic invoice template: header row spans both cols; main
+        // + sidebar split row 2; footer spans both cols in row 3.
+        using var style = Materialize(
+            "\"head head\" \"main side\" \"foot foot\"",
+            out var sink);
+        Assert.Empty(sink.Diagnostics);
+
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Equal(3, areas.RowCount);
+        Assert.Equal(2, areas.ColumnCount);
+        Assert.Equal(4, areas.NameToRect.Count);
+
+        // head: rows 1-2 (= 1-based line 1 to 2), cols 1-3 (= span 2).
+        Assert.Equal(new GridAreaRect(1, 2, 1, 3), areas.NameToRect["head"]);
+        Assert.Equal(new GridAreaRect(2, 3, 1, 2), areas.NameToRect["main"]);
+        Assert.Equal(new GridAreaRect(2, 3, 2, 3), areas.NameToRect["side"]);
+        Assert.Equal(new GridAreaRect(3, 4, 1, 3), areas.NameToRect["foot"]);
+    }
+
+    [Fact]
+    public void Period_token_is_null_cell()
+    {
+        using var style = Materialize(
+            "\"head . head\" \"main main main\"", out var sink);
+        // "head . head" is invalid: head appears in non-rectangular
+        // positions (col 1 and col 3, but not col 2). Expect Invalid.
+        Assert.NotEmpty(sink.Diagnostics);
+    }
+
+    [Fact]
+    public void Period_token_excluded_from_name_map()
+    {
+        using var style = Materialize("\"head .\" \"foot foot\"", out var sink);
+        Assert.Empty(sink.Diagnostics);
+
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Equal(2, areas.RowCount);
+        Assert.Equal(2, areas.ColumnCount);
+        Assert.Null(areas[0, 1]);
+        Assert.Equal("head", areas[0, 0]);
+        Assert.Equal(2, areas.NameToRect.Count);
+        Assert.Equal(new GridAreaRect(1, 2, 1, 2), areas.NameToRect["head"]);
+        Assert.Equal(new GridAreaRect(2, 3, 1, 3), areas.NameToRect["foot"]);
+    }
+
+    [Fact]
+    public void Multiple_periods_count_as_single_null_cell()
+    {
+        // Per §7.3 — "a sequence of one or more . characters" is one
+        // null cell.
+        using var style = Materialize(
+            "\"head ...\" \"main main\"", out var sink);
+        Assert.Empty(sink.Diagnostics);
+
+        var areas = style.ReadGridTemplateAreas();
+        Assert.Equal(2, areas.ColumnCount);
+        Assert.Null(areas[0, 1]);
+    }
+
+    [Fact]
+    public void Ragged_rows_rejected()
+    {
+        using var style = Materialize(
+            "\"head head\" \"main\"", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        var d = sink.Diagnostics[0];
+        Assert.Equal(CssDiagnosticCodes.CssPropertyValueInvalid001, d.Code);
+        Assert.Contains("ragged rows", d.Message);
+    }
+
+    [Fact]
+    public void Non_rectangular_named_area_rejected()
+    {
+        // L-shape: head occupies (0,0), (0,1), (1,0) — not a rectangle.
+        using var style = Materialize(
+            "\"head head\" \"head .\"", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+        Assert.Equal(CssDiagnosticCodes.CssPropertyValueInvalid001,
+            sink.Diagnostics[0].Code);
+    }
+
+    [Fact]
+    public void Empty_value_rejected()
+    {
+        using var style = Materialize("\"\"", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+    }
+
+    [Fact]
+    public void Unquoted_value_rejected()
+    {
+        using var style = Materialize("head head", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+    }
+
+    [Fact]
+    public void Unclosed_string_rejected()
+    {
+        using var style = Materialize("\"head", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+    }
+
+    [Fact]
+    public void Css_wide_keyword_rejected_defense_in_depth()
+    {
+        using var style = Materialize("inherit", out var sink);
+        Assert.NotEmpty(sink.Diagnostics);
+    }
+}

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -63,6 +63,7 @@ public sealed class DeferralsParityTests
         "grid-fragment-plan-shared-sizing-deferral",
         "grid-spanning-item-intrinsic-distribution-deferral",
         "grid-reverse-auto-placement-deferral",
+        "grid-named-line-placement-deferral",
         "recursive-block-continuation-consumed-extent-accounting-deferral",
     };
 

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -1536,6 +1536,71 @@ public sealed class GridLayouterProductionTests
     }
 
     // ====================================================================
+    //  PR-#105 review F6 — cross-feature integration: named-area
+    //  placement (cycle 7a) + spanning-pagination atomicity (cycle 6b).
+    // ====================================================================
+
+    [Fact]
+    public async Task F6_named_area_spanning_two_rows_defers_atomically_across_pages()
+    {
+        // grid-template-areas declares a `tall` area spanning rows 2+3.
+        // Each row is 100px; page budget = 150px fits row 1 + half of
+        // row 2 naively. Per cycle 6b's atomicity contract, the
+        // `tall` spanning item defers entirely to page 2; per cycle
+        // 7a's named-area resolution, the placement comes from the
+        // areas map (= no fallback path). Proves both features
+        // integrate cleanly.
+        // No explicit grid `height` — exercises cycle 6a's auto-
+        // height paginatable path (= the `grid-explicit-height-
+        // paginate-deferral` is intentionally avoided here).
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .grid {
+                    display: grid;
+                    grid-template-rows: 100px 100px 100px;
+                    grid-template-columns: 100px;
+                    grid-template-areas:
+                        "head"
+                        "tall"
+                        "tall";
+                    width: 100px;
+                }
+                .h { grid-area: head; }
+                .t { grid-area: tall; }
+            </style></head><body>
+                <div class="grid">
+                    <div class="h"></div>
+                    <div class="t"></div>
+                </div>
+            </body></html>
+            """;
+
+        var pages = await RenderMultiPageAsync(
+            html, contentInlineSize: 100, blockSize: 150, maxPages: 4);
+
+        Assert.True(pages.Count >= 2,
+            $"Expected ≥ 2 pages; got {pages.Count}");
+
+        // Page 1: only `head` emits (tall defers atomically per cycle
+        // 6b). If cycle 6b's atomicity contract had broken, tall
+        // would have started on page 1 with its rectangle straddling
+        // the page break.
+        var headOnPage1 = FindByClass(pages[0].Sink, "h");
+        var tallOnPage1 = FindByClass(pages[0].Sink, "t");
+        Assert.NotNull(headOnPage1);
+        Assert.Null(tallOnPage1);
+
+        // Page 2: `tall` emits at its full 200px span. If cycle 7a's
+        // named-area resolution had fallen back to auto, the item
+        // would have landed at a single cell, not the 200px named
+        // area.
+        var tallOnPage2 = FindByClass(pages[1].Sink, "t");
+        Assert.NotNull(tallOnPage2);
+        Assert.Equal(200, tallOnPage2!.Value.BlockSize, precision: 3);
+        Assert.Equal(100, tallOnPage2.Value.InlineSize, precision: 3);
+    }
+
+    // ====================================================================
     //  Pipeline driver — mirrors FlexLayouterProductionTests.
     // ====================================================================
 

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -1469,6 +1469,73 @@ public sealed class GridLayouterProductionTests
     }
 
     // ====================================================================
+    //  Phase 3 Task 18 cycle 7a — grid-template-areas + grid-area
+    // ====================================================================
+
+    [Fact]
+    public async Task Cycle7a_production_grid_template_areas_lays_out_named_items()
+    {
+        // Real HTML with `grid-template-areas` + `grid-area: name` on
+        // children. Items lay out in the named rectangles per CSS Grid
+        // §7.3 + §8.4. The grid-area shorthand expander (cycle 0c)
+        // routes the name to all four longhands; cycle 7a's placement
+        // service resolves it via grid-template-areas.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .grid {
+                    display: grid;
+                    grid-template-rows: 100px 100px 50px;
+                    grid-template-columns: 100px 100px;
+                    grid-template-areas:
+                        "head head"
+                        "main side"
+                        "foot foot";
+                }
+                .h { grid-area: head; }
+                .m { grid-area: main; }
+                .s { grid-area: side; }
+                .f { grid-area: foot; }
+            </style></head><body>
+            <div class="grid">
+                <div class="h"></div>
+                <div class="m"></div>
+                <div class="s"></div>
+                <div class="f"></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _, _) = await RenderViaFullPipelineAsync(html);
+
+        var h = FindByClass(sink, "h");
+        var m = FindByClass(sink, "m");
+        var s = FindByClass(sink, "s");
+        var f = FindByClass(sink, "f");
+        Assert.NotNull(h); Assert.NotNull(m); Assert.NotNull(s); Assert.NotNull(f);
+
+        // head: row 0, cols 0+1 → 200×100 at (0, 0).
+        Assert.Equal(0, h!.Value.InlineOffset, precision: 3);
+        Assert.Equal(0, h.Value.BlockOffset, precision: 3);
+        Assert.Equal(200, h.Value.InlineSize, precision: 3);
+        Assert.Equal(100, h.Value.BlockSize, precision: 3);
+        // main: row 1, col 0 → 100×100 at (0, 100).
+        Assert.Equal(0, m!.Value.InlineOffset, precision: 3);
+        Assert.Equal(100, m.Value.BlockOffset, precision: 3);
+        Assert.Equal(100, m.Value.InlineSize, precision: 3);
+        Assert.Equal(100, m.Value.BlockSize, precision: 3);
+        // side: row 1, col 1 → 100×100 at (100, 100).
+        Assert.Equal(100, s!.Value.InlineOffset, precision: 3);
+        Assert.Equal(100, s.Value.BlockOffset, precision: 3);
+        Assert.Equal(100, s.Value.InlineSize, precision: 3);
+        Assert.Equal(100, s.Value.BlockSize, precision: 3);
+        // foot: row 2, cols 0+1 → 200×50 at (0, 200).
+        Assert.Equal(0, f!.Value.InlineOffset, precision: 3);
+        Assert.Equal(200, f.Value.BlockOffset, precision: 3);
+        Assert.Equal(200, f.Value.InlineSize, precision: 3);
+        Assert.Equal(50, f.Value.BlockSize, precision: 3);
+    }
+
+    // ====================================================================
     //  Pipeline driver — mirrors FlexLayouterProductionTests.
     // ====================================================================
 

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
@@ -3850,6 +3850,139 @@ public sealed class GridLayouterTests
     }
 
     // =====================================================================
+    //  Phase 3 Task 18 cycle 7a — grid-template-areas + named-area
+    //  placement (= `grid-row-start: head`, `grid-area: head` etc.).
+    // =====================================================================
+
+    [Fact]
+    public void Cycle7a_named_area_start_with_auto_end_spans_full_area_on_axis()
+    {
+        // grid-template-areas: "head head" "main side" — 2-row × 2-col
+        // grid. `grid-row-start: head` (without explicit end) spans
+        // the FULL head area on the row axis (= 1 row, since head is
+        // one row tall). Pair with grid-column-start auto → auto-
+        // placed column.
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(
+            rowsPx: new[] { 100.0, 100.0 },
+            colsPx: new[] { 50.0, 150.0 });
+        SetGridTemplateAreas(grid, "\"head head\" \"main side\"");
+        var item = BuildItemWithNamedAreaStarts(rowName: "head", colName: null);
+        grid.AppendChild(item);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Single(sink.Fragments);
+        AssertFragmentEquals(sink, item,
+            inlineOffset: 0, blockOffset: 0,
+            inlineSize: 50, blockSize: 100);
+    }
+
+    [Fact]
+    public void Cycle7a_grid_area_shorthand_lands_item_in_full_named_area()
+    {
+        // `grid-area: head` shorthand expands to all four longhands
+        // as `head`. Per cycle-7a placement, this lands the item in
+        // the full head rectangle (= 1 row × 2 cols, total 200px wide).
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(
+            rowsPx: new[] { 100.0, 100.0 },
+            colsPx: new[] { 50.0, 150.0 });
+        SetGridTemplateAreas(grid, "\"head head\" \"main side\"");
+        var item = BuildItemWithNamedAreaStartsAndEnds(
+            rowStart: "head", rowEnd: "head",
+            colStart: "head", colEnd: "head");
+        grid.AppendChild(item);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Single(sink.Fragments);
+        AssertFragmentEquals(sink, item,
+            inlineOffset: 0, blockOffset: 0,
+            inlineSize: 200, blockSize: 100);
+    }
+
+    [Fact]
+    public void Cycle7a_named_area_main_lands_at_row_2_col_1()
+    {
+        // The `main` area is at row 2 col 1 in the invoice template.
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(
+            rowsPx: new[] { 100.0, 100.0 },
+            colsPx: new[] { 50.0, 150.0 });
+        SetGridTemplateAreas(grid, "\"head head\" \"main side\"");
+        var item = BuildItemWithNamedAreaStartsAndEnds(
+            rowStart: "main", rowEnd: "main",
+            colStart: "main", colEnd: "main");
+        grid.AppendChild(item);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Single(sink.Fragments);
+        AssertFragmentEquals(sink, item,
+            inlineOffset: 0, blockOffset: 100,
+            inlineSize: 50, blockSize: 100);
+    }
+
+    [Fact]
+    public void Cycle7a_unknown_area_name_falls_back_to_auto_with_diagnostic()
+    {
+        // `grid-row-start: nope` where "nope" isn't an area name → auto
+        // placement + diagnostic.
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(
+            rowsPx: new[] { 100.0 },
+            colsPx: new[] { 50.0 });
+        SetGridTemplateAreas(grid, "\"head\"");
+        var item = BuildItemWithNamedAreaStarts(rowName: "nope", colName: null);
+        grid.AppendChild(item);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Single(sink.Fragments);
+        Assert.Contains(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
+    }
+
+    [Fact]
+    public void Cycle7a_three_row_template_spans_via_named_area()
+    {
+        // 3-row template; an item in the foot area lands at row 3.
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(
+            rowsPx: new[] { 100.0, 100.0, 50.0 },
+            colsPx: new[] { 100.0, 100.0 });
+        SetGridTemplateAreas(grid,
+            "\"head head\" \"main side\" \"foot foot\"");
+        var item = BuildItemWithNamedAreaStartsAndEnds(
+            rowStart: "foot", rowEnd: "foot",
+            colStart: "foot", colEnd: "foot");
+        grid.AppendChild(item);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Single(sink.Fragments);
+        AssertFragmentEquals(sink, item,
+            inlineOffset: 0, blockOffset: 200,
+            inlineSize: 200, blockSize: 50);
+    }
+
+    // =====================================================================
     //  PR-#103 review F1–F7 — coverage for the review-pass-resolved
     //  findings: implicit-only grids, captured-explicit-count negative
     //  resolution, sparse-occupancy DoS guard, auto-flow:column
@@ -4375,6 +4508,63 @@ public sealed class GridLayouterTests
         var keywordId = flow == GridAutoFlowValue.Column ? 1 : 0;
         grid.Style.Set(PropertyId.GridAutoFlow,
             ComputedSlot.FromKeyword(keywordId));
+    }
+
+    /// <summary>Per Phase 3 Task 18 cycle 7a — set the
+    /// <c>grid-template-areas</c> property on the grid container by
+    /// invoking the CSS resolver pipeline against the literal CSS
+    /// value (e.g., <c>"head head" "main side"</c>). The parsed AST
+    /// lands in the side-table.</summary>
+    private static void SetGridTemplateAreas(Box grid, string cssValue)
+    {
+        var result = NetPdf.Css.ComputedValues.PropertyResolvers
+            .PropertyResolverDispatch.Resolve(
+                PropertyId.GridTemplateAreas, cssValue);
+        result.MaterializeInto(grid.Style, PropertyId.GridTemplateAreas);
+    }
+
+    /// <summary>Per Phase 3 Task 18 cycle 7a — build an item with
+    /// named-area references on <c>grid-row-start</c> /
+    /// <c>grid-column-start</c>. Pass <see langword="null"/> for an
+    /// axis to leave it as auto.</summary>
+    private static Box BuildItemWithNamedAreaStarts(string? rowName, string? colName)
+    {
+        var style = MakeStyle();
+        if (rowName is not null)
+        {
+            var rowValue = GridLineValue.ForNamedLine(rowName);
+            style.SetSideTablePayload(PropertyId.GridRowStart, (object)rowValue);
+            style.Set(PropertyId.GridRowStart, ComputedSlot.FromSideTableIndex(0));
+        }
+        if (colName is not null)
+        {
+            var colValue = GridLineValue.ForNamedLine(colName);
+            style.SetSideTablePayload(PropertyId.GridColumnStart, (object)colValue);
+            style.Set(PropertyId.GridColumnStart, ComputedSlot.FromSideTableIndex(0));
+        }
+        return Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
+    }
+
+    /// <summary>Per Phase 3 Task 18 cycle 7a — build an item with
+    /// named-area references on ALL four placement longhands
+    /// (= the <c>grid-area: name</c> shorthand expansion).</summary>
+    private static Box BuildItemWithNamedAreaStartsAndEnds(
+        string rowStart, string rowEnd, string colStart, string colEnd)
+    {
+        var style = MakeStyle();
+        var rowStartValue = GridLineValue.ForNamedLine(rowStart);
+        style.SetSideTablePayload(PropertyId.GridRowStart, (object)rowStartValue);
+        style.Set(PropertyId.GridRowStart, ComputedSlot.FromSideTableIndex(0));
+        var rowEndValue = GridLineValue.ForNamedLine(rowEnd);
+        style.SetSideTablePayload(PropertyId.GridRowEnd, (object)rowEndValue);
+        style.Set(PropertyId.GridRowEnd, ComputedSlot.FromSideTableIndex(0));
+        var colStartValue = GridLineValue.ForNamedLine(colStart);
+        style.SetSideTablePayload(PropertyId.GridColumnStart, (object)colStartValue);
+        style.Set(PropertyId.GridColumnStart, ComputedSlot.FromSideTableIndex(0));
+        var colEndValue = GridLineValue.ForNamedLine(colEnd);
+        style.SetSideTablePayload(PropertyId.GridColumnEnd, (object)colEndValue);
+        style.Set(PropertyId.GridColumnEnd, ComputedSlot.FromSideTableIndex(0));
+        return Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
     }
 
     private static ComputedStyle MakeStyle() => ComputedStyle.RentForExclusiveTesting();

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
@@ -3879,6 +3879,11 @@ public sealed class GridLayouterTests
         AssertFragmentEquals(sink, item,
             inlineOffset: 0, blockOffset: 0,
             inlineSize: 50, blockSize: 100);
+        // Per PR-#105 review F4 — happy-path placement must not emit
+        // any placement-approximated diagnostic; the resolved position
+        // came directly from the named-area lookup.
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
     }
 
     [Fact]
@@ -3906,6 +3911,8 @@ public sealed class GridLayouterTests
         AssertFragmentEquals(sink, item,
             inlineOffset: 0, blockOffset: 0,
             inlineSize: 200, blockSize: 100);
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
     }
 
     [Fact]
@@ -3931,6 +3938,8 @@ public sealed class GridLayouterTests
         AssertFragmentEquals(sink, item,
             inlineOffset: 0, blockOffset: 100,
             inlineSize: 50, blockSize: 100);
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
     }
 
     [Fact]
@@ -3980,6 +3989,82 @@ public sealed class GridLayouterTests
         AssertFragmentEquals(sink, item,
             inlineOffset: 0, blockOffset: 200,
             inlineSize: 200, blockSize: 50);
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
+    }
+
+    // =================================================================
+    //  PR-#105 review F5 — grid-template-areas with missing /
+    //  partial explicit tracks. Cycle 6a's implicit-only path handles
+    //  this when the cascade default for grid-template-rows /
+    //  grid-template-columns is `none`.
+    // =================================================================
+
+    [Fact]
+    public void F5_grid_template_areas_with_no_explicit_tracks_uses_implicit()
+    {
+        // No grid-template-rows / -columns declared. With cycle 6a's
+        // implicit-only grid path, items in the areas map use auto-
+        // sized implicit tracks. Without item dimensions, tracks
+        // collapse to 0; the fragment still gets a valid placement.
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var rowsTrack = TrackList.None;
+        var colsTrack = TrackList.None;
+        var grid = BuildGridContainerWithTemplates(rowsTrack, colsTrack);
+        SetGridTemplateAreas(grid, "\"head head\" \"main side\"");
+        var head = BuildItemWithNamedAreaStartsAndEnds(
+            rowStart: "head", rowEnd: "head",
+            colStart: "head", colEnd: "head");
+        var main = BuildItemWithNamedAreaStartsAndEnds(
+            rowStart: "main", rowEnd: "main",
+            colStart: "main", colEnd: "main");
+        grid.AppendChild(head);
+        grid.AppendChild(main);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        // 2 items emit. Implicit tracks generated past the cycle-6a
+        // 1×1 seed (= rows 0+1, cols 0+1). All sized 0 since items
+        // have no declared dimensions; positions are valid.
+        Assert.Equal(2, sink.Fragments.Count);
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
+    }
+
+    [Fact]
+    public void F5_grid_template_areas_with_partial_explicit_rows_grows_implicit()
+    {
+        // Areas declare 3 rows; explicit grid-template-rows only
+        // declares 2. Cycle 6a's implicit-track generation handles
+        // the third (implicit) row via grid-auto-rows: auto (default).
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(
+            rowsPx: new[] { 100.0, 100.0 },
+            colsPx: new[] { 100.0, 100.0 });
+        SetGridTemplateAreas(grid,
+            "\"head head\" \"main side\" \"foot foot\"");
+        var foot = BuildItemWithNamedAreaStartsAndEnds(
+            rowStart: "foot", rowEnd: "foot",
+            colStart: "foot", colEnd: "foot");
+        grid.AppendChild(foot);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Single(sink.Fragments);
+        // foot occupies row 2 (= 1-based row 3 = 0-based 2, past the
+        // 2 explicit rows). blockOffset = 200 (two 100px rows above);
+        // blockSize = 0 (implicit row auto-sized; no item content).
+        AssertFragmentEquals(sink, foot,
+            inlineOffset: 0, blockOffset: 200,
+            inlineSize: 200, blockSize: 0);
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutGridPlacementApproximated001);
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary

Per `docs/phases/task-17-grid-design.md` §3 cycle 7. First of four cycle-7 features (named lines from `grid-template-rows/-columns` = 7b; `repeat(auto-fill/auto-fit)` = 7c; `grid-auto-flow: dense` = 7d ship in follow-up cycles).

Ships the `grid-template-areas` multi-string parser + named-area placement via `grid-row-start: name` / `grid-area: name` shorthand. Items can now lay out into the named rectangles declared by an invoice-style template:

```css
.grid {
  display: grid;
  grid-template-rows: 100px 100px 50px;
  grid-template-columns: 100px 100px;
  grid-template-areas:
    "head head"
    "main side"
    "foot foot";
}
.header { grid-area: head; }   /* 200×100 at (0, 0)   */
.main   { grid-area: main; }   /* 100×100 at (0, 100) */
.side   { grid-area: side; }   /* 100×100 at (100, 100) */
.footer { grid-area: foot; }   /* 200×50  at (0, 200) */
```

## Changes

- **AST** (`Grid.cs`): new `GridTemplateAreas` record (RowCount, ColumnCount, flat row-major Cells array, NameToRect map) + `GridAreaRect` (1-based inclusive-start, exclusive-end line numbers).
- **PropertyType** + properties.json: new `GridTemplateAreas = 26` type; `grid-template-areas` property registered. SourceGen allowlist updated.
- **Resolver** (`GridTemplateAreasResolver`): tokenizes quoted-string rows, splits on whitespace, derives the name → rectangle map, validates:
  - same column count across rows (= rejects ragged rows)
  - every named cell forms a single rectangle (= rejects L-shapes / disjoint regions)
  - period tokens are null cells (multiple periods collapse to one)
  - empty / unquoted / unclosed strings rejected with diagnostic
  - CSS-wide keywords rejected (defense in depth)
- **Reader** (`GridReaders.ReadGridTemplateAreas`): mirrors the existing grid-readers pattern.
- **Placement** (`GridSizing.ReadPlacement`): now takes the parent's `GridTemplateAreas` map. Resolves `grid-row-start: name` (and per-axis end variants) against the area map; falls back to auto with diagnostic when the ident doesn't match an area name (= ident might be a cycle-7b named line). New `ResolveNamedAreaPlacement` helper covers the named-start × end-spec matrix.

## Test plan

- [x] **5164 unit** (+18 cycle 7a tests vs cycle 6a's 5146 baseline):
  - `GridTemplateAreasResolverTests` (12) — parser AST + invariants
  - `GridLayouterTests` `Cycle7a_*` (5) — layouter placement
  - `GridLayouterProductionTests` `Cycle7a_production_*` (1) — full HTML pipeline
- [x] **97 RealDocs** / **30 LayoutSnapshots** / **4 AotJitParity** / **3 DeferralsParity**
- [x] AOT/JIT byte-parity sha256 preserved
- [x] `0` warnings under `-warnaserror`

## Deferred / known gaps

- **Cycle 7b** — named lines via `grid-template-rows: [foo] 100px [bar]` syntax. The ident path in `ReadPlacement` falls back to auto when no area matches; cycle 7b will check the parent's named-line map next.
- **Cycle 7c** — `repeat(auto-fill, ...)` / `repeat(auto-fit, ...)`. Currently emits the existing unsupported-track-kind diagnostic.
- **Cycle 7d** — `grid-auto-flow: dense` backtracking. Currently `dense` falls through to the cycle-6 row-mode sparse cursor.
- **`grid-reverse-auto-placement-deferral`** still tracks the auto-start + definite-end simplification (= now exercised by cycle 7a's auto-start + named-area-end path too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)