### PR TITLE
Phase 3 Task 17 cycle 5c.3: F3 explicit-height grid pagination

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2173,45 +2173,24 @@ flags the categories):
 ## grid-explicit-height-paginate-deferral
 
 - **ID** — `grid-explicit-height-paginate-deferral`
-- **Status** — `shipped (Phase 3 Task 17 cycle 5c.3)`. Initial
-  cycle-5c.2c F3 mechanism was REVERTED (cycle 5b post-PR-#97
-  review F3 + cycle 5c.2c post-PR-#101 review P1#1); the
-  cycle-5c.3 dual-input fix ships explicit-height grid
-  pagination via the minimum-viable "authored geometry for
-  row sizing, clamped geometry for page budget" separation,
-  without requiring the full
-  `grid-fragment-plan-shared-sizing-deferral` shared plan.
-- **Behavior** — grids with explicit `height: 300px` style get
-  their natural extent restored by
+- **Status** — `approximated` (mechanism shipped end-to-end +
+  verified by Cycle5c3_* unit + production-pipeline tests;
+  residual approximation lives only in the cursor-advance
+  bookkeeping where the ancestor's `marginBoxBlockSizeForCursor`
+  reads the projected subtree extent — see *Residual
+  approximation* below). Phase 3 Task 17 cycle 5c.3 +
+  post-PR-#110 review P1#1+P1#2.
+- **Behavior (pre-5c.3)** — grids with explicit `height: 300px`
+  style had their natural extent restored by
   `MeasureSubtreeVisualBlockExtent` AFTER the paginatable-grid
   clamp would have shrunk `borderBoxBlockSize`. The resolver
-  path then sees a 300px chunk on a 250px page → forced-overflow
-  branch, which dispatches grid atomically (`allowPagination:
-  false`). So even with cycle 5b's outer-site wiring active,
-  explicit-height grids would never paginate.
-- **Missing** —
-  - A shared per-attempt grid plan (see
-    `grid-fragment-plan-shared-sizing-deferral`) that
-    SEPARATES resolved grid geometry (= rows / fr / placement
-    computed against authored `height`) from per-fragment
-    budget (= page-remaining capacity). The cycle 5c.2c
-    initial implementation conflated these — clamping
-    `borderBoxBlockSize` to fragment budget fed the shrunk
-    size into `GridSizing.Resolve` as `contentBlockSize`,
-    causing fr / definite-height row sizing to redistribute
-    against the smaller budget (e.g.,
-    <c>height: 400px; grid-template-rows: 100px 1fr</c> on a
-    250px page resolved rows as (100, 150) instead of the
-    authored (100, 300), silently losing 150px of authored
-    geometry).
-  - With a shared plan, the paginatable-grid clamp can carry
-    the post-clamp page budget without re-resolving the grid
-    against it; the resolved row geometry stays authoritative.
+  path saw a 300px chunk on a 250px page → forced-overflow
+  branch → atomic grid dispatch (`allowPagination: false`). So
+  even with cycle 5b's outer-site wiring active, explicit-
+  height grids would never paginate.
 - **Cycle 5c.2c INITIAL → REVERTED** — added a subtree-extent
   clamp in `MeasureSubtreeVisualBlockExtent`'s outer
-  consumer (= when `paginateGridForOuterChild`, cap subtree
-  extent back to post-clamp `borderBoxBlockSize`); also
-  removed the cycle-5c.2b post-PR-#100 review P1#3
+  consumer + removed the cycle-5c.2b post-PR-#100 review P1#3
   `IsHeightAuto(child)` gate. PR-#101 review correctly
   identified that this changed row sizing inputs to
   GridSizing.Resolve — the subtree clamp without
@@ -2219,59 +2198,95 @@ flags the categories):
   height row resolution. Reverted to the cycle-5c.2b-post-
   PR-#100 state: `IsHeightAuto(child)` gates the outer-site
   clamp; explicit-height grids stay atomic.
-- **Practical impact** — explicit-height grids in invoices /
-  reports still render past page edges via forced-overflow,
-  same as cycle 5b. The F1 + F2 + clamp pipeline applies only
-  to auto-height grids. Authored row geometry is preserved
-  (= no silent loss).
-- **Trigger** — wait for `grid-fragment-plan-shared-sizing-
-  deferral` to land; then F3 can ship cleanly using
-  authored-size resolution for geometry + page-budget for
-  fragmentation.
+- **Resolution (cycle 5c.3 + PR-#110 review P1)** — shipped in
+  three coordinated changes:
+  1. `GridLayouter.ConfigureEmission` gained a `pageBlockBudget`
+     parameter that separates "geometry input" (= authored
+     container extent passed to `GridSizing.Resolve` for row
+     sizing) from "page budget" (= clamped page-remaining
+     capacity that drives `ComputePaginatedRowRange`'s row-
+     fit cut-off). This fixes the cycle-5c.2c row-geometry
+     corruption: fr / definite rows now distribute against
+     authored height, while pagination cuts off at page
+     budget. The BlockLayouter outer + recursive grid
+     dispatch sites capture `authoredBorderBoxBlockSize`
+     pre-clamp + thread it as `contentBlockSize` while
+     passing the clamped value as `pageBlockBudget`.
+  2. `IsHeightAuto(child)` gate is removed from both grid
+     clamps; the subtree-extent clamp is re-enabled (= now
+     safe because the dual-input separation prevents the
+     row-sizing corruption).
+  3. Post-PR-#110 review P1#2 — `MeasureSubtreeVisualBlockExtent`
+     projects paginatable grid descendants to the fragment
+     budget (`min(authoredExtent, fragmentainer.BlockSize)`).
+     Without this, an ancestor's break-check saw the grid's
+     full authored extent → false BreakHere → forced-overflow
+     path → stale `PAGINATION-FORCED-OVERFLOW-001` + an
+     empty trailing page from the forced-overflow's
+     unconditional `ResumeAtChild = childIdx + 1` return.
+     With projection, ancestors' break-checks take the
+     Continue path → no stale diagnostic, no empty tail page,
+     end-to-end emission returns AllDone cleanly when the
+     grid finishes.
+- **Residual approximation** — the projection at (3) caps the
+  ancestor's `subtreeBlockExtent` at the fragment budget,
+  which feeds `marginBoxBlockSizeForCursor` (= ancestor's
+  cursor advance after emit). For an explicit-height grid
+  that emits FEWER rows than fill the budget (e.g.,
+  `height: 200` grid with 2×100 rows on a 150px page emits
+  only row 0 = 100), the ancestor advances by the projected
+  budget (150) instead of the F2-resized wrapper extent
+  (100). The grid wrapper itself ends up at the correct
+  emitted extent via the F2 resize; the over-advance lives
+  only in the ancestor's UsedBlockSize accounting (= ≤
+  page-budget, so the page still closes cleanly without
+  spurious PageComplete). Eliminating this residual requires
+  a measure→emit→re-measure pass or threading the F2 result
+  back through the ancestor's cursor-advance — tracked
+  alongside the broader cursor-accounting work in
+  `recursive-block-continuation-consumed-extent-accounting-deferral`.
+- **Performance follow-on** — the full `GridFragmentPlan`
+  consolidation across pre-measure + F1 + dispatch (=
+  performance optimization that lets the §11 sizing work
+  run ONCE per attempt instead of three times) is still
+  tracked under `grid-fragment-plan-shared-sizing-deferral`.
+  Cycle 5c.3 explicitly chose the minimum-viable correctness
+  fix without the perf consolidation; the perf work is
+  independent + post-v1.
 - **Owner files** —
-  - `src/NetPdf.Layout/Layouters/GridSizing.cs` — `Result`
-    type expanded to immutable `GridFragmentPlan`.
-  - `src/NetPdf.Layout/Layouters/BlockLayouter.cs` —
-    `MeasureSubtreeVisualBlockExtent` + outer-site clamp
-    consume the plan; `IsHeightAuto(child)` gate removed
-    when plan-based separation lands.
   - `src/NetPdf.Layout/Layouters/GridLayouter.cs` —
-    `ConfigureEmission` accepts a pre-computed plan in lieu
-    of running its own `Resolve`.
+    `ConfigureEmission.pageBlockBudget` parameter;
+    `_pageBlockBudget` field; budget threading through
+    `ComputePaginatedRowRange`.
+  - `src/NetPdf.Layout/Layouters/BlockLayouter.cs` —
+    `authoredBorderBoxBlockSize` capture at both grid
+    dispatch sites; subtree-extent clamp re-enabled;
+    `MeasureSubtreeVisualBlockExtentRecursive` projection;
+    `IsHeightAuto(child)` gate removed from both clamps;
+    F1 probe sites use authored geometry.
 - **Added** — Phase 3 Task 17 cycle 5b + post-PR-#97 review F3.
 - **Updated** — Phase 3 Task 17 cycle 5c.2c initial (mechanism
-  attempted) + post-PR-#101 review P1#1 (mechanism reverted).
-- **Removal condition** — `grid-fragment-plan-shared-sizing-
-  deferral` ships AND explicit-height grids on tight pages
-  paginate correctly + don't fall into forced-overflow with
-  pagination disabled AND production HTML fixtures with
-  explicit-height multipage grids verify end-to-end through
-  the full HTML → cascade → BoxBuilder → BlockLayouter chain.
-- **Shipped fix (cycle 5c.3)** — `GridLayouter.ConfigureEmission`
-  gained a `pageBlockBudget` parameter that separates "geometry
-  input" (= the authored container extent passed to
-  `GridSizing.Resolve` for row sizing) from "page budget" (=
-  the clamped page-remaining capacity that drives
-  `ComputePaginatedRowRange`'s row-fit cut-off). The
-  BlockLayouter outer + recursive grid dispatch sites capture
-  `authoredBorderBoxBlockSize` pre-clamp + thread it as the
-  ConfigureEmission `contentBlockSize` while passing the
-  clamped value as `pageBlockBudget`. The
-  `IsHeightAuto(child)` gate on the clamp is removed; the
-  subtree-extent clamp is re-enabled (= now safe because the
-  dual-input separation prevents the row-sizing corruption
-  that the cycle-5c.2c initial attempt produced). The full
-  `GridFragmentPlan` consolidation across pre-measure + F1 +
-  dispatch (= performance optimization that lets the §11
-  sizing work run once per attempt instead of three times)
-  is still tracked under
-  `grid-fragment-plan-shared-sizing-deferral`. KNOWN GAP at
-  the outer-body level: `MeasureSubtreeVisualBlockExtent`
-  isn't grid-paginatable-aware, so the body still triggers
-  `PAGINATION-FORCED-OVERFLOW-001` when its only descendant
-  is a tall paginatable grid; the body's forced-overflow
-  recursion still routes through the F3 recursive dispatch,
-  so end-to-end emission is correct.
+  attempted) + post-PR-#101 review P1#1 (mechanism reverted)
+  + cycle 5c.3 (dual-input fix shipped, outer-site projection
+  pending) + post-PR-#110 review P1#1+P1#2 (outer-site
+  projection shipped, deferral resolved end-to-end except
+  the residual cursor-advance approximation documented
+  above).
+- **Removal condition** — RESOLVED end-to-end for
+  correctness; the residual cursor-advance approximation
+  rolls into `recursive-block-continuation-consumed-extent-
+  accounting-deferral` for the broader unified fix. PR-#110
+  ships dedicated regression tests:
+  `Cycle5c3_explicit_height_grid_with_fr_paginates_with_authored_geometry`
+  (production pipeline, 2 pages exactly, no stale
+  `PAGINATION-FORCED-OVERFLOW-001`, page 2 outcome AllDone,
+  page 2 wrapper at the F2-resized emitted extent),
+  `Cycle5c3_explicit_height_with_fr_rows_preserves_authored_geometry`
+  (resume cache RowBaseSizes = [100, 300] proving fr
+  resolved against authored 400, not clamped 250),
+  `Cycle5c3_recursive_explicit_height_grid_paginates` (asserts
+  the diagnostic does NOT fire end-to-end through the full
+  HTML → cascade → BoxBuilder → BlockLayouter chain).
 
 ---
 

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2173,9 +2173,14 @@ flags the categories):
 ## grid-explicit-height-paginate-deferral
 
 - **ID** — `grid-explicit-height-paginate-deferral`
-- **Status** — `not-started`. Phase 3 Task 17 cycle 5b post-
-  PR-#97 review F3 + cycle 5c.2c post-PR-#101 review P1#1
-  (= initial 5c.2c F3 mechanism REVERTED).
+- **Status** — `shipped (Phase 3 Task 17 cycle 5c.3)`. Initial
+  cycle-5c.2c F3 mechanism was REVERTED (cycle 5b post-PR-#97
+  review F3 + cycle 5c.2c post-PR-#101 review P1#1); the
+  cycle-5c.3 dual-input fix ships explicit-height grid
+  pagination via the minimum-viable "authored geometry for
+  row sizing, clamped geometry for page budget" separation,
+  without requiring the full
+  `grid-fragment-plan-shared-sizing-deferral` shared plan.
 - **Behavior** — grids with explicit `height: 300px` style get
   their natural extent restored by
   `MeasureSubtreeVisualBlockExtent` AFTER the paginatable-grid
@@ -2242,6 +2247,31 @@ flags the categories):
   pagination disabled AND production HTML fixtures with
   explicit-height multipage grids verify end-to-end through
   the full HTML → cascade → BoxBuilder → BlockLayouter chain.
+- **Shipped fix (cycle 5c.3)** — `GridLayouter.ConfigureEmission`
+  gained a `pageBlockBudget` parameter that separates "geometry
+  input" (= the authored container extent passed to
+  `GridSizing.Resolve` for row sizing) from "page budget" (=
+  the clamped page-remaining capacity that drives
+  `ComputePaginatedRowRange`'s row-fit cut-off). The
+  BlockLayouter outer + recursive grid dispatch sites capture
+  `authoredBorderBoxBlockSize` pre-clamp + thread it as the
+  ConfigureEmission `contentBlockSize` while passing the
+  clamped value as `pageBlockBudget`. The
+  `IsHeightAuto(child)` gate on the clamp is removed; the
+  subtree-extent clamp is re-enabled (= now safe because the
+  dual-input separation prevents the row-sizing corruption
+  that the cycle-5c.2c initial attempt produced). The full
+  `GridFragmentPlan` consolidation across pre-measure + F1 +
+  dispatch (= performance optimization that lets the §11
+  sizing work run once per attempt instead of three times)
+  is still tracked under
+  `grid-fragment-plan-shared-sizing-deferral`. KNOWN GAP at
+  the outer-body level: `MeasureSubtreeVisualBlockExtent`
+  isn't grid-paginatable-aware, so the body still triggers
+  `PAGINATION-FORCED-OVERFLOW-001` when its only descendant
+  is a tall paginatable grid; the body's forced-overflow
+  recursion still routes through the F3 recursive dispatch,
+  so end-to-end emission is correct.
 
 ---
 

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -1749,14 +1749,18 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // actual emitted extent (= eliminates the empty
             // trailing space + corrects sibling placement).</para>
             //
-            // <para>F3 (= explicit-height grids) is still deferred
-            // (see <c>docs/deferrals.md</c>
-            // <c>grid-explicit-height-paginate-deferral</c>); the
-            // <see cref="MeasureSubtreeVisualBlockExtent"/> restore
-            // path makes explicit-height grids fall into the
-            // forced-overflow branch. Cycle 5c.2c addresses F3 by
-            // making that helper grid-aware. The recursive-site
-            // wiring + production-pipeline tests land in cycle 5c.2d.
+            // <para>F3 (= explicit-height grids) — SHIPPED in
+            // cycle 5c.3 + post-PR-#110 review P1#2 via the
+            // dual-input <c>pageBlockBudget</c> separation in
+            // <see cref="GridLayouter.ConfigureEmission"/> + the
+            // paginatable-grid projection in
+            // <see cref="MeasureSubtreeVisualBlockExtentRecursive"/>.
+            // See the resolved
+            // <c>grid-explicit-height-paginate-deferral</c> entry
+            // in <c>docs/deferrals.md</c> for the full ship
+            // summary + the residual cursor-advance approximation
+            // tracked under
+            // <c>recursive-block-continuation-consumed-extent-accounting-deferral</c>.
             // </para>
             // Per Phase 3 Task 17 cycle 5c.2b post-PR-#100 review
             // P1#1 — <c>_disableGridPagination</c> gate. Nested
@@ -1769,30 +1773,27 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // discard would silently drop remaining grid rows.
             //
             // <para>Per Phase 3 Task 17 cycle 5c.2c post-PR-#101
-            // review P1#1 — <c>IsHeightAuto(child)</c> gate
-            // RESTORED. The cycle-5c.2c F3 subtree-extent clamp
-            // approach was reverted because the clamp also fed the
-            // shrunk <c>borderBoxBlockSize</c> into
-            // <see cref="GridLayouter.ConfigureEmission"/> /
+            // review P1#1 — <c>IsHeightAuto(child)</c> gate was
+            // RESTORED then REMOVED again by cycle 5c.3 once the
+            // dual-input separation made the clamp safe for
+            // explicit-height grids. The cycle-5c.2c F3 subtree-
+            // extent clamp approach corrupted row geometry because
+            // the clamp fed the shrunk <c>borderBoxBlockSize</c>
+            // into <see cref="GridLayouter.ConfigureEmission"/> /
             // <see cref="GridSizing.Resolve"/> as the
             // <c>contentBlockSize</c>, causing fr / definite-height
             // row sizing to redistribute against the SMALLER
-            // budget — e.g., <c>height: 400px; grid-template-rows:
-            // 100px 1fr</c> on a 250px page would resolve rows as
-            // (100, 150) instead of the authored (100, 300),
-            // silently losing 150px of grid geometry. Explicit-
-            // height pagination needs a shared
-            // <c>GridFragmentPlan</c> that SEPARATES resolved
-            // geometry (= computed against authored container
-            // size) from fragment budget (= per-page emission
-            // capacity); tracked in
-            // <c>grid-fragment-plan-shared-sizing-deferral</c>
-            // (cycle 5c.2b post-PR-#100 review P2) +
-            // <c>grid-explicit-height-paginate-deferral</c>
-            // remains <c>not-started</c> until that plan ships.
-            // Auto-height grids stay clamped — they have no
-            // authored container extent to confuse with the
-            // fragment budget.</para>
+            // budget. Cycle 5c.3's <c>pageBlockBudget</c> parameter
+            // separates "row sizing input" (= authored geometry)
+            // from "page budget" (= clamped geometry); the
+            // dispatch site below computes both + threads them as
+            // separate <see cref="GridLayouter.ConfigureEmission"/>
+            // arguments. The full <c>GridFragmentPlan</c> perf
+            // consolidation across pre-measure + F1 + dispatch is
+            // still tracked under
+            // <c>grid-fragment-plan-shared-sizing-deferral</c>;
+            // <c>grid-explicit-height-paginate-deferral</c> is
+            // RESOLVED end-to-end (see deferrals.md).</para>
             // Per Phase 3 Task 17 cycle 5c.3 — capture the AUTHORED
             // (= pre-clamp) border-box block size so the
             // <see cref="DispatchGridInner"/> call below can pass the
@@ -2659,14 +2660,17 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // discards the result, silently dropping the grid.
             //
             // <para>Per Phase 3 Task 17 cycle 5c.2c post-PR-#101
-            // review P1#3 — F1 ALSO gated by
+            // review P1#3 + cycle 5c.3 — F1 ALSO gated by
             // <c>paginateGridForOuterChild</c>. The outer-site
             // clamp (above, in the pre-grow section) decides
             // whether the dispatch will actually paginate the
-            // grid: only when the wrapper would otherwise overflow
-            // page-remaining AND the chrome fits AND the grid is
-            // auto-height. F1 must mirror that decision — if the
-            // clamp didn't fire, dispatch passes
+            // grid: when the wrapper would otherwise overflow
+            // page-remaining AND the chrome fits. Cycle 5c.3
+            // removed the auto-height-only gate; explicit-height
+            // grids now also participate (their authored row
+            // geometry is preserved via the dual-input dispatch).
+            // F1 must mirror the clamp's decision — if the clamp
+            // didn't fire, dispatch passes
             // <c>allowPagination: false</c>, and a fabricated
             // GridContinuation here would route a continuation
             // that the resume page's F2 (= keyed off
@@ -6390,6 +6394,47 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             return Math.Max(parentBorderBoxBlockSize, tableDriven);
         }
 
+        // Per Phase 3 Task 17 cycle 5c.3 post-PR-#110 review P1#2 —
+        // paginatable grid descendants project to the fragment budget
+        // for the break-check measure. Pre-fix the body's subtree-
+        // extent walk got back the grid's AUTHORED extent (= the
+        // wrapper's own border-box from style — e.g., 200 for
+        // <c>height: 200</c>) which exceeded page-remaining (= 150
+        // on a 150px page) → body's outer break-check fired
+        // BreakHere → forced-overflow path emitted
+        // <see cref="PaginateDiagnosticCodes.PaginationForcedOverflow001"/>
+        // + advanced the body's cursor by the full authored extent,
+        // producing an empty trailing page (= ResumeAtChild past
+        // the last child + a stale diagnostic) even though the
+        // recursive grid dispatch actually paginated cleanly via
+        // F3.
+        //
+        // <para>Projection: <c>min(authoredExtent, pageBlockSize)</c>
+        // — the grid contributes at most one page's worth of extent
+        // to the ancestor's break-check measure. The recursive grid
+        // dispatch site computes its own pageRemaining based on
+        // <c>childBlockOffset</c> + handles the row-by-row
+        // pagination separately, so the over-projection here doesn't
+        // affect emission; only the ancestor's break-check decision.</para>
+        //
+        // <para>Side effect: the ancestor's <c>marginBoxBlockSizeForCursor</c>
+        // also reads <c>subtreeBlockExtent</c>, so the cursor
+        // advance after the ancestor emit is bounded by
+        // pageBlockSize too. F2 wrapper-resize at the recursive
+        // grid dispatch site sets the actual grid wrapper extent
+        // to the emitted-rows extent; any over-advance at the
+        // ancestor level is bounded by the projection (= page
+        // budget) instead of the unbounded authored extent —
+        // ancestor's emit returns AllDone instead of spurious
+        // PageComplete.</para>
+        if (IsPaginatableGrid(parent)
+            && !_disableGridPagination
+            && _capturedFragmentainer is not null)
+        {
+            return Math.Min(parentBorderBoxBlockSize,
+                _capturedFragmentainer.BlockSize);
+        }
+
         // Non-flow block kinds (Flex/Grid/Replaced) are atomic to the
         // BlockLayouter — their inner geometry belongs to a dedicated
         // layouter. Return own size. (Tables were special-cased above
@@ -7408,8 +7453,18 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// clamped budget). The property is populated by
     /// <see cref="GridLayouter.AttemptLayout"/> on EVERY outcome
     /// (PageComplete, AllDone, Strict-defer, early-return). Callers
-    /// that don't consume the value (= forced-overflow + recursive
-    /// sites in 5c.2b's dormant scope) pass <c>out _</c>.</para></summary>
+    /// that don't consume the value (= the forced-overflow re-route
+    /// site, which dispatches atomically without
+    /// <c>allowPagination</c>) pass <c>out _</c>. The outer + recursive
+    /// dispatch sites consume the value for F2 wrapper-resize.</para>
+    ///
+    /// <para>Per Phase 3 Task 17 cycle 5c.3 — the optional
+    /// <paramref name="pageBlockBudget"/> separates row-sizing input
+    /// from pagination cut-off. The outer + recursive dispatch sites
+    /// pass it when their clamp fired (= explicit-height grid + the
+    /// authored extent exceeds page-remaining); the forced-overflow
+    /// site passes <see langword="null"/> (= legacy single-input
+    /// behavior where contentBlockSize doubles as the budget).</para></summary>
     private LayoutAttemptResult DispatchGridInner(
         Box gridBox,
         double contentInlineOffset,

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -1793,9 +1793,38 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // Auto-height grids stay clamped — they have no
             // authored container extent to confuse with the
             // fragment budget.</para>
+            // Per Phase 3 Task 17 cycle 5c.3 — capture the AUTHORED
+            // (= pre-clamp) border-box block size so the
+            // <see cref="DispatchGridInner"/> call below can pass the
+            // authored geometry to <see cref="GridSizing.Resolve"/>
+            // while the clamped value drives break-check + page
+            // budget. For auto-height grids the two are equal (=
+            // the clamp shrinks the natural extent which was the
+            // authored "auto" computed value), so the dual-input
+            // mechanism degenerates to legacy behavior. For
+            // explicit-height grids the authored value preserves
+            // the row geometry (= `1fr` distributes against
+            // authored height, not page-remaining), fixing the
+            // `grid-explicit-height-paginate-deferral` correctness
+            // gap.
+            var authoredBorderBoxBlockSize = borderBoxBlockSize;
+            // Per Phase 3 Task 17 cycle 5c.3 — `IsHeightAuto(child)`
+            // gate REMOVED. The cycle-5c.2c gate was reverted
+            // because clamping `borderBoxBlockSize` for explicit-
+            // height grids fed the shrunk size into
+            // <see cref="GridSizing.Resolve"/>, silently corrupting
+            // fr / definite-height row sizing. Cycle 5c.3 ships
+            // the minimum-viable separation: authored size flows
+            // into Resolve (= row geometry preserved); clamped size
+            // flows into break-check + page budget (= correct
+            // pagination cut-off). The full
+            // `GridFragmentPlan` refactor
+            // (`grid-fragment-plan-shared-sizing-deferral`) is a
+            // future optimization that consolidates the §11
+            // sizing work across pre-measure + F1 + dispatch;
+            // this cycle only fixes the correctness gap.
             if (IsPaginatableGrid(child)
-                && !_disableGridPagination
-                && IsHeightAuto(child))
+                && !_disableGridPagination)
             {
                 var pageRemainingForOuterGrid =
                     fragmentainer.BlockSize
@@ -1967,20 +1996,40 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 subtreeBlockExtent = borderBoxBlockSize;
             }
             // Per Phase 3 Task 17 cycle 5c.2c post-PR-#101 review
-            // P1#1 — the F3 subtree-extent clamp that ORIGINALLY
-            // lived here was REVERTED. The mechanism + the clamp's
-            // sibling effect (= passing the shrunk
+            // P1#1 + cycle 5c.3 — the F3 subtree-extent clamp is
+            // RE-ENABLED with the dual-input fix from cycle 5c.3.
+            // The cycle-5c.2c version corrupted row geometry
+            // because the clamp fed the shrunk
             // <c>borderBoxBlockSize</c> into
-            // <c>GridSizing.Resolve</c>) caused explicit-height
-            // grids with fr / flexible rows to redistribute track
-            // sizes against the shrunk container, silently losing
-            // authored row geometry. <c>IsHeightAuto(child)</c>
-            // gates the outer-site clamp instead (above), keeping
-            // explicit-height grids on the atomic-dispatch path
-            // until a shared <c>GridFragmentPlan</c> lands that
-            // separates resolved geometry from fragment budget.
-            // The <c>grid-explicit-height-paginate-deferral</c>
-            // remains <c>not-started</c>.
+            // <c>GridSizing.Resolve</c> as both the geometry input
+            // AND the page budget. Cycle 5c.3 ships
+            // <see cref="GridLayouter.ConfigureEmission"/>'s
+            // <c>pageBlockBudget</c> parameter that separates the
+            // two: dispatch passes AUTHORED contentBlockSize to
+            // Resolve (= row geometry preserved) + clamped
+            // contentBlockSize as pageBlockBudget (= pagination
+            // cut-off). The clamp here can now also fire for
+            // explicit-height grids without silently losing
+            // authored row sizing — the dispatch site (line ~3041)
+            // computes both authored + clamped geometries when the
+            // gate fires.
+            //
+            // <para>Mirrors the flex clamp at line ~1984 — when the
+            // grid is paginatable AND the outer-site gate fired
+            // (= cleared the page-budget arithmetic above), clamp
+            // <c>subtreeBlockExtent</c> back to the clamped
+            // <c>borderBoxBlockSize</c> so the break-check below
+            // sees a chunk that fits within page-remaining and
+            // takes the Continue path (= GridLayouter dispatch
+            // paginates rows) instead of the forced-overflow path
+            // (= would emit the wrapper at clamped extent + dispatch
+            // atomically with mismatched content sizing).</para>
+            if (IsGridContainer(child)
+                && paginateGridForOuterChild
+                && subtreeBlockExtent > borderBoxBlockSize)
+            {
+                subtreeBlockExtent = borderBoxBlockSize;
+            }
             //
             // The "effective" border-box block size for pagination +
             // cursor purposes: max of own border-box + subtree extent.
@@ -2644,15 +2693,19 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     incomingGridForProbe = probeGridCont;
                 }
 
-                // Per PR-#99 review P1#2 — derive the content-box
-                // geometry the actual dispatch below will use, so the
-                // probe sees the same sizing inputs. Matches the
+                // Per PR-#99 review P1#2 + cycle 5c.3 — derive the
+                // content-box geometry the actual dispatch below will
+                // use as its ROW-SIZING input, so the probe sees the
+                // same sizing inputs. For explicit-height grids that
+                // triggered the cycle-5c.3 clamp, this is the AUTHORED
+                // (= pre-clamp) borderBoxBlockSize; for auto-height
+                // grids the authored == clamped. Matches the
                 // <see cref="GridGeometryHelper.ComputeContentGeometry"/>
                 // call on the IsGridContainer dispatch branch.
                 var probeGridGeom = GridGeometryHelper.ComputeContentGeometry(
                     gridBox: child,
                     borderBoxInlineSize: borderBoxInlineSize,
-                    borderBoxBlockSize: borderBoxBlockSize,
+                    borderBoxBlockSize: authoredBorderBoxBlockSize,
                     borderBoxInlineOffset: inFlowInlineOffset,
                     borderBoxBlockOffset: blockOffset);
 
@@ -3015,12 +3068,41 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // gets the same wiring in cycle 5c.)
             if (IsGridContainer(child))
             {
+                // Per Phase 3 Task 17 cycle 5c.3 — when the paginatable-
+                // grid clamp fired, compute BOTH the clamped geometry
+                // (= page budget) AND the authored geometry (= row
+                // sizing input). The clamped geometry's
+                // ContentBlockSize feeds <c>DispatchGridInner</c>'s
+                // <c>pageBlockBudget</c>; the authored geometry's
+                // ContentBlockSize feeds the standard
+                // <c>contentBlockSize</c> parameter that
+                // <see cref="GridSizing.Resolve"/> uses for fr /
+                // definite-height row distribution. When the clamp
+                // didn't fire (= auto-height grid that fits, OR
+                // pagination disabled at this site), authored == clamped
+                // and the dual-input mechanism degenerates to legacy
+                // single-input behavior with <c>pageBlockBudget</c>
+                // passed as null.
                 var gridGeom = GridGeometryHelper.ComputeContentGeometry(
                     gridBox: child,
                     borderBoxInlineSize: borderBoxInlineSize,
                     borderBoxBlockSize: borderBoxBlockSize,
                     borderBoxInlineOffset: inFlowInlineOffset,
                     borderBoxBlockOffset: blockOffset);
+                double? gridPageBlockBudget = null;
+                double gridSizingContentBlockSize = gridGeom.ContentBlockSize;
+                if (paginateGridForOuterChild
+                    && authoredBorderBoxBlockSize > borderBoxBlockSize)
+                {
+                    var authoredGridGeom = GridGeometryHelper.ComputeContentGeometry(
+                        gridBox: child,
+                        borderBoxInlineSize: borderBoxInlineSize,
+                        borderBoxBlockSize: authoredBorderBoxBlockSize,
+                        borderBoxInlineOffset: inFlowInlineOffset,
+                        borderBoxBlockOffset: blockOffset);
+                    gridSizingContentBlockSize = authoredGridGeom.ContentBlockSize;
+                    gridPageBlockBudget = gridGeom.ContentBlockSize;
+                }
 
                 // Resume contract: extract the incoming GridContinuation
                 // if the BlockLayouter was invoked with a chained
@@ -3041,13 +3123,14 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     contentInlineOffset: gridGeom.ContentInlineOffset,
                     contentBlockOffset: gridGeom.ContentBlockOffset,
                     contentInlineSize: gridGeom.ContentInlineSize,
-                    contentBlockSize: gridGeom.ContentBlockSize,
+                    contentBlockSize: gridSizingContentBlockSize,
                     fragmentainer: fragmentainer,
                     layout: ref layout,
                     cancellationToken: cancellationToken,
                     lastEmittedBlockExtent: out var gridLastEmittedBlockExtent,
                     allowPagination: paginateGridForOuterChild,
-                    incomingContinuation: incomingGridContinuation);
+                    incomingContinuation: incomingGridContinuation,
+                    pageBlockBudget: gridPageBlockBudget);
 
                 // Per Phase 3 Task 17 cycle 5c.2b F2 — wrapper-resize
                 // + cursor-advance consumer for grids in a multi-page
@@ -4114,23 +4197,22 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 }
             }
 
-            // Per Phase 3 Task 17 cycle 5c.2d — recursive-site
-            // paginatable-grid extent clamp + gate-flip. Mirrors
-            // the outer-site clamp at line ~1796 + the recursive
-            // paginatable-flex clamp at line ~4054. When the grid
-            // is paginatable, auto-height (per cycle-5c.2c post-
-            // PR-#101 review P1#1 — explicit-height pagination
-            // waits for <c>grid-fragment-plan-shared-sizing-
-            // deferral</c>), + the grown natural extent would
-            // overflow the page-remaining (= captured
-            // fragmentainer's BlockSize minus the child's block
-            // offset), clamp <c>childBorderBoxBlockSize</c> to
-            // page-remaining + flip the gate so the dispatch
-            // below passes <c>allowPagination: true</c>.
+            // Per Phase 3 Task 17 cycle 5c.2d + cycle 5c.3 — recursive-
+            // site paginatable-grid extent clamp + gate-flip. Mirrors
+            // the outer-site clamp at line ~1796. Per cycle 5c.3 the
+            // <c>IsHeightAuto(child)</c> gate is REMOVED — the dispatch
+            // below passes the AUTHORED <c>childBorderBoxBlockSize</c>
+            // captured here as the grid sizing input + the CLAMPED
+            // value as the page budget, so explicit-height grids
+            // resolve row geometry against authored height (= fr /
+            // definite rows distribute correctly) while paginating
+            // against the page-remaining budget. Auto-height grids
+            // see authored == clamped + the dual-input mechanism
+            // degenerates to legacy behavior.
+            var recursiveAuthoredBorderBoxBlockSize = childBorderBoxBlockSize;
             if (IsPaginatableGrid(child)
                 && !_disableGridPagination
-                && _capturedFragmentainer is not null
-                && IsHeightAuto(child))
+                && _capturedFragmentainer is not null)
             {
                 var pageRemainingForGrid =
                     _capturedFragmentainer.BlockSize - childBlockOffset;
@@ -4216,14 +4298,19 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
 
                 if (recursivePageRemainingForGridContent > 0)
                 {
-                    // Per cycle 5c.2a P1#2 — the probe uses the
-                    // actual grid content geometry; mirrors the
-                    // outer site.
+                    // Per cycle 5c.2a P1#2 + cycle 5c.3 — the probe
+                    // uses the actual grid content geometry the
+                    // dispatch will use as its ROW-SIZING input;
+                    // mirrors the outer site. For explicit-height
+                    // grids the AUTHORED (= pre-clamp) borderBox
+                    // feeds the probe so row geometry matches what
+                    // the dispatch sees. Auto-height grids see
+                    // authored == clamped.
                     var recursiveProbeGridGeom =
                         GridGeometryHelper.ComputeContentGeometry(
                             gridBox: child,
                             borderBoxInlineSize: childBorderBoxInlineSize,
-                            borderBoxBlockSize: childBorderBoxBlockSize,
+                            borderBoxBlockSize: recursiveAuthoredBorderBoxBlockSize,
                             borderBoxInlineOffset: childInlineOffset,
                             borderBoxBlockOffset: childBlockOffset);
                     var recursiveFirstRowExtent = PreMeasureGridRowExtentAt(
@@ -4557,12 +4644,36 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // optimization is needed inside nested grids.</para>
             if (IsGridContainer(child) && _capturedFragmentainer is not null)
             {
+                // Per Phase 3 Task 17 cycle 5c.3 — same dual-input
+                // pattern as the outer site (line ~3039): when the
+                // recursive clamp fired AND the authored size is
+                // larger than the clamped size, dispatch with the
+                // AUTHORED geometry as the row-sizing input + the
+                // CLAMPED geometry as the page budget. Auto-height
+                // grids (= authored == clamped) get
+                // <c>pageBlockBudget</c> = null + dispatch behaves
+                // identically to the pre-5c.3 path.
                 var nestedGridGeom = GridGeometryHelper.ComputeContentGeometry(
                     gridBox: child,
                     borderBoxInlineSize: childBorderBoxInlineSize,
                     borderBoxBlockSize: childBorderBoxBlockSize,
                     borderBoxInlineOffset: childInlineOffset,
                     borderBoxBlockOffset: childBlockOffset);
+                double? nestedGridPageBlockBudget = null;
+                double nestedGridSizingContentBlockSize = nestedGridGeom.ContentBlockSize;
+                if (paginateGridForChild
+                    && recursiveAuthoredBorderBoxBlockSize > childBorderBoxBlockSize)
+                {
+                    var nestedAuthoredGridGeom = GridGeometryHelper.ComputeContentGeometry(
+                        gridBox: child,
+                        borderBoxInlineSize: childBorderBoxInlineSize,
+                        borderBoxBlockSize: recursiveAuthoredBorderBoxBlockSize,
+                        borderBoxInlineOffset: childInlineOffset,
+                        borderBoxBlockOffset: childBlockOffset);
+                    nestedGridSizingContentBlockSize = nestedAuthoredGridGeom.ContentBlockSize;
+                    nestedGridPageBlockBudget = nestedGridGeom.ContentBlockSize;
+                }
+
                 var nestedGridLayoutCtx = new LayoutContext(_capturedFragmentainer)
                 {
                     Diagnostics = _diagnostics,
@@ -4590,13 +4701,14 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     contentInlineOffset: nestedGridGeom.ContentInlineOffset,
                     contentBlockOffset: nestedGridGeom.ContentBlockOffset,
                     contentInlineSize: nestedGridGeom.ContentInlineSize,
-                    contentBlockSize: nestedGridGeom.ContentBlockSize,
+                    contentBlockSize: nestedGridSizingContentBlockSize,
                     fragmentainer: _capturedFragmentainer,
                     layout: ref nestedGridLayoutCtx,
                     cancellationToken: cancellationToken,
                     lastEmittedBlockExtent: out var nestedGridLastEmittedBlockExtent,
                     allowPagination: paginateGridForChild,
-                    incomingContinuation: incomingGridForChild);
+                    incomingContinuation: incomingGridForChild,
+                    pageBlockBudget: nestedGridPageBlockBudget);
 
                 // F2 wrapper-resize + cursor-advance recomputation.
                 // Same trigger semantics as the outer site: fire
@@ -7309,7 +7421,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         CancellationToken cancellationToken,
         out double lastEmittedBlockExtent,
         bool allowPagination = false,
-        GridContinuation? incomingContinuation = null)
+        GridContinuation? incomingContinuation = null,
+        double? pageBlockBudget = null)
     {
         using var gridLayouter = new GridLayouter(
             rootBox: gridBox,
@@ -7317,12 +7430,24 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             incomingContinuation: incomingContinuation,
             diagnostics: _diagnostics,
             shaperResolver: _shaperResolver);
+        // Per Phase 3 Task 17 cycle 5c.3 — pass the page-budget through
+        // to ConfigureEmission so explicit-height grids resolve rows
+        // against the authored content-block-size while paginating
+        // against the page-remaining budget. Auto-height callers + the
+        // forced-overflow + recursive sites pass null which falls back
+        // to using contentBlockSize as the budget (= pre-5c.3
+        // behavior). Per the grid-explicit-height-paginate-deferral the
+        // separation here is the minimum viable F3 — the full shared
+        // GridFragmentPlan refactor (= grid-fragment-plan-shared-sizing-
+        // deferral) is a future optimization that consolidates the
+        // §11 sizing work; this cycle only fixes the correctness gap.
         gridLayouter.ConfigureEmission(
             contentInlineOffset: contentInlineOffset,
             contentBlockOffset: contentBlockOffset,
             contentInlineSize: contentInlineSize,
             contentBlockSize: contentBlockSize,
-            allowPagination: allowPagination);
+            allowPagination: allowPagination,
+            pageBlockBudget: pageBlockBudget);
         using var gridResolver = new BreakResolver();
         var result = gridLayouter.AttemptLayout(
             fragmentainer,

--- a/src/NetPdf.Layout/Layouters/GridLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/GridLayouter.cs
@@ -145,19 +145,22 @@ internal sealed class GridLayouter : ILayouter, IDisposable
     /// container overflows).</summary>
     private bool _allowPagination;
 
-    /// <summary>Per Phase 3 Task 17 cycle 5c.3 — the per-page block-
-    /// axis budget for emission. Separates the "geometry input" (=
-    /// <see cref="_contentBlockSize"/>, used by
-    /// <see cref="GridSizing.Resolve"/> to compute row sizes against
-    /// the authored container extent) from the "page budget" (=
-    /// page-remaining capacity that drives the
+    /// <summary>Per Phase 3 Task 17 cycle 5c.3 + post-PR-#110
+    /// review P3#2 — the per-page block-axis budget for emission.
+    /// Separates the "geometry input" (= <see cref="_contentBlockSize"/>,
+    /// used by <see cref="GridSizing.Resolve"/> to compute row sizes
+    /// against the authored container extent) from the "page budget"
+    /// (= page-remaining capacity that drives the
     /// <see cref="ComputePaginatedRowRange"/> row-fit cut-off). When
-    /// negative, the budget falls back to <see cref="_contentBlockSize"/>
-    /// (= the pre-cycle-5c.3 behavior where geometry + budget were
-    /// the same value); when non-negative, pagination uses the
-    /// explicit budget so explicit-height grids resolve rows against
-    /// authored height while still paginating per page-remaining
-    /// capacity.
+    /// <see langword="null"/>, the budget falls back to
+    /// <see cref="_contentBlockSize"/> (= the pre-cycle-5c.3 behavior
+    /// where geometry + budget were the same value); when non-null,
+    /// pagination uses the explicit budget so explicit-height grids
+    /// resolve rows against authored height while still paginating
+    /// per page-remaining capacity. Pre-PR-#110 review the field
+    /// used a <c>-1.0</c> sentinel; the nullable shape makes the
+    /// "either-or" contract self-documenting + matches
+    /// <see cref="ConfigureEmission"/>'s parameter shape.
     ///
     /// <para><b>Why this separation</b>: pre-5c.3 a 400px-tall grid
     /// with <c>grid-template-rows: 100px 1fr</c> on a 250px page got
@@ -170,7 +173,7 @@ internal sealed class GridLayouter : ILayouter, IDisposable
     /// separately to row-fit selection, explicit-height grids
     /// paginate correctly while authored row geometry stays
     /// authoritative.</para></summary>
-    private double _pageBlockBudget = -1.0;
+    private double? _pageBlockBudget;
 
     /// <summary>Per Phase 3 Task 17 cycle 5 — the resume-from-prior-
     /// page state, captured by the constructor. When non-null the
@@ -398,7 +401,7 @@ internal sealed class GridLayouter : ILayouter, IDisposable
         _contentInlineSize = contentInlineSize;
         _contentBlockSize = contentBlockSize;
         _allowPagination = allowPagination;
-        _pageBlockBudget = pageBlockBudget ?? -1.0;
+        _pageBlockBudget = pageBlockBudget;
         _emissionConfigured = true;
     }
 
@@ -598,9 +601,7 @@ internal sealed class GridLayouter : ILayouter, IDisposable
             // for explicit-height grids the page-budget is the
             // page-remaining capacity while the content-block-size
             // stays at the authored height (preserving row geometry).
-            var paginationBudget = _pageBlockBudget > 0
-                ? _pageBlockBudget
-                : _contentBlockSize;
+            var paginationBudget = _pageBlockBudget ?? _contentBlockSize;
             (endRowExclusive, needsContinuation, var deferEntireGrid) =
                 ComputePaginatedRowRange(
                     startRow: startRow,

--- a/src/NetPdf.Layout/Layouters/GridLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/GridLayouter.cs
@@ -145,6 +145,33 @@ internal sealed class GridLayouter : ILayouter, IDisposable
     /// container overflows).</summary>
     private bool _allowPagination;
 
+    /// <summary>Per Phase 3 Task 17 cycle 5c.3 — the per-page block-
+    /// axis budget for emission. Separates the "geometry input" (=
+    /// <see cref="_contentBlockSize"/>, used by
+    /// <see cref="GridSizing.Resolve"/> to compute row sizes against
+    /// the authored container extent) from the "page budget" (=
+    /// page-remaining capacity that drives the
+    /// <see cref="ComputePaginatedRowRange"/> row-fit cut-off). When
+    /// negative, the budget falls back to <see cref="_contentBlockSize"/>
+    /// (= the pre-cycle-5c.3 behavior where geometry + budget were
+    /// the same value); when non-negative, pagination uses the
+    /// explicit budget so explicit-height grids resolve rows against
+    /// authored height while still paginating per page-remaining
+    /// capacity.
+    ///
+    /// <para><b>Why this separation</b>: pre-5c.3 a 400px-tall grid
+    /// with <c>grid-template-rows: 100px 1fr</c> on a 250px page got
+    /// its <c>contentBlockSize</c> clamped to 250px BEFORE
+    /// <see cref="GridSizing.Resolve"/> ran — the 1fr row redistributed
+    /// against the smaller budget (= 100 + 150 instead of authored
+    /// 100 + 300), silently losing 150px of grid geometry per
+    /// <c>grid-explicit-height-paginate-deferral</c>. By passing the
+    /// authored geometry to <c>Resolve</c> + the page budget
+    /// separately to row-fit selection, explicit-height grids
+    /// paginate correctly while authored row geometry stays
+    /// authoritative.</para></summary>
+    private double _pageBlockBudget = -1.0;
+
     /// <summary>Per Phase 3 Task 17 cycle 5 — the resume-from-prior-
     /// page state, captured by the constructor. When non-null the
     /// layouter skips the resolution + placement passes (using the
@@ -300,12 +327,27 @@ internal sealed class GridLayouter : ILayouter, IDisposable
     /// <see cref="LayoutAttemptStrategy.LastResort"/>: a Strict
     /// strategy + first row doesn't fit defers the entire grid via
     /// <c>PageComplete(GridContinuation(startRow, null))</c>.</param>
+    /// <param name="pageBlockBudget">Per Phase 3 Task 17 cycle 5c.3 —
+    /// the per-page block-axis budget for emission, separating
+    /// "geometry input" (= <paramref name="contentBlockSize"/>, used
+    /// by <see cref="GridSizing.Resolve"/> to compute row sizes
+    /// against the authored container extent) from "page budget" (=
+    /// page-remaining capacity that drives row-fit pagination). Pass
+    /// <see langword="null"/> (default) to use
+    /// <paramref name="contentBlockSize"/> as both inputs (= pre-5c.3
+    /// behavior — required for auto-height grids where the values
+    /// are the same anyway, and for any caller that hasn't been
+    /// updated yet). Pass a non-null value when an explicit-height
+    /// grid clamps for break-check fit but resolves row geometry
+    /// against the larger authored extent; the budget controls
+    /// pagination cut-off without corrupting row sizing.</param>
     public void ConfigureEmission(
         double contentInlineOffset,
         double contentBlockOffset,
         double contentInlineSize,
         double contentBlockSize,
-        bool allowPagination = false)
+        bool allowPagination = false,
+        double? pageBlockBudget = null)
     {
         if (!double.IsFinite(contentInlineSize) || contentInlineSize <= 0)
         {
@@ -335,11 +377,28 @@ internal sealed class GridLayouter : ILayouter, IDisposable
                 $"contentBlockOffset must be finite; got {contentBlockOffset}.");
         }
 
+        // Per Phase 3 Task 17 cycle 5c.3 — validate the optional page
+        // budget. Non-null values must be finite + positive (otherwise
+        // they'd produce a zero / negative row-fit budget downstream,
+        // and the cycle-1 ComputePaginatedRowRange contract requires
+        // a positive budget to make progress). Null falls through to
+        // contentBlockSize (= legacy single-input behavior).
+        if (pageBlockBudget is { } budget
+            && (!double.IsFinite(budget) || budget <= 0))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(pageBlockBudget),
+                $"pageBlockBudget must be finite + positive when non-null; "
+                + $"got {budget}. Pass null to use contentBlockSize as the "
+                + "budget (= pre-cycle-5c.3 single-input behavior).");
+        }
+
         _contentInlineOffset = contentInlineOffset;
         _contentBlockOffset = contentBlockOffset;
         _contentInlineSize = contentInlineSize;
         _contentBlockSize = contentBlockSize;
         _allowPagination = allowPagination;
+        _pageBlockBudget = pageBlockBudget ?? -1.0;
         _emissionConfigured = true;
     }
 
@@ -532,13 +591,23 @@ internal sealed class GridLayouter : ILayouter, IDisposable
             //   grid on a fresh page).
             // - LastResort: force-emit the oversized first row per
             //   §4.4 progress rule + emit diagnostic.
+            // Per Phase 3 Task 17 cycle 5c.3 — pagination budget is the
+            // explicit page-budget (when ConfigureEmission supplied
+            // one) OR the content-block-size (= legacy single-input
+            // behavior). For auto-height grids the two are the same;
+            // for explicit-height grids the page-budget is the
+            // page-remaining capacity while the content-block-size
+            // stays at the authored height (preserving row geometry).
+            var paginationBudget = _pageBlockBudget > 0
+                ? _pageBlockBudget
+                : _contentBlockSize;
             (endRowExclusive, needsContinuation, var deferEntireGrid) =
                 ComputePaginatedRowRange(
                     startRow: startRow,
                     rowSizesView: rowSizesRelative,
                     rowPositionsView: rowPositionsRelative,
                     placedItems: placedItems,
-                    budget: _contentBlockSize,
+                    budget: paginationBudget,
                     strategy: strategy);
 
             if (deferEntireGrid)

--- a/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
@@ -5351,32 +5351,36 @@ public sealed class BlockLayouterTests
     }
 
     [Fact]
-    public void Cycle5c2c_post_PR_101_explicit_height_grid_atomic_until_GridFragmentPlan_ships()
+    public void Cycle5c3_explicit_height_grid_paginates_via_outer_site()
     {
-        // Per PR-#101 review P1#1 — the cycle-5c.2c F3 mechanism
-        // was REVERTED. Clamping borderBoxBlockSize fed the
-        // shrunk size into GridSizing.Resolve as the
-        // contentBlockSize, causing fr / definite-height row
-        // sizing to redistribute against the smaller budget +
-        // silently lose authored row geometry. The
-        // <c>IsHeightAuto(child)</c> safety gate on the outer-
-        // site clamp is RESTORED; explicit-height grids stay on
-        // the atomic-dispatch path until the
-        // <c>grid-fragment-plan-shared-sizing-deferral</c> lands
-        // (= separates resolved geometry from fragment budget).
+        // Per Phase 3 Task 17 cycle 5c.3 — F3 SHIPPED. Explicit-
+        // height grids now paginate via the outer-site clamp +
+        // dual-input dispatch:
+        //   1. PreMeasure leaves borderBoxBlockSize at the
+        //      authored 300.
+        //   2. <c>authoredBorderBoxBlockSize</c> captures 300
+        //      pre-clamp.
+        //   3. Outer-site clamp (no longer gated on IsHeightAuto)
+        //      shrinks borderBoxBlockSize to pageRemaining 250 +
+        //      flips <c>paginateGridForOuterChild</c>.
+        //   4. Subtree-extent clamp brings <c>subtreeBlockExtent</c>
+        //      to 250 so the break-check stays in the Continue
+        //      path.
+        //   5. Dispatch passes AUTHORED contentBlockSize (300 -
+        //      0 chrome = 300) to <c>GridSizing.Resolve</c> +
+        //      clamped contentBlockSize (250) as
+        //      <c>pageBlockBudget</c>. Rows resolve as
+        //      [100, 100, 100] against authored 300 (= preserves
+        //      authored geometry).
+        //   6. <c>ComputePaginatedRowRange</c> with budget 250
+        //      emits rows 0..1 (sum 200), defers row 2 via
+        //      GridContinuation.
+        //   7. F2 wrapper-resize shrinks wrapper to chrome (0) +
+        //      lastEmittedBlockExtent (200) = 200.
         //
-        // Fixture: explicit-height grid (height: 300, rows
-        // [100,100,100]) on a 250 fresh page. Post-revert:
-        //   1. PreMeasure leaves borderBoxBlockSize at 300.
-        //   2. Outer-site clamp does NOT fire (= IsHeightAuto
-        //      gate). paginateGridForOuterChild stays false.
-        //   3. Break-check: chunk 300 > remaining 250 →
-        //      forced-overflow path (= grid is first emittable
-        //      + nothingEmittedThisAttempt).
-        //   4. Forced-overflow emits wrapper at AUTHORED 300 +
-        //      dispatches grid atomically (allowPagination=false).
-        //   5. GridLayouter atomic emit: all 3 rows render past
-        //      the 250 page edge (= visual overflow per cycle-1).
+        // Pre-F3 (cycle 5c.2c-post-PR-#101 state): wrapper at
+        // authored 300, atomic dispatch emits all 3 rows past
+        // the page edge.
         var sink = new RecordingFragmentSink();
         var root = Box.CreateRoot(MakeStyle());
 
@@ -5395,28 +5399,48 @@ public sealed class BlockLayouterTests
         var result = layouter.AttemptLayout(
             ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
 
-        // Authored wrapper geometry preserved (= 300, NOT the
-        // clamped 250). No GridContinuation = atomic dispatch
-        // produced no nested pagination state.
+        // F2 resized wrapper to chrome + emittedRowsExtent =
+        // 0 + 200 = 200 (= 2 emitted rows × 100).
         var wrapperFragment = sink.Fragments
             .First(f => ReferenceEquals(f.Box, grid));
-        Assert.Equal(300.0, wrapperFragment.BlockSize, precision: 3);
-        if (result.Continuation is BlockContinuation bc)
-        {
-            Assert.Null(bc.LayouterState);
-        }
+        Assert.Equal(200.0, wrapperFragment.BlockSize, precision: 3);
+        // PageComplete carries a chained BlockContinuation with
+        // a GridContinuation leaf pointing at row 2 (= the
+        // deferred row).
+        Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+        var bc = (BlockContinuation)result.Continuation!;
+        var gridCont = (GridContinuation)bc.LayouterState!;
+        Assert.Equal(2, gridCont.RowIndex);
     }
 
     [Fact]
-    public void Cycle5c2c_post_PR_101_explicit_height_grid_after_sibling_no_partial_clamp()
+    public void Cycle5c3_explicit_height_grid_after_sibling_paginates_first_row()
     {
-        // Per PR-#101 review P1#1 — sibling + explicit-height
-        // grid scenario: clamp doesn't fire (= IsHeightAuto
-        // gate). Grid wrapper natural 200 > pageRemaining 150 →
-        // break-check returns BreakHere (= chunk doesn't fit
-        // remaining, grid is not first child) → PageComplete
-        // without grid emit, resume on next page. Authored
-        // wrapper geometry preserved.
+        // Per Phase 3 Task 17 cycle 5c.3 — sibling + explicit-
+        // height grid scenario WITH F3. The outer-site clamp
+        // now fires for explicit-height grids; the
+        // dual-input dispatch emits row 0 + defers row 1 via
+        // GridContinuation.
+        //
+        // Pre-F3 (cycle 5c.2c-post-PR-#101 state): the clamp
+        // didn't fire (IsHeightAuto gate), the break-check
+        // would fire BreakHere because the grid's natural
+        // borderBox (200) exceeded pageRemaining (150), and the
+        // grid was deferred whole via break-before.
+        //
+        // Post-F3:
+        //   1. After sibling (150) emits, UsedBlockSize=150.
+        //   2. pageRemaining for grid = 300 - 150 = 150.
+        //   3. authored borderBox = 200, clamp shrinks to 150.
+        //   4. Subtree-extent clamp brings subtreeBlockExtent
+        //      from 200 → 150 → break-check Continues.
+        //   5. F1 row-fit probe (Strict + emittedThisAttempt=1):
+        //      row 0 = 100 fits pageRemaining 150 (content) →
+        //      F1 does NOT defer.
+        //   6. Dispatch with authored 200 + budget 150. Rows
+        //      [100, 100]. Budget fits row 0 only → emit row 0,
+        //      defer row 1 via GridContinuation.
+        //   7. F2 resizes wrapper to 0 + 100 = 100.
         var sink = new RecordingFragmentSink();
         var root = Box.CreateRoot(MakeStyle());
 
@@ -5439,33 +5463,45 @@ public sealed class BlockLayouterTests
         var result = layouter.AttemptLayout(
             ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
 
-        // Sibling emitted; grid NOT emitted (break-before-grid).
-        // No GridContinuation — clamp didn't fire + atomic-break.
+        // Sibling + grid wrapper (F2-resized to 100) both
+        // emitted. PageComplete carries a chained
+        // BlockContinuation → GridContinuation(RowIndex=1).
         Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
         Assert.Contains(sink.Fragments, f => ReferenceEquals(f.Box, sibling));
-        Assert.DoesNotContain(sink.Fragments, f => ReferenceEquals(f.Box, grid));
+        var wrapperFragment = sink.Fragments
+            .First(f => ReferenceEquals(f.Box, grid));
+        Assert.Equal(100.0, wrapperFragment.BlockSize, precision: 3);
         var blockCont = (BlockContinuation)result.Continuation!;
         Assert.Equal(1, blockCont.ResumeAtChild);
-        Assert.Null(blockCont.LayouterState);
+        var gridCont = (GridContinuation)blockCont.LayouterState!;
+        Assert.Equal(1, gridCont.RowIndex);
     }
 
     [Fact]
-    public void Cycle5c2c_post_PR_101_oversized_first_row_LastResort_emits_diagnostic_and_makes_progress()
+    public void Cycle5c3_oversized_first_row_LastResort_emits_diagnostic_and_makes_progress()
     {
-        // Per PR-#101 review P2#1 — strengthen the oversized-row
-        // test. Previously the test only asserted the wrapper
-        // existed; it would pass even if the diagnostic wasn't
-        // emitted, the item was dropped, or progress broke.
-        // Post-fix the test asserts ALL of:
-        //   - LayoutGridForcedOverflow001 diagnostic emitted.
-        //   - Wrapper IS in the sink with authored geometry.
-        //   - Grid item IS in the sink (= no row drop).
-        //   - LastResort attempt result is AllDone OR PageComplete
-        //     (NOT NeedsRewind — LastResort forbids rewind per the
-        //     coordinator contract).
-        //   - The result's continuation does not carry a
-        //     fabricated GridContinuation (= atomic dispatch
-        //     under LastResort doesn't split).
+        // Per Phase 3 Task 17 cycle 5c.3 — F3 reroutes the
+        // oversized-first-row case through the Continue path
+        // with pagination enabled. The grid emits the oversized
+        // row via its OWN §4.4 force-emit path; the outer
+        // block-level forced-overflow path no longer fires.
+        //
+        // Pre-F3: clamp didn't fire (IsHeightAuto gate) →
+        // break-check BreakHere → outer forced-overflow path →
+        // PAGINATION-FORCED-OVERFLOW-001 + atomic dispatch.
+        //
+        // Post-F3:
+        //   1. authored borderBox = 500, clamp shrinks to 250.
+        //   2. Subtree-extent clamp brings 500 → 250.
+        //   3. Break-check Continue.
+        //   4. Dispatch with authored 500 contentBlockSize +
+        //      budget 250.
+        //   5. GridSizing.Resolve against 500: row = 500.
+        //   6. ComputePaginatedRowRange(budget=250) sees row 0
+        //      = 500 doesn't fit. LastResort force-emits row +
+        //      emits LAYOUT-GRID-FORCED-OVERFLOW-001.
+        //   7. LastEmittedBlockExtent = 500. F2 resizes
+        //      wrapper to 0 + 500 = 500.
         var sink = new RecordingFragmentSink();
         var diag = new RecordingDiagnosticsSink();
         var root = Box.CreateRoot(MakeStyle());
@@ -5487,48 +5523,45 @@ public sealed class BlockLayouterTests
         // Result is committed (not NeedsRewind per LastResort
         // contract): either AllDone or PageComplete.
         Assert.NotEqual(LayoutAttemptOutcome.NeedsRewind, result.Outcome);
-        // Wrapper in sink at authored geometry (= 500, NOT
-        // clamped — IsHeightAuto gate prevents clamp for
-        // explicit-height).
+        // Wrapper in sink at F2-resized geometry (= chrome 0 +
+        // emittedExtent 500 = 500). Authored row geometry
+        // preserved (= GridSizing.Resolve ran against authored
+        // 500, NOT clamped 250).
         var wrapperFragment = sink.Fragments
             .First(f => ReferenceEquals(f.Box, grid));
         Assert.Equal(500.0, wrapperFragment.BlockSize, precision: 3);
-        // Grid item dispatched + emitted (= no row drop under
-        // forced-overflow / atomic LastResort).
+        // Grid item dispatched + emitted (= the §4.4 force-emit
+        // path inside GridLayouter committed it).
         Assert.Contains(sink.Fragments, f => ReferenceEquals(f.Box, item));
-        // No fabricated GridContinuation (= atomic dispatch).
-        if (result.Continuation is BlockContinuation outBc)
-        {
-            Assert.Null(outBc.LayouterState);
-        }
-        // Pagination forced-overflow diagnostic fires for the
-        // oversized first-row scenario (= the outer
-        // BlockLayouter's forced-overflow path emits
-        // PAGINATION-FORCED-OVERFLOW-001 since the wrapper
-        // exceeds page; GridLayouter under atomic mode does NOT
-        // emit LayoutGridForcedOverflow001 since allowPagination
-        // is false, so the §4.4 force-emit path inside the grid
-        // doesn't fire — but the outer block-level diagnostic
-        // documents the overflow).
+        // GridLayouter emits LAYOUT-GRID-FORCED-OVERFLOW-001
+        // because the oversized row was force-emitted in
+        // LastResort + paginatable mode.
         Assert.Contains(diag.Diagnostics, d =>
-            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+            d.Code == PaginateDiagnosticCodes.LayoutGridForcedOverflow001);
     }
 
     [Fact]
-    public void Cycle5c2c_post_PR_101_explicit_height_with_fr_rows_preserves_authored_geometry()
+    public void Cycle5c3_explicit_height_with_fr_rows_preserves_authored_geometry()
     {
-        // Per PR-#101 review P1#1 required regression test —
+        // Per PR-#101 review P1#1 → Phase 3 Task 17 cycle 5c.3
+        // — THE CRITICAL F3 REGRESSION TEST:
         // <c>height: 400px; grid-template-rows: 100px 1fr</c>.
-        // Authored row resolution: 100 + 300 = 400. With the F3
-        // bug (pre-revert), the clamp shrunk borderBoxBlockSize
-        // to pageRemaining (e.g., 250), then GridSizing.Resolve
-        // ran against contentBlockSize=250 → fr row resolved to
-        // 250-100=150 instead of 300 (= 150px of authored row
-        // geometry silently lost).
         //
-        // Post-revert: IsHeightAuto gate prevents the clamp.
-        // GridSizing.Resolve runs against authored 400, fr row =
-        // 300. Atomic dispatch emits all rows at authored sizes.
+        // F3 minimum-viable correctness requirement: the fr row
+        // MUST resolve against AUTHORED 400 (not the clamped
+        // page budget), giving rows [100, 300]. The cycle 5c.2c
+        // initial F3 attempt fed the clamped 250 into
+        // <c>GridSizing.Resolve</c> as <c>contentBlockSize</c>,
+        // causing fr to redistribute against 250 → row 1 =
+        // 250 - 100 = 150 (= 150px silently lost). The fix:
+        // <c>ConfigureEmission</c>'s new <c>pageBlockBudget</c>
+        // parameter separates row-sizing input (authored 400)
+        // from pagination budget (clamped 250).
+        //
+        // Page 1 (this test): emit item1 (row 0, height 100) +
+        // defer row 1 via GridContinuation. Resume cache pins
+        // row 1 size = 300 (= the authored fr resolution); page
+        // 2 would emit item2 at that size.
         var sink = new RecordingFragmentSink();
         var root = Box.CreateRoot(MakeStyle());
 
@@ -5576,19 +5609,31 @@ public sealed class BlockLayouterTests
         var layoutCtx = new LayoutContext(ctx);
         using var resolver = new BreakResolver();
 
-        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+        var result = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
 
-        // Row geometry preserved: item 1 at row 0 (= 100 tall),
-        // item 2 at row 1 (= 300 tall). Verifies fr distributed
-        // against AUTHORED 400 - 100 = 300, not against any
-        // clamped budget. Pre-revert: fr would be 250-100=150
-        // (= silent loss of 150px).
+        // Page 1: item1 emitted at row 0 (= 100 tall). item2
+        // (row 1) is deferred via GridContinuation; the resume
+        // cache carries row sizes [100, 300] (= the AUTHORED fr
+        // distribution against 400, NOT the clamped 250).
         var item1Fragment = sink.Fragments
             .First(f => ReferenceEquals(f.Box, item1));
-        var item2Fragment = sink.Fragments
-            .First(f => ReferenceEquals(f.Box, item2));
         Assert.Equal(100.0, item1Fragment.BlockSize, precision: 3);
-        Assert.Equal(300.0, item2Fragment.BlockSize, precision: 3);
+        // item2 NOT in page 1 fragments (= deferred to page 2).
+        Assert.DoesNotContain(sink.Fragments, f => ReferenceEquals(f.Box, item2));
+        // Verify the resume cache pins row 1 size = AUTHORED 300
+        // (= the F3 correctness contract — fr resolved against
+        // authored 400, not clamped 250). Pre-F3 the cache
+        // would have shown row 1 size = 150 (silent geometry
+        // loss).
+        Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+        var bc = (BlockContinuation)result.Continuation!;
+        var gridCont = (GridContinuation)bc.LayouterState!;
+        Assert.Equal(1, gridCont.RowIndex);
+        Assert.NotNull(gridCont.Cache);
+        Assert.Equal(2, gridCont.Cache!.RowBaseSizes.Length);
+        Assert.Equal(100.0, gridCont.Cache.RowBaseSizes[0], precision: 3);
+        Assert.Equal(300.0, gridCont.Cache.RowBaseSizes[1], precision: 3);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -1016,25 +1016,25 @@ public sealed class GridLayouterProductionTests
     [Fact]
     public async Task Cycle5c3_recursive_explicit_height_grid_paginates()
     {
-        // Per Phase 3 Task 17 cycle 5c.3 — F3 SHIPPED at the
-        // recursive site too. Explicit-height grids reached via
-        // the recursive walk now paginate via the dual-input
-        // dispatch (= authored geometry for row sizing, clamped
-        // geometry for page budget) just like the outer site.
+        // Per Phase 3 Task 17 cycle 5c.3 + post-PR-#110 review
+        // P1#2 — F3 SHIPPED at the recursive site too, AND the
+        // outer body's break-check projection eliminates the
+        // stale `PAGINATION-FORCED-OVERFLOW-001` that the
+        // initial cycle-5c.3 ship still emitted (see
+        // `grid-explicit-height-paginate-deferral` Residual
+        // approximation note for the cursor-advance scope).
         //
         // Fixture: height: 200px grid with 2 rows of 100px on a
-        // 150px page. Pre-F3 the grid went through forced-overflow
-        // (wrapper at authored 200, atomic emit of both rows past
-        // the page edge). Post-F3:
-        //   1. Recursive site authored borderBox = 200.
-        //   2. Recursive clamp shrinks to pageRemaining 150.
-        //   3. Dispatch with authored 200 + budget 150.
-        //   4. Row 0 (100) fits, row 1 (100) makes 200 > 150 →
-        //      defer row 1 via GridContinuation.
-        //   5. F2 wrapper-resize shrinks wrapper to 100.
-        //   6. PaginationForcedOverflow001 no longer fires (= the
-        //      forced-overflow path doesn't run when F3 paginates
-        //      via the Continue path).
+        // 150px page.
+        //   1. Outer body subtree measure projects the grid to
+        //      <c>min(authored 200, pageBlockSize 150) = 150</c>
+        //      → body break-check Continue (= no
+        //      `PAGINATION-FORCED-OVERFLOW-001`).
+        //   2. Body recurses; recursive grid dispatch sees
+        //      pageRemaining 150, authored 200 → clamp fires.
+        //   3. Dispatch with authored 200 + budget 150 + F2
+        //      wrapper-resize to the emitted-rows extent (100).
+        //   4. Row 0 fits, row 1 deferred via GridContinuation.
         const string html = """
             <!DOCTYPE html><html><head><style>
                 .grid {
@@ -1069,19 +1069,14 @@ public sealed class GridLayouterProductionTests
         // row), NOT authored 200.
         Assert.Contains(sink.Fragments, f => Math.Abs(f.BlockSize - 100.0) < 0.001);
         Assert.DoesNotContain(sink.Fragments, f => Math.Abs(f.BlockSize - 200.0) < 0.001);
-        // KNOWN GAP: the OUTER body wrapper still triggers
-        // PAGINATION-FORCED-OVERFLOW-001 because its
-        // <c>MeasureSubtreeVisualBlockExtent</c> isn't grid-
-        // paginatable-aware — it reports the grid's authored
-        // 200 as the subtree extent for the body's break-check,
-        // which exceeds the 150 page. The body's forced-overflow
-        // emit at 0 then recurses into the grid, where F3
-        // paginates correctly. Eliminating the stale outer
-        // diagnostic requires teaching the subtree-extent helper
-        // to project paginatable descendants to their fragment
-        // budget — tracked separately (= the eventual
-        // <c>grid-fragment-plan-shared-sizing-deferral</c> shared
-        // plan would carry this).
+        // Per post-PR-#110 review P1#2 — the body's
+        // MeasureSubtreeVisualBlockExtent projection eliminates
+        // the stale outer-body `PAGINATION-FORCED-OVERFLOW-001`
+        // that fired pre-projection. The body's break-check
+        // takes the Continue path + the recursive grid F3
+        // dispatch handles the row-by-row pagination cleanly.
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
     }
 
     [Fact]
@@ -1262,10 +1257,16 @@ public sealed class GridLayouterProductionTests
         var pages = await RenderMultiPageAsync(
             html, contentInlineSize: 100, blockSize: 250, maxPages: 4);
 
-        // 2 or 3 pages: page 1 emits r1, page 2 emits r2 (force-
-        // emit since 300 > 250 page), page 3 (if present) is the
-        // empty AllDone tail page from the helper's loop ordering.
-        Assert.InRange(pages.Count, 2, 3);
+        // Per post-PR-#110 review P1#1 — exactly 2 pages (no
+        // empty AllDone tail page). The pre-P1#2 outer-body
+        // forced-overflow path advanced UsedBlockSize past the
+        // page extent + returned PageComplete pointing past
+        // the last child, producing a spurious page 3.
+        // MeasureSubtreeVisualBlockExtent's paginatable-grid
+        // projection (PR-#110 review P1#2) keeps the body's
+        // break-check on the Continue path so page 2 closes
+        // cleanly with AllDone.
+        Assert.Equal(2, pages.Count);
 
         // Page 1: r1 emits + r2 deferred via continuation.
         var page1 = pages[0];
@@ -1280,14 +1281,33 @@ public sealed class GridLayouterProductionTests
         Assert.NotNull(page1Wrapper);
         Assert.Equal(100.0, page1Wrapper!.Value.BlockSize, precision: 3);
 
-        // Page 2: r2 emits. The fr row resolved to AUTHORED
-        // 300, NOT page-budget 150 — this is the F3 correctness
-        // contract.
+        // Per post-PR-#110 review P1#2 — no stale
+        // PAGINATION-FORCED-OVERFLOW-001 on page 1 even though
+        // the grid's authored extent (400) exceeds the page
+        // budget (250). The body's break-check sees the
+        // projected grid extent (= min(400, 250) = 250) +
+        // takes the Continue path. F3 emits row 0 cleanly +
+        // defers row 1 via the GridContinuation.
+        Assert.DoesNotContain(page1.Diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+
+        // Page 2: r2 emits at AUTHORED fr-resolved 300px
+        // (NOT clamped 150). LastResort force-emits since
+        // 300 > 250 budget; the row geometry is preserved
+        // via the resume cache's RowBaseSizes pinned on page 1.
         var page2 = pages[1];
         Assert.Null(FindByClass(page2.Sink, "r1"));
         Assert.NotNull(FindByClass(page2.Sink, "r2"));
         var r2 = FindByClass(page2.Sink, "r2");
         Assert.Equal(300.0, r2!.Value.BlockSize, precision: 3);
+        // Page 2 outcome AllDone (= the helper loop exits
+        // immediately + no further continuation).
+        Assert.Equal(LayoutAttemptOutcome.AllDone, page2.Result.Outcome);
+        // F2-resized grid wrapper on page 2 at 300 (= the
+        // emitted r2 extent).
+        var page2Wrapper = FindGridWrapper(page2.Sink);
+        Assert.NotNull(page2Wrapper);
+        Assert.Equal(300.0, page2Wrapper!.Value.BlockSize, precision: 3);
     }
 
     /// <summary>Per Phase 3 Task 17 cycle 5c.2d post-PR-#102
@@ -1297,7 +1317,10 @@ public sealed class GridLayouterProductionTests
     /// page's <c>incomingContinuation</c>, until AllDone or
     /// <paramref name="maxPages"/>. Mirrors what the production
     /// document driver would do.</summary>
-    private static async Task<List<(RecordingFragmentSink Sink, LayoutAttemptResult Result)>>
+    private static async Task<List<(
+        RecordingFragmentSink Sink,
+        LayoutAttemptResult Result,
+        RecordingDiagnosticsSink Diag)>>
         RenderMultiPageAsync(
             string html,
             double contentInlineSize,
@@ -1311,7 +1334,7 @@ public sealed class GridLayouterProductionTests
         var resolved = VarResolver.Resolve(cascade, document);
         var box = BoxBuilder.Build(document, resolved);
 
-        var pages = new List<(RecordingFragmentSink, LayoutAttemptResult)>();
+        var pages = new List<(RecordingFragmentSink, LayoutAttemptResult, RecordingDiagnosticsSink)>();
         LayoutContinuation? incoming = null;
         for (var pageIdx = 0; pageIdx < maxPages; pageIdx++)
         {
@@ -1331,7 +1354,7 @@ public sealed class GridLayouterProductionTests
             var result = layouter.AttemptLayout(
                 ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
 
-            pages.Add((sink, result));
+            pages.Add((sink, result, diagSink));
 
             if (result.Outcome == LayoutAttemptOutcome.AllDone) break;
             if (result.Continuation is null) break;

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -1014,20 +1014,27 @@ public sealed class GridLayouterProductionTests
     }
 
     [Fact]
-    public async Task Cycle5c2d_recursive_explicit_height_grid_stays_atomic_pending_F3()
+    public async Task Cycle5c3_recursive_explicit_height_grid_paginates()
     {
-        // Per PR-#101 review P1#1 — explicit-height grids stay
-        // atomic at the recursive site too (= same
-        // IsHeightAuto(child) gate as the outer site).
-        // Strengthened post-PR-#102 review P2#2 to also assert
-        // authored wrapper geometry preserved + diagnostic on
-        // unavoidable forced-overflow.
+        // Per Phase 3 Task 17 cycle 5c.3 — F3 SHIPPED at the
+        // recursive site too. Explicit-height grids reached via
+        // the recursive walk now paginate via the dual-input
+        // dispatch (= authored geometry for row sizing, clamped
+        // geometry for page budget) just like the outer site.
         //
         // Fixture: height: 200px grid with 2 rows of 100px on a
-        // 150px page → wrapper at authored 200 > page 150 →
-        // forced-overflow path (= grid is body's only direct
-        // child + body is at top of fresh page so no break-
-        // before is productive).
+        // 150px page. Pre-F3 the grid went through forced-overflow
+        // (wrapper at authored 200, atomic emit of both rows past
+        // the page edge). Post-F3:
+        //   1. Recursive site authored borderBox = 200.
+        //   2. Recursive clamp shrinks to pageRemaining 150.
+        //   3. Dispatch with authored 200 + budget 150.
+        //   4. Row 0 (100) fits, row 1 (100) makes 200 > 150 →
+        //      defer row 1 via GridContinuation.
+        //   5. F2 wrapper-resize shrinks wrapper to 100.
+        //   6. PaginationForcedOverflow001 no longer fires (= the
+        //      forced-overflow path doesn't run when F3 paginates
+        //      via the Continue path).
         const string html = """
             <!DOCTYPE html><html><head><style>
                 .grid {
@@ -1049,27 +1056,32 @@ public sealed class GridLayouterProductionTests
         var (sink, diag, result, _) = await RenderViaFullPipelineWithResultAsync(
             html, contentInlineSize: 100, blockSize: 150);
 
-        // No GridContinuation in the result chain — F3 isn't
-        // active for explicit-height; the grid renders atomic.
+        // GridContinuation present in chain (= F3 deferred row 1).
         var gridLeaf = result.Continuation is null
             ? null
             : FindGridContinuationLeaf(result.Continuation);
-        Assert.Null(gridLeaf);
-        // Both grid items emitted atomically (= no row drop).
+        Assert.NotNull(gridLeaf);
+        Assert.Equal(1, gridLeaf!.RowIndex);
+        // r1 emitted on page 1; r2 deferred to page 2.
         Assert.NotNull(FindByClass(sink, "r1"));
-        Assert.NotNull(FindByClass(sink, "r2"));
-        // Per P2#2 — authored wrapper geometry preserved (= 200,
-        // not clamped to 150). Look up by class since the grid
-        // div doesn't have a class; find by SourceElement tag
-        // name. Easier: just assert at least one fragment has
-        // BlockSize == 200 (= the grid wrapper).
-        Assert.Contains(sink.Fragments, f => Math.Abs(f.BlockSize - 200.0) < 0.001);
-        // Per P2#2 — unavoidable forced-overflow on a fresh
-        // 150px page produces PaginationForcedOverflow001 (the
-        // outer BlockLayouter's forced-overflow diagnostic; the
-        // grid is dispatched atomically per IsHeightAuto gate).
-        Assert.Contains(diag.Diagnostics, d =>
-            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+        Assert.Null(FindByClass(sink, "r2"));
+        // F2 wrapper-resize: grid wrapper at 100 (= 1 emitted
+        // row), NOT authored 200.
+        Assert.Contains(sink.Fragments, f => Math.Abs(f.BlockSize - 100.0) < 0.001);
+        Assert.DoesNotContain(sink.Fragments, f => Math.Abs(f.BlockSize - 200.0) < 0.001);
+        // KNOWN GAP: the OUTER body wrapper still triggers
+        // PAGINATION-FORCED-OVERFLOW-001 because its
+        // <c>MeasureSubtreeVisualBlockExtent</c> isn't grid-
+        // paginatable-aware — it reports the grid's authored
+        // 200 as the subtree extent for the body's break-check,
+        // which exceeds the 150 page. The body's forced-overflow
+        // emit at 0 then recurses into the grid, where F3
+        // paginates correctly. Eliminating the stale outer
+        // diagnostic requires teaching the subtree-extent helper
+        // to project paginatable descendants to their fragment
+        // budget — tracked separately (= the eventual
+        // <c>grid-fragment-plan-shared-sizing-deferral</c> shared
+        // plan would carry this).
     }
 
     [Fact]
@@ -1209,6 +1221,73 @@ public sealed class GridLayouterProductionTests
         Assert.NotNull(page2Wrapper);
         Assert.Equal(300.0, page1Wrapper!.Value.BlockSize, precision: 3);
         Assert.Equal(100.0, page2Wrapper!.Value.BlockSize, precision: 3);
+    }
+
+    [Fact]
+    public async Task Cycle5c3_explicit_height_grid_with_fr_paginates_with_authored_geometry()
+    {
+        // Per Phase 3 Task 17 cycle 5c.3 — the end-to-end F3
+        // regression test through the full HTML →
+        // cascade → BoxBuilder → BlockLayouter pipeline.
+        //
+        // Fixture: <c>height: 400px;
+        // grid-template-rows: 100px 1fr</c> on a 250px page.
+        // The fr row MUST resolve to 300 (= 400 - 100 authored
+        // distribution), NOT 150 (= 250 - 100 budget-shrunk).
+        //   - Page 1 (250px): row 0 (100) fits, row 1 (300)
+        //     doesn't → emit r1 + defer r2 via continuation.
+        //     Wrapper resized to 100.
+        //   - Page 2 (250px): r2 emits at fr-resolved 300, but
+        //     since 300 > 250 page, the LastResort force-emits
+        //     it (= page-2 wrapper is 300, item r2 is 300, +
+        //     LAYOUT-GRID-FORCED-OVERFLOW-001 fires).
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .grid {
+                    display: grid;
+                    grid-template-rows: 100px 1fr;
+                    grid-template-columns: 100px;
+                    height: 400px;
+                }
+                .r1 { grid-row-start: 1; grid-column-start: 1; }
+                .r2 { grid-row-start: 2; grid-column-start: 1; }
+            </style></head><body>
+            <div class="grid">
+              <div class="r1"></div>
+              <div class="r2"></div>
+            </div>
+            </body></html>
+            """;
+
+        var pages = await RenderMultiPageAsync(
+            html, contentInlineSize: 100, blockSize: 250, maxPages: 4);
+
+        // 2 or 3 pages: page 1 emits r1, page 2 emits r2 (force-
+        // emit since 300 > 250 page), page 3 (if present) is the
+        // empty AllDone tail page from the helper's loop ordering.
+        Assert.InRange(pages.Count, 2, 3);
+
+        // Page 1: r1 emits + r2 deferred via continuation.
+        var page1 = pages[0];
+        Assert.NotNull(FindByClass(page1.Sink, "r1"));
+        Assert.Null(FindByClass(page1.Sink, "r2"));
+        Assert.Equal(LayoutAttemptOutcome.PageComplete, page1.Result.Outcome);
+        // r1 is at the authored row 0 size (100).
+        var r1 = FindByClass(page1.Sink, "r1");
+        Assert.Equal(100.0, r1!.Value.BlockSize, precision: 3);
+        // F2-resized grid wrapper at 100 on page 1.
+        var page1Wrapper = FindGridWrapper(page1.Sink);
+        Assert.NotNull(page1Wrapper);
+        Assert.Equal(100.0, page1Wrapper!.Value.BlockSize, precision: 3);
+
+        // Page 2: r2 emits. The fr row resolved to AUTHORED
+        // 300, NOT page-budget 150 — this is the F3 correctness
+        // contract.
+        var page2 = pages[1];
+        Assert.Null(FindByClass(page2.Sink, "r1"));
+        Assert.NotNull(FindByClass(page2.Sink, "r2"));
+        var r2 = FindByClass(page2.Sink, "r2");
+        Assert.Equal(300.0, r2!.Value.BlockSize, precision: 3);
     }
 
     /// <summary>Per Phase 3 Task 17 cycle 5c.2d post-PR-#102


### PR DESCRIPTION
## Summary

- Ships F3 explicit-height grid pagination, resolving the
  `grid-explicit-height-paginate-deferral`. Explicit-height grids on
  tight pages now paginate via the outer-site + recursive-site clamp +
  dual-input dispatch, replacing the pre-5c.3 atomic-only behavior
  where explicit-height grids would force-overflow past the page edge.
- New `GridLayouter.ConfigureEmission.pageBlockBudget` parameter
  separates row-sizing input from page budget. Auto-height grids fall
  through with `pageBlockBudget: null` and behave identically to
  pre-5c.3. Explicit-height grids resolve row geometry against
  authored height (= fr / definite rows distribute correctly) while
  pagination cuts off at the page-remaining budget.
- BlockLayouter changes: capture `authoredBorderBoxBlockSize` pre-clamp
  at both grid dispatch sites; remove `IsHeightAuto` gates on both
  clamps; re-enable the paginatable-grid subtree-extent clamp parallel
  to the existing flex clamps; F1 probe sites use authored geometry
  so probe sees same row sizes as dispatch.

## Behavior change

Take this fixture (height:400, grid-template-rows:100px 1fr, page 250):
- **Pre-5c.3**: clamp gated on `IsHeightAuto` → didn't fire → break-check
  forced-overflow → atomic dispatch → both rows emit at 100+300 past
  the page edge.
- **5c.3**: clamp fires; authored geometry (400) feeds Resolve so
  fr → 300 (NOT clamped 250-100=150); budget 250 cuts off row 1; r1
  emits on page 1 at 100, r2 deferred via continuation, page 2 emits
  r2 at fr-resolved 300.

## Test plan

- [x] 5,236 unit tests + 6 cycle-5c.3 specific tests pass
- [x] 97 RealDocuments + 30 LayoutSnapshots + 4 AotJitParity all green
- [x] Build clean (0 warnings, 0 errors)
- [x] 5 existing `Cycle5c2c_post_PR_101_*` tests updated to reflect the
  new F3 behavior (Cycle5c3_*); known-gap diagnostic at outer body
  level documented in test comments + deferral entry
- [x] New `Cycle5c3_explicit_height_grid_with_fr_paginates_with_authored_geometry`
  multi-page production test through the full HTML→cascade→BoxBuilder→
  BlockLayouter pipeline asserting fr-row authored geometry preservation
- [x] `grid-explicit-height-paginate-deferral` marked as `shipped` in
  `docs/deferrals.md` with the ship summary + the residual known gap
  (`MeasureSubtreeVisualBlockExtent` isn't grid-paginatable-aware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)