### PR TITLE
Phase 3 Task 19 cycle 2a: nearest-positioned-ancestor containing block

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2512,14 +2512,30 @@ flags the categories):
   collected by the top-level post-flow pass + anchored to this ICB.
 - **Missing** —
   - ~~**Nearest-positioned-ancestor CB + ancestor walk**~~ — SHIPPED
-    in cycle 2a. An abspos box inside a `position: relative` (or any
-    non-`static`) ancestor now anchors to that ancestor's PADDING box
-    (`Box.Parent` walk + per-box geometry recorded during in-flow
-    emit; padding box = recorded border box inset by border widths).
-    ICB remains the fallback when there's no positioned ancestor.
-    Remaining gap: positioned ancestors laid out via the
-    forced-overflow / table-cell / grid-item paths aren't recorded yet
-    (those still fall back to the ICB) — cycle 2b.
+    in cycle 2a (+ post-PR-#113 review). An abspos box inside a
+    `position: relative` (or any non-`static`) ancestor now anchors to
+    that ancestor's PADDING box (`Box.Parent` walk + per-box geometry
+    recorded during in-flow emit at the block-flow + recursive +
+    forced-overflow emit sites; padding box = recorded border box
+    inset by border widths). ICB remains the fallback when there's NO
+    positioned ancestor. Per PR-#113 review P1#1: when a positioned
+    ancestor IS found but its geometry wasn't recorded, the box is
+    DROPPED + diagnosed (`LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001`)
+    rather than misplaced at the ICB.
+    Remaining gap: **positioned GRID / FLEX / TABLE containers as CB
+    establishers** — their wrapper geometry isn't recorded on a path
+    the abspos pass can read (+ the grid/flex item collectors now
+    EXCLUDE abspos children per P1#2 so they aren't double-emitted),
+    so an abspos child of a positioned grid/flex anchors to the ICB or
+    a higher recorded ancestor. Cycle 2b.
+  - **`position: relative` offset application** — per PR-#113 review
+    P2#1, a `position: relative` ancestor with explicit inset offsets
+    (`top`/`right`/`bottom`/`left`) would visually shift, moving its
+    abspos descendants' CB origin; relative-offset application is
+    unimplemented, so such abspos descendants are DROPPED + diagnosed
+    (not anchored to the unshifted flow position). Cycle 2b ships
+    relative-offset application (to both the relative box + its abspos
+    descendants' CB).
   - **`auto` offset resolution (static position)** — `top`/`left` auto
     should resolve to the box's static-flow position per §6. Cycle 2b.
   - **`right`/`bottom` anchoring + over-constrained resolution** — §6

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2511,12 +2511,17 @@ flags the categories):
   positioned root's content box. Abspos descendants at ANY depth are
   collected by the top-level post-flow pass + anchored to this ICB.
 - **Missing** —
-  - **Nearest-positioned-ancestor CB + ancestor walk** — an abspos box
-    inside a `position: relative` ancestor must anchor to that
-    ancestor's PADDING box, not the ICB. Cycle 1 anchors everything to
-    the ICB (correct only when there's no positioned ancestor).
+  - ~~**Nearest-positioned-ancestor CB + ancestor walk**~~ — SHIPPED
+    in cycle 2a. An abspos box inside a `position: relative` (or any
+    non-`static`) ancestor now anchors to that ancestor's PADDING box
+    (`Box.Parent` walk + per-box geometry recorded during in-flow
+    emit; padding box = recorded border box inset by border widths).
+    ICB remains the fallback when there's no positioned ancestor.
+    Remaining gap: positioned ancestors laid out via the
+    forced-overflow / table-cell / grid-item paths aren't recorded yet
+    (those still fall back to the ICB) — cycle 2b.
   - **`auto` offset resolution (static position)** — `top`/`left` auto
-    should resolve to the box's static-flow position per §6.
+    should resolve to the box's static-flow position per §6. Cycle 2b.
   - **`right`/`bottom` anchoring + over-constrained resolution** — §6
     left/right/width (and top/bottom/height) constraint solving. Per
     post-PR-#112 review C1, a box with an EXPLICIT `right` or `bottom`

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -584,6 +584,21 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         ArgumentNullException.ThrowIfNull(resolver);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Per Phase 3 Task 19 cycle 2a post-PR-#113 review P2#2 — clear
+        // the positioned-box geometry map at the start of EACH in-flow
+        // pass. A rewind returns NeedsRewind to the coordinator, which
+        // rolls the sink back + RE-CALLS AttemptLayout — so each
+        // AttemptLayoutInFlow invocation is a single forward pass with
+        // no internal rollback loop. Rebuilding the map from scratch
+        // each call means the COMMITTED pass's map reflects exactly the
+        // boxes that pass emitted (no stale geometry from a rolled-back
+        // speculative attempt). The abspos pass (in the AttemptLayout
+        // wrapper) reads the map immediately after the committed core
+        // returns. This is simpler + more robust than threading the map
+        // through LayoutCheckpoint (which only snapshots cursor state,
+        // not side-table maps).
+        _positionedBoxGeometry?.Clear();
+
         // Per PR #23 review fix #1 — resume point. After a rewind,
         // the coordinator restores state + re-calls AttemptLayout; the
         // retry must resume from the rewind-target's
@@ -2314,6 +2329,14 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                         BlockOffset: forcedOverflowChildBlockOffset,
                         InlineSize: borderBoxInlineSize,
                         BlockSize: borderBoxBlockSize));
+                    // Per Phase 3 Task 19 cycle 2a post-PR-#113 review
+                    // P1#1 — record positioned-CB establishers emitted
+                    // via the forced-overflow path too, so abspos
+                    // descendants anchored to a force-emitted positioned
+                    // box resolve correctly instead of deferring.
+                    RecordPositionedBoxGeometry(
+                        child, forcedOverflowInlineOffset, forcedOverflowChildBlockOffset,
+                        borderBoxInlineSize, borderBoxBlockSize);
 
                     // Per Phase 3 Task 16 cycle 4b post-PR-#83 review
                     // P1 #2 — flex container forced-overflow re-route.
@@ -3583,24 +3606,55 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             _rootBox, icb, diagnostics, ref layout, cancellationToken);
     }
 
-    /// <summary>Per Phase 3 Task 19 cycle 2a — resolve the containing
-    /// block for <paramref name="absBox"/> per CSS Positioned Layout L3
-    /// §6: the nearest ancestor with <c>position</c> != <c>static</c>
-    /// (walked via <see cref="Box.Parent"/>), using that ancestor's
-    /// PADDING box (= its recorded border box inset by its border
-    /// widths). Falls back to <paramref name="icb"/> (the initial
-    /// containing block) when there's no positioned ancestor OR the
-    /// ancestor's geometry wasn't recorded (e.g., it was laid out via a
-    /// path that doesn't record — table cell / grid item / forced-
-    /// overflow; those fall back to the ICB in cycle 2a).</summary>
-    private AbsoluteContainingBlock ResolveContainingBlock(
+    /// <summary>Per Phase 3 Task 19 cycle 2a (+ post-PR-#113 review
+    /// P1#1 / P2#1) — resolve the containing block for
+    /// <paramref name="absBox"/> per CSS Positioned Layout L3 §6: the
+    /// nearest ancestor with <c>position</c> != <c>static</c> (walked
+    /// via <see cref="Box.Parent"/>), using that ancestor's PADDING box
+    /// (= its recorded border box inset by its border widths).
+    ///
+    /// <para><b>Return contract</b>: a non-null
+    /// <see cref="AbsoluteContainingBlock"/> on success;
+    /// <see langword="null"/> = DEFERRED (the caller drops the box with
+    /// <c>LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001</c> rather than
+    /// misplacing it). Cases:</para>
+    /// <list type="bullet">
+    ///   <item>No positioned ancestor → the <paramref name="icb"/>
+    ///   (initial containing block) IS the correct CB per §6.</item>
+    ///   <item>Positioned ancestor found + geometry recorded + (if
+    ///   <c>relative</c>) no explicit inset offsets → its padding
+    ///   box.</item>
+    ///   <item>Per P1#1 — positioned ancestor found but geometry NOT
+    ///   recorded (laid out on a later page that page-1 didn't reach,
+    ///   OR via the table-cell / grid-item / forced-overflow paths that
+    ///   don't record) → DEFER. Falling back to the ICB here would
+    ///   silently MISPLACE the box at the wrong origin.</item>
+    ///   <item>Per P2#1 — a <c>position: relative</c> ancestor with an
+    ///   explicit inset (<c>top</c>/<c>right</c>/<c>bottom</c>/<c>left</c>)
+    ///   → DEFER. Relative-offset application (shifting the ancestor's
+    ///   visual box + therefore its abspos descendants' CB origin) is
+    ///   unimplemented; using the unshifted flow position would place
+    ///   the descendant against the wrong origin.</item>
+    /// </list></summary>
+    private AbsoluteContainingBlock? ResolveContainingBlock(
         Box absBox, AbsoluteContainingBlock icb)
     {
         for (var ancestor = absBox.Parent; ancestor is not null; ancestor = ancestor.Parent)
         {
             if (!ancestor.Style.EstablishesAbsoluteContainingBlock()) continue;
+
+            // P2#1 — a relative ancestor with explicit inset offsets
+            // can't have its (unimplemented) relative shift applied to
+            // the CB origin → defer rather than anchor to the unshifted
+            // flow position.
+            if (ancestor.Style.ReadPosition() == PositionValue.Relative
+                && HasExplicitInset(ancestor.Style))
+            {
+                return null;
+            }
+
             // Found the nearest positioned ancestor. Use its padding
-            // box if we recorded its geometry; else fall back to ICB.
+            // box IFF its geometry was recorded during in-flow emit.
             if (_positionedBoxGeometry is not null
                 && _positionedBoxGeometry.TryGetValue(ancestor, out var borderBox))
             {
@@ -3614,12 +3668,32 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     InlineSize: System.Math.Max(0, borderBox.InlineSize - bl - br),
                     BlockSize: System.Math.Max(0, borderBox.BlockSize - bt - bb));
             }
-            // Positioned ancestor found but geometry not recorded —
-            // ICB fallback (cycle 2a limitation; documented).
-            return icb;
+            // P1#1 — positioned ancestor found but geometry NOT recorded.
+            // Defer (drop + diagnose) instead of misplacing at the ICB.
+            return null;
         }
-        // No positioned ancestor → ICB.
+        // No positioned ancestor → the ICB IS the containing block.
         return icb;
+    }
+
+    /// <summary>Per post-PR-#113 review P2#1 — true when any physical
+    /// inset (<c>top</c>/<c>right</c>/<c>bottom</c>/<c>left</c>) is
+    /// explicitly specified (a length or percentage, not the
+    /// <c>auto</c> default). Used to detect a <c>position: relative</c>
+    /// ancestor whose unimplemented relative shift would otherwise
+    /// corrupt an abspos descendant's containing-block origin.</summary>
+    private static bool HasExplicitInset(ComputedStyle style)
+    {
+        return IsExplicitInset(style, PropertyId.Top)
+            || IsExplicitInset(style, PropertyId.Right)
+            || IsExplicitInset(style, PropertyId.Bottom)
+            || IsExplicitInset(style, PropertyId.Left);
+
+        static bool IsExplicitInset(ComputedStyle s, PropertyId id)
+        {
+            var tag = s.Get(id).Tag;
+            return tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
+        }
     }
 
     /// <summary>Per Phase 3 Task 19 cycle 1 — recursively walk
@@ -3662,9 +3736,28 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         CancellationToken cancellationToken)
     {
         // Per Phase 3 Task 19 cycle 2a — anchor to the nearest
-        // positioned ancestor's padding box (ICB fallback).
+        // positioned ancestor's padding box. Per post-PR-#113 review
+        // P1#1/P2#1 — a null CB means the ancestor's geometry isn't
+        // resolvable this page (unrecorded, or relative-with-offsets):
+        // DROP + diagnose rather than misplace at the ICB.
         var containingBlock = ResolveContainingBlock(child, icb);
-        var placement = AbsoluteLayouter.ResolvePlacement(child, containingBlock);
+        if (containingBlock is null)
+        {
+            OptimizingBreakResolver.SafeEmit(
+                diagnostics,
+                new PaginateDiagnostic(
+                    PaginateDiagnosticCodes.LayoutAbsoluteFeatureUnsupported001,
+                    "position:absolute box dropped (cycle-2a): its containing block "
+                    + "(nearest positioned ancestor) could not be resolved on this "
+                    + "page — the ancestor was laid out via an unrecorded path "
+                    + "(later page / table-cell / grid-item / forced-overflow) OR is "
+                    + "`position: relative` with explicit inset offsets (relative-"
+                    + "offset application is a later cycle).",
+                    PaginateDiagnosticSeverity.Warning));
+            return;
+        }
+
+        var placement = AbsoluteLayouter.ResolvePlacement(child, containingBlock.Value);
         if (!placement.IsResolved)
         {
             OptimizingBreakResolver.SafeEmit(

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -544,6 +544,35 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// coordinator's rewind/retry cycle).</summary>
     private bool _absoluteChildrenEmitted;
 
+    /// <summary>Per Phase 3 Task 19 cycle 2a — border-box geometry (in
+    /// fragmentainer/sink coordinates) of in-flow descendants that
+    /// establish an absolute containing block (<c>position</c> !=
+    /// <c>static</c>), recorded as they're emitted. The post-flow
+    /// abspos pass walks <c>Box.Parent</c> to the nearest such ancestor
+    /// + reads its geometry here to derive the containing block (=
+    /// padding box). Keyed by <see cref="Box"/>; last-write-wins so the
+    /// committed layout pass overwrites any rolled-back rewind attempt.
+    /// Lazily allocated (most documents have no positioned ancestors).</summary>
+    private System.Collections.Generic.Dictionary<Box, BoxFragment>? _positionedBoxGeometry;
+
+    /// <summary>Per Phase 3 Task 19 cycle 2a — record an in-flow box's
+    /// emitted border-box geometry IFF it establishes an absolute
+    /// containing block, so the abspos pass can anchor descendants to
+    /// it. No-op for the common (non-positioned) box.</summary>
+    private void RecordPositionedBoxGeometry(
+        Box box, double inlineOffset, double blockOffset,
+        double inlineSize, double blockSize)
+    {
+        if (!box.Style.EstablishesAbsoluteContainingBlock()) return;
+        _positionedBoxGeometry ??= new System.Collections.Generic.Dictionary<Box, BoxFragment>();
+        _positionedBoxGeometry[box] = new BoxFragment(
+            Box: box,
+            InlineOffset: inlineOffset,
+            BlockOffset: blockOffset,
+            InlineSize: inlineSize,
+            BlockSize: blockSize);
+    }
+
     private LayoutAttemptResult AttemptLayoutInFlow(
         FragmentainerContext fragmentainer,
         ref LayoutContext layout,
@@ -2852,6 +2881,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 BlockOffset: blockOffset,
                 InlineSize: borderBoxInlineSize,
                 BlockSize: borderBoxBlockSize));
+            // Per Phase 3 Task 19 cycle 2a — record positioned-CB
+            // establishers for abspos descendant anchoring.
+            RecordPositionedBoxGeometry(
+                child, inFlowInlineOffset, blockOffset,
+                borderBoxInlineSize, borderBoxBlockSize);
 
             // Per Phase 3 Task 14 cycle 1 — multicol container
             // dispatch. A block container with `column-count: N`
@@ -3531,7 +3565,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         ref LayoutContext layout,
         CancellationToken cancellationToken)
     {
-        var containingBlock = new AbsoluteContainingBlock(
+        // The initial containing block (cycle 1 fallback) = the
+        // fragmentainer content area. Cycle 2a anchors each abspos box
+        // to its NEAREST positioned ancestor's padding box when one
+        // exists (see ResolveContainingBlock); the ICB is the fallback
+        // when there's no positioned ancestor.
+        var icb = new AbsoluteContainingBlock(
             InlineOrigin: 0,
             BlockOrigin: 0,
             InlineSize: fragmentainer.ContentInlineSize,
@@ -3541,7 +3580,46 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // The diagnostics sink is captured once for the whole pass.
         var diagnostics = layout.Diagnostics ?? _diagnostics;
         EmitAbsolutelyPositionedDescendants(
-            _rootBox, containingBlock, diagnostics, ref layout, cancellationToken);
+            _rootBox, icb, diagnostics, ref layout, cancellationToken);
+    }
+
+    /// <summary>Per Phase 3 Task 19 cycle 2a — resolve the containing
+    /// block for <paramref name="absBox"/> per CSS Positioned Layout L3
+    /// §6: the nearest ancestor with <c>position</c> != <c>static</c>
+    /// (walked via <see cref="Box.Parent"/>), using that ancestor's
+    /// PADDING box (= its recorded border box inset by its border
+    /// widths). Falls back to <paramref name="icb"/> (the initial
+    /// containing block) when there's no positioned ancestor OR the
+    /// ancestor's geometry wasn't recorded (e.g., it was laid out via a
+    /// path that doesn't record — table cell / grid item / forced-
+    /// overflow; those fall back to the ICB in cycle 2a).</summary>
+    private AbsoluteContainingBlock ResolveContainingBlock(
+        Box absBox, AbsoluteContainingBlock icb)
+    {
+        for (var ancestor = absBox.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (!ancestor.Style.EstablishesAbsoluteContainingBlock()) continue;
+            // Found the nearest positioned ancestor. Use its padding
+            // box if we recorded its geometry; else fall back to ICB.
+            if (_positionedBoxGeometry is not null
+                && _positionedBoxGeometry.TryGetValue(ancestor, out var borderBox))
+            {
+                var bl = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderLeftWidth);
+                var bt = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderTopWidth);
+                var br = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderRightWidth);
+                var bb = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderBottomWidth);
+                return new AbsoluteContainingBlock(
+                    InlineOrigin: borderBox.InlineOffset + bl,
+                    BlockOrigin: borderBox.BlockOffset + bt,
+                    InlineSize: System.Math.Max(0, borderBox.InlineSize - bl - br),
+                    BlockSize: System.Math.Max(0, borderBox.BlockSize - bt - bb));
+            }
+            // Positioned ancestor found but geometry not recorded —
+            // ICB fallback (cycle 2a limitation; documented).
+            return icb;
+        }
+        // No positioned ancestor → ICB.
+        return icb;
     }
 
     /// <summary>Per Phase 3 Task 19 cycle 1 — recursively walk
@@ -3578,11 +3656,14 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
 
     private void EmitOneAbsoluteBox(
         Box child,
-        AbsoluteContainingBlock containingBlock,
+        AbsoluteContainingBlock icb,
         IPaginateDiagnosticsSink? diagnostics,
         ref LayoutContext layout,
         CancellationToken cancellationToken)
     {
+        // Per Phase 3 Task 19 cycle 2a — anchor to the nearest
+        // positioned ancestor's padding box (ICB fallback).
+        var containingBlock = ResolveContainingBlock(child, icb);
         var placement = AbsoluteLayouter.ResolvePlacement(child, containingBlock);
         if (!placement.IsResolved)
         {
@@ -4676,6 +4757,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 BlockOffset: childBlockOffset,
                 InlineSize: childBorderBoxInlineSize,
                 BlockSize: childBorderBoxBlockSize));
+            // Per Phase 3 Task 19 cycle 2a — record positioned-CB
+            // establishers reached via the recursive walk so abspos
+            // descendants anchor to their nearest positioned ancestor.
+            RecordPositionedBoxGeometry(
+                child, childInlineOffset, childBlockOffset,
+                childBorderBoxInlineSize, childBorderBoxBlockSize);
 
             // Per Phase 3 Task 14 cycle 1 — nested multicol dispatch.
             // A nested block-flow descendant with `column-count: N`

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -1054,6 +1054,15 @@ internal static class ComputedStyleLayoutExtensions
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!flexContainer.Children[i].IsBlockLevel) continue;
+            // Per Phase 3 Task 19 cycle 2a post-PR-#113 review P1#2 — an
+            // absolutely-positioned child of a flex container is NOT a
+            // flex item (CSS Flexbox L1 §4 / CSS Positioned Layout L3
+            // §3): it's out-of-flow + doesn't participate in flex line
+            // packing. Excluding it keeps it from displacing real flex
+            // items + from being emitted by the FlexLayouter; the
+            // establishing BlockLayouter's post-flow abspos pass owns
+            // its placement (otherwise double emission).
+            if (flexContainer.Children[i].Style.IsAbsolutelyPositioned()) continue;
             var order = flexContainer.Children[i].Style.ReadOrder();
             if (order != 0) hasNonZeroOrder = true;
             indexedOrders.Add((i, order));

--- a/src/NetPdf.Layout/Layouters/GridSizing.cs
+++ b/src/NetPdf.Layout/Layouters/GridSizing.cs
@@ -2787,6 +2787,16 @@ internal static class GridSizing
     /// mirroring <c>GridLayouter.IsGridItem</c>.</summary>
     private static bool IsGridItem(Box box)
     {
+        // Per Phase 3 Task 19 cycle 2a post-PR-#113 review P1#2 — an
+        // absolutely-positioned child of a grid container is NOT a grid
+        // item (CSS Grid L1 §9 / CSS Positioned Layout L3 §3): it's
+        // out-of-flow. Excluding it here keeps it from occupying a grid
+        // cell + from being emitted by the grid; the establishing
+        // BlockLayouter's post-flow abspos pass owns its placement +
+        // emission (otherwise it would be emitted twice). The static
+        // position influence of the grid area on the abspos box is a
+        // later-cycle refinement.
+        if (box.Style.IsAbsolutelyPositioned()) return false;
         return box.Kind is BoxKind.BlockContainer
             or BoxKind.GridContainer or BoxKind.InlineGridContainer
             or BoxKind.FlexContainer or BoxKind.InlineFlexContainer

--- a/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
@@ -159,6 +159,43 @@ public sealed class AbsoluteLayouterProductionTests
         Assert.Equal(40.0, abs.Value.InlineSize, precision: 3);
     }
 
+    [Fact]
+    public async Task Cycle2a_production_abspos_anchors_to_relative_parent()
+    {
+        // Per Phase 3 Task 19 cycle 2a — `position: absolute` inside a
+        // `position: relative` parent anchors to the PARENT's padding
+        // box, not the initial containing block. The relative parent
+        // sits at block 100 (after a 100px spacer); the abspos child's
+        // top:10 left:20 resolve relative to the parent's content/
+        // padding-box origin (parent has no border → padding box ==
+        // border box origin = (0, 100)).
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .spacer { height: 100px; }
+                .rel { position: relative; height: 300px; }
+                .abs {
+                    position: absolute;
+                    top: 10px; left: 20px;
+                    width: 50px; height: 30px;
+                }
+            </style></head><body>
+            <div class="spacer"></div>
+            <div class="rel">
+              <div class="abs"></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var abs = FindByClass(sink, "abs");
+        Assert.NotNull(abs);
+        // Anchored to .rel's padding box (origin 0, 100) + top/left.
+        Assert.Equal(20.0, abs!.Value.InlineOffset, precision: 3); // 0 + 20
+        Assert.Equal(110.0, abs.Value.BlockOffset, precision: 3);  // 100 + 10
+        Assert.Equal(50.0, abs.Value.InlineSize, precision: 3);
+        Assert.Equal(30.0, abs.Value.BlockSize, precision: 3);
+    }
+
     // ================================================================
     //  Pipeline driver — mirrors GridLayouterProductionTests.
     // ================================================================

--- a/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
@@ -196,6 +196,103 @@ public sealed class AbsoluteLayouterProductionTests
         Assert.Equal(30.0, abs.Value.BlockSize, precision: 3);
     }
 
+    [Fact]
+    public async Task Cycle2a_production_abspos_in_grid_emits_once_no_displacement()
+    {
+        // Per post-PR-#113 review P1#2 — an abspos child of a grid
+        // container is out-of-flow: it must NOT occupy a grid cell or
+        // be emitted by the grid (it's emitted ONCE by the abspos
+        // pass). The two real grid items (.a, .b) fill cols 1+2 of row
+        // 1 undisplaced; the abspos box anchors to the ICB.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .grid {
+                    display: grid;
+                    grid-template-rows: 100px;
+                    grid-template-columns: 100px 100px;
+                    width: 200px;
+                }
+                .abs {
+                    position: absolute;
+                    top: 5px; left: 5px; width: 30px; height: 30px;
+                }
+            </style></head><body>
+            <div class="grid">
+              <div class="a"></div>
+              <div class="abs"></div>
+              <div class="b"></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var a = FindByClass(sink, "a");
+        var b = FindByClass(sink, "b");
+        // .a + .b are the only two grid items → cols 0 and 1. The
+        // abspos box did NOT take a cell (else .b would be at row 2).
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(0.0, a!.Value.InlineOffset, precision: 3);
+        Assert.Equal(0.0, a.Value.BlockOffset, precision: 3);
+        Assert.Equal(100.0, b!.Value.InlineOffset, precision: 3);
+        Assert.Equal(0.0, b.Value.BlockOffset, precision: 3);
+        // The abspos box is emitted exactly once, at the ICB anchor.
+        var absFrags = sink.Fragments.Where(f =>
+            f.Box.SourceElement?.GetAttribute("class")?.Split(' ').Contains("abs") == true)
+            .ToList();
+        Assert.Single(absFrags);
+        Assert.Equal(5.0, absFrags[0].InlineOffset, precision: 3);
+        Assert.Equal(5.0, absFrags[0].BlockOffset, precision: 3);
+    }
+
+    [Fact]
+    public async Task Cycle2a_production_abspos_in_flex_emits_once_no_displacement()
+    {
+        // Per post-PR-#113 review P1#2 — abspos child of a flex
+        // container is out-of-flow: not a flex item, emitted once.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .flex { display: flex; width: 300px; }
+                .a { width: 100px; height: 50px; }
+                .b { width: 100px; height: 50px; }
+                .abs {
+                    position: absolute;
+                    top: 5px; left: 5px; width: 30px; height: 30px;
+                }
+            </style></head><body>
+            <div class="flex">
+              <div class="a"></div>
+              <div class="abs"></div>
+              <div class="b"></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var a = FindByClass(sink, "a");
+        var b = FindByClass(sink, "b");
+        // .a at main-start 0; .b directly after at 100 (the abspos box
+        // didn't consume a flex slot, else .b would be at 200).
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(0.0, a!.Value.InlineOffset, precision: 3);
+        Assert.Equal(100.0, b!.Value.InlineOffset, precision: 3);
+        var absFrags = sink.Fragments.Where(f =>
+            f.Box.SourceElement?.GetAttribute("class")?.Split(' ').Contains("abs") == true)
+            .ToList();
+        Assert.Single(absFrags);
+    }
+
+    // NB: the PADDING-box border inset (CB = positioned ancestor's
+    // padding box, not border box) is proven deterministically by the
+    // BlockLayouterTests integration test
+    // `Cycle2a_abspos_anchors_to_positioned_ancestor_padding_box`
+    // (which sets BorderTopWidth/etc explicitly). A production-CSS
+    // version is entangled with `border` shorthand + border-style
+    // cascade interaction; positioned GRID/FLEX containers as CB
+    // establishers are a cycle-2b item (only block-flow positioned
+    // ancestors record their geometry today — see deferrals.md).
+
     // ================================================================
     //  Pipeline driver — mirrors GridLayouterProductionTests.
     // ================================================================

--- a/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
@@ -6274,6 +6274,84 @@ public sealed class BlockLayouterTests
         Assert.Equal(10.0, absFrag.BlockOffset, precision: 3);
     }
 
+    [Fact]
+    public void Cycle2a_abspos_under_relative_ancestor_with_offsets_dropped_with_diagnostic()
+    {
+        // Per post-PR-#113 review P2#1 — a `position: relative` ancestor
+        // with explicit inset offsets (top/left) would visually shift,
+        // moving its abspos descendants' CB origin. Relative-offset
+        // application is unimplemented, so the abspos child is DROPPED +
+        // LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001 emitted rather than
+        // anchored to the unshifted flow position.
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        var root = Box.CreateRoot(MakeStyle());
+
+        var relStyle = MakeStyle();
+        SetKeyword(relStyle, PropertyId.Position, 1); // relative
+        SetLengthPx(relStyle, PropertyId.Height, 200);
+        SetLengthPx(relStyle, PropertyId.Top, 50);   // relative offset
+        SetLengthPx(relStyle, PropertyId.Left, 10);
+        var rel = Box.ForElement(BoxKind.BlockContainer, relStyle, MakeElement());
+        root.AppendChild(rel);
+
+        var absStyle = MakeStyle();
+        SetKeyword(absStyle, PropertyId.Position, 2); // absolute
+        SetLengthPx(absStyle, PropertyId.Top, 0);
+        SetLengthPx(absStyle, PropertyId.Left, 0);
+        SetLengthPx(absStyle, PropertyId.Width, 30);
+        SetLengthPx(absStyle, PropertyId.Height, 30);
+        var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
+        rel.AppendChild(abs);
+
+        using var layouter = new BlockLayouter(root, sink, diagnostics: diag);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx) { Diagnostics = diag };
+        using var resolver = new BreakResolver();
+
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        Assert.DoesNotContain(sink.Fragments, f => ReferenceEquals(f.Box, abs));
+        Assert.Contains(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutAbsoluteFeatureUnsupported001);
+    }
+
+    [Fact]
+    public void Cycle2a_abspos_relative_ancestor_no_offsets_still_anchors()
+    {
+        // Sanity: a `position: relative` ancestor WITHOUT offsets is the
+        // fully-supported case (the cycle-2a headline) — the abspos
+        // child still anchors to its padding box, not dropped.
+        var sink = new RecordingFragmentSink();
+        var root = Box.CreateRoot(MakeStyle());
+
+        var relStyle = MakeStyle();
+        SetKeyword(relStyle, PropertyId.Position, 1);
+        SetLengthPx(relStyle, PropertyId.Height, 200);
+        var rel = Box.ForElement(BoxKind.BlockContainer, relStyle, MakeElement());
+        root.AppendChild(rel);
+
+        var absStyle = MakeStyle();
+        SetKeyword(absStyle, PropertyId.Position, 2);
+        SetLengthPx(absStyle, PropertyId.Top, 10);
+        SetLengthPx(absStyle, PropertyId.Left, 20);
+        SetLengthPx(absStyle, PropertyId.Width, 30);
+        SetLengthPx(absStyle, PropertyId.Height, 30);
+        var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
+        rel.AppendChild(abs);
+
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        var absFrag = sink.Fragments.First(f => ReferenceEquals(f.Box, abs));
+        Assert.Equal(20.0, absFrag.InlineOffset, precision: 3); // rel at (0,0), no border
+        Assert.Equal(10.0, absFrag.BlockOffset, precision: 3);
+    }
+
     private static ComputedStyle MakeStyle() => ComputedStyle.RentForExclusiveTesting();
 
     private static void SetLengthPx(ComputedStyle style, PropertyId id, double px) =>

--- a/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
@@ -6181,6 +6181,99 @@ public sealed class BlockLayouterTests
         Assert.Equal(30.0, innerFrag.BlockSize, precision: 3);
     }
 
+    // --- Cycle 2a: nearest-positioned-ancestor containing block -------
+
+    [Fact]
+    public void Cycle2a_abspos_anchors_to_positioned_ancestor_padding_box()
+    {
+        // A position:relative ancestor establishes the containing block.
+        // The relative parent sits at block 50 (after a 50px spacer)
+        // with a 10px border; its abspos child with top:10 left:20
+        // anchors to the parent's PADDING box origin (border-box origin
+        // + border widths), NOT the ICB.
+        //
+        //   spacer: height 50 → relative parent border-box top = 50.
+        //   relative parent: border 10, height 200 → padding-box origin
+        //     = (10 inline, 50 + 10 = 60 block).
+        //   abs child top:10 left:20 → (10+20=30 inline, 60+10=70 block).
+        var sink = new RecordingFragmentSink();
+        var root = Box.CreateRoot(MakeStyle());
+
+        var spacerStyle = MakeStyle();
+        SetLengthPx(spacerStyle, PropertyId.Height, 50);
+        root.AppendChild(Box.ForElement(BoxKind.BlockContainer, spacerStyle, MakeElement()));
+
+        var relStyle = MakeStyle();
+        SetKeyword(relStyle, PropertyId.Position, 1); // relative
+        SetLengthPx(relStyle, PropertyId.Height, 200);
+        SetLengthPx(relStyle, PropertyId.BorderTopWidth, 10);
+        SetLengthPx(relStyle, PropertyId.BorderLeftWidth, 10);
+        SetLengthPx(relStyle, PropertyId.BorderRightWidth, 10);
+        SetLengthPx(relStyle, PropertyId.BorderBottomWidth, 10);
+        var rel = Box.ForElement(BoxKind.BlockContainer, relStyle, MakeElement());
+        root.AppendChild(rel);
+
+        var absStyle = MakeStyle();
+        SetKeyword(absStyle, PropertyId.Position, 2); // absolute
+        SetLengthPx(absStyle, PropertyId.Top, 10);
+        SetLengthPx(absStyle, PropertyId.Left, 20);
+        SetLengthPx(absStyle, PropertyId.Width, 30);
+        SetLengthPx(absStyle, PropertyId.Height, 30);
+        var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
+        rel.AppendChild(abs);
+
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        var absFrag = sink.Fragments.First(f => ReferenceEquals(f.Box, abs));
+        // Anchored to the relative parent's padding box, NOT the ICB.
+        Assert.Equal(30.0, absFrag.InlineOffset, precision: 3); // 10(border)+20(left)
+        Assert.Equal(70.0, absFrag.BlockOffset, precision: 3);  // 50(spacer)+10(border)+10(top)
+        Assert.Equal(30.0, absFrag.InlineSize, precision: 3);
+        Assert.Equal(30.0, absFrag.BlockSize, precision: 3);
+    }
+
+    [Fact]
+    public void Cycle2a_abspos_no_positioned_ancestor_falls_back_to_icb()
+    {
+        // Sanity: with the relative parent made static, the abspos box
+        // falls back to the ICB (= fragmentainer origin), so top/left
+        // are NOT offset by the (now static) ancestor.
+        var sink = new RecordingFragmentSink();
+        var root = Box.CreateRoot(MakeStyle());
+
+        var staticParentStyle = MakeStyle();
+        SetLengthPx(staticParentStyle, PropertyId.Height, 200);
+        var staticParent = Box.ForElement(
+            BoxKind.BlockContainer, staticParentStyle, MakeElement());
+        root.AppendChild(staticParent);
+
+        var absStyle = MakeStyle();
+        SetKeyword(absStyle, PropertyId.Position, 2);
+        SetLengthPx(absStyle, PropertyId.Top, 10);
+        SetLengthPx(absStyle, PropertyId.Left, 20);
+        SetLengthPx(absStyle, PropertyId.Width, 30);
+        SetLengthPx(absStyle, PropertyId.Height, 30);
+        var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
+        staticParent.AppendChild(abs);
+
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        var absFrag = sink.Fragments.First(f => ReferenceEquals(f.Box, abs));
+        // ICB anchoring: top/left from fragmentainer origin (0,0).
+        Assert.Equal(20.0, absFrag.InlineOffset, precision: 3);
+        Assert.Equal(10.0, absFrag.BlockOffset, precision: 3);
+    }
+
     private static ComputedStyle MakeStyle() => ComputedStyle.RentForExclusiveTesting();
 
     private static void SetLengthPx(ComputedStyle style, PropertyId id, double px) =>


### PR DESCRIPTION
## Summary

Extends the cycle-1 abspos MVP so a `position: absolute` box anchors to its **nearest positioned ancestor's padding box** (CSS Positioned Layout L3 §6) instead of always the initial containing block. This makes the canonical `position:absolute` inside `position:relative` pattern work.

- `BlockLayouter` records the border-box geometry of in-flow boxes that establish a containing block (`position != static`) as they're emitted (top-level + recursive sites), into a lazy `Dictionary<Box,BoxFragment>` (last-write-wins).
- The post-flow abspos pass resolves each box's CB via `ResolveContainingBlock`: walk `Box.Parent` to the nearest positioned ancestor; CB = its padding box (recorded border box inset by border widths), else ICB.

## Cycle-2a scope + deferrals (cycle 2b)

Shipped: CB resolution + padding-box derivation. Still deferred: `auto` offset (static position), percentage offsets/sizes, `right`/`bottom` anchoring + over-constrained §6 solver, `auto` width/height, and positioned ancestors laid out via forced-overflow/table-cell/grid-item paths (ICB fallback for now). `deferrals.md` updated.

## Test plan

- [x] 2 `BlockLayouter` integration tests (anchor to relative ancestor's padding box; static-ancestor → ICB fallback)
- [x] 1 production test (`abs` inside `rel` after a spacer, end-to-end)
- [x] All 21 prior abspos tests still green (ICB behavior unchanged when no positioned ancestor)
- [x] 5,320 unit + 97 RealDocuments + 30 LayoutSnapshots + 4 AotJitParity green
- [x] AOT/JIT byte-parity preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)