### PR TITLE
Phase 3 Task 19 cycle 2b: full §6 abspos offset/size solver

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2528,29 +2528,33 @@ flags the categories):
     EXCLUDE abspos children per P1#2 so they aren't double-emitted),
     so an abspos child of a positioned grid/flex anchors to the ICB or
     a higher recorded ancestor. Cycle 2b.
-  - **`position: relative` offset application** — per PR-#113 review
-    P2#1, a `position: relative` ancestor with explicit inset offsets
-    (`top`/`right`/`bottom`/`left`) would visually shift, moving its
-    abspos descendants' CB origin; relative-offset application is
-    unimplemented, so such abspos descendants are DROPPED + diagnosed
-    (not anchored to the unshifted flow position). Cycle 2b ships
-    relative-offset application (to both the relative box + its abspos
-    descendants' CB).
-  - **`auto` offset resolution (static position)** — `top`/`left` auto
-    should resolve to the box's static-flow position per §6. Cycle 2b.
-  - **`right`/`bottom` anchoring + over-constrained resolution** — §6
-    left/right/width (and top/bottom/height) constraint solving. Per
-    post-PR-#112 review C1, a box with an EXPLICIT `right` or `bottom`
-    (length or percentage) is DEFERRED (dropped with the diagnostic)
-    rather than silently placed via top/left — cycle 1 doesn't honor
-    them. Cycle 2 ships the full constraint solver (incl. the
-    over-constrained LTR "ignore right/bottom" rule).
-  - **Percentage** `top`/`left`/`width`/`height` (resolve against the
-    CB extent).
-  - **`auto` width/height** — shrink-to-fit + offset-derived sizing.
-  - **Padding-box CB** — cycle 1 uses the content box (= padding box
-    only when the ancestor has zero padding).
-  - **z-index paint ordering** — cycle 1 paints in source order.
+  - ~~**`position: relative` offset application (to the CB)**~~ —
+    SHIPPED in cycle 2b. A `position: relative` ancestor's §9.4.3 shift
+    (`left`/`top`, or `-right`/`-bottom`) is now applied to the abspos
+    descendant's CB origin. (The relative box's OWN in-flow fragment is
+    still emitted unshifted — applying relative offsets to the relative
+    box's own rendering is a separate relative-positioning slice.)
+  - ~~**`auto` offset resolution (static position)**~~ — SHIPPED in
+    cycle 2b as an APPROXIMATION: `auto` insets resolve to the CB
+    content origin (offset 0), exact when the box would have been the
+    first in-flow child. True static-flow-position tracking is a later
+    refinement.
+  - ~~**`right`/`bottom` anchoring + over-constrained resolution**~~ —
+    SHIPPED in cycle 2b: the full CSS 2.1 §10.3.7 / §10.6.4 constraint
+    solver (right/bottom anchoring, over-constrained "ignore the end
+    inset" LTR/ttb rule, auto-margin centering).
+  - ~~**Percentage** `top`/`left`/`width`/`height`~~ — SHIPPED in
+    cycle 2b (resolve against the CB inline / block extent).
+  - **`auto` width/height (true shrink-to-fit / content height)** —
+    cycle 2b approximates an `auto` size NOT pinned by both insets as
+    the AVAILABLE extent (CB minus resolved insets + margins + chrome).
+    The pinned-both-insets case (fill) is EXACT. True shrink-to-fit
+    (inline) + content height (block) need intrinsic-size measurement
+    (the speculative-measure machinery TableLayouter uses) — a later
+    refinement.
+  - **Padding-box CB** — uses the recorded border box inset by border
+    widths = the padding box (correct). [Resolved cycle 2a.]
+  - **z-index paint ordering** — paints in source order; no z-index.
   - **Pagination interaction** — cycle 1 emits all abspos boxes on the
     establishing block's FIRST page (the `AttemptLayout` wrapper runs
     the pass once, for `_incomingContinuation is null`, on AllDone OR

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2522,18 +2522,34 @@ flags the categories):
     ancestor IS found but its geometry wasn't recorded, the box is
     DROPPED + diagnosed (`LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001`)
     rather than misplaced at the ICB.
-    Remaining gap: **positioned GRID / FLEX / TABLE containers as CB
-    establishers** — their wrapper geometry isn't recorded on a path
-    the abspos pass can read (+ the grid/flex item collectors now
-    EXCLUDE abspos children per P1#2 so they aren't double-emitted),
-    so an abspos child of a positioned grid/flex anchors to the ICB or
-    a higher recorded ancestor. Cycle 2b.
+    Per post-PR-#114 review P2#4: a positioned GRID ITEM / TABLE CELL /
+    abspos box that is itself the root of a nested-BlockLayouter
+    formatting context now resolves its OWN abspos descendants against
+    that nested layouter's ICB (= the positioned root's content area),
+    rather than dropping them — the nested layouter owns + emits them
+    exactly once, and the top-level pass stops at that delegation
+    boundary (grid items + table cells/captions) so it doesn't
+    double-emit. (Flex is NOT a boundary — `FlexLayouter` spawns no
+    per-item nested BlockLayouter, so an abspos box inside a flex item's
+    content is emitted by the top-level pass; adding flex to the
+    boundary would DROP it.)
+    Remaining gap: **positioned GRID / FLEX / TABLE containers (the
+    WRAPPER) as CB establishers** — a positioned ancestor that sits
+    ABOVE a nested layouter's subtree (e.g., a positioned grid container
+    with a static item holding the abspos box) still isn't recorded on a
+    path the abspos pass can read, so such a box anchors to the ICB or a
+    higher recorded ancestor / is dropped + diagnosed. Later cycle.
   - ~~**`position: relative` offset application (to the CB)**~~ —
     SHIPPED in cycle 2b. A `position: relative` ancestor's §9.4.3 shift
     (`left`/`top`, or `-right`/`-bottom`) is now applied to the abspos
-    descendant's CB origin. (The relative box's OWN in-flow fragment is
-    still emitted unshifted — applying relative offsets to the relative
-    box's own rendering is a separate relative-positioning slice.)
+    descendant's CB origin. Per post-PR-#114 review P1#2: PERCENTAGE
+    relative offsets resolve PER-AXIS — `left`/`right` against the
+    ancestor's inline extent, `top`/`bottom` against its BLOCK extent
+    (pre-fix both used the inline extent, shifting the block axis along
+    the wrong dimension whenever the two differ). (The relative box's
+    OWN in-flow fragment is still emitted unshifted — applying relative
+    offsets to the relative box's own rendering is a separate
+    relative-positioning slice.)
   - ~~**`auto` offset resolution (static position)**~~ — SHIPPED in
     cycle 2b as an APPROXIMATION: `auto` insets resolve to the CB
     content origin (offset 0), exact when the box would have been the
@@ -2542,7 +2558,14 @@ flags the categories):
   - ~~**`right`/`bottom` anchoring + over-constrained resolution**~~ —
     SHIPPED in cycle 2b: the full CSS 2.1 §10.3.7 / §10.6.4 constraint
     solver (right/bottom anchoring, over-constrained "ignore the end
-    inset" LTR/ttb rule, auto-margin centering).
+    inset" LTR/ttb rule, auto-margin centering). Per post-PR-#114 review
+    P1#1: the auto-margin centering applies the §10.3.7 negative-slack
+    rule on the INLINE axis only — an over-constrained over-wide box
+    with both inline margins `auto` pins `margin-left` to 0 (LTR) and
+    lets `margin-right` absorb the negative slack (stays anchored at
+    `left`), rather than splitting the negative slack equally (which
+    would shift it left of `left`). The BLOCK axis (§10.6.4) has no such
+    clause and still centers even when the margins go negative.
   - ~~**Percentage** `top`/`left`/`width`/`height`~~ — SHIPPED in
     cycle 2b (resolve against the CB inline / block extent).
   - **`auto` width/height (true shrink-to-fit / content height)** —
@@ -2551,7 +2574,11 @@ flags the categories):
     The pinned-both-insets case (fill) is EXACT. True shrink-to-fit
     (inline) + content height (block) need intrinsic-size measurement
     (the speculative-measure machinery TableLayouter uses) — a later
-    refinement.
+    refinement. Per post-PR-#114 review P2#3: when the end inset
+    (`right`/`bottom`) exceeds the CB and the available size goes
+    negative, the size clamps to 0 but the END anchor is PRESERVED —
+    the box's start offset is recomputed from the end inset (a negative
+    offset) instead of being re-pinned to the static position 0.
   - **Padding-box CB** — uses the recorded border box inset by border
     widths = the padding box (correct). [Resolved cycle 2a.]
   - **z-index paint ordering** — paints in source order; no z-index.

--- a/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
@@ -43,9 +43,14 @@ internal static class AbsoluteLayouter
 {
     /// <summary>Resolve a <c>position: absolute</c> box's border-box
     /// rectangle in the SAME coordinate space as
-    /// <paramref name="cb"/> (= the caller's sink coordinates). Returns
-    /// <see cref="AbsolutePlacement.Unresolved"/> only for the
-    /// genuinely-invalid case (negative resolved size).</summary>
+    /// <paramref name="cb"/> (= the caller's sink coordinates). The §6
+    /// solver always returns a <see cref="AbsolutePlacement.Resolved"/>
+    /// placement: a negative resolved content size is CLAMPED to 0 (CSS
+    /// used width/height are >= 0) rather than reported as unresolved.
+    /// <see cref="AbsolutePlacement.Unresolved"/> is retained for the
+    /// API contract (the caller's <c>IsResolved</c> check) but is no
+    /// longer produced here — the <c>BlockLayouter</c>'s null-containing-
+    /// block path is the drop site.</summary>
     public static AbsolutePlacement ResolvePlacement(
         Box box, AbsoluteContainingBlock cb)
     {
@@ -64,7 +69,8 @@ internal static class AbsoluteLayouter
             paddingStart: ReadPxOrPct(style, PropertyId.PaddingLeft, cb.InlineSize),
             paddingEnd: ReadPxOrPct(style, PropertyId.PaddingRight, cb.InlineSize),
             borderEnd: style.ReadLengthPxOrZero(PropertyId.BorderRightWidth),
-            cbExtent: cb.InlineSize);
+            cbExtent: cb.InlineSize,
+            isInlineAxis: true);
 
         // Block axis: top = inset-start, bottom = inset-end, height =
         // size. Per CSS 2.1 percentage top/bottom/height resolve against
@@ -82,7 +88,8 @@ internal static class AbsoluteLayouter
             paddingStart: ReadPxOrPct(style, PropertyId.PaddingTop, cb.InlineSize),
             paddingEnd: ReadPxOrPct(style, PropertyId.PaddingBottom, cb.InlineSize),
             borderEnd: style.ReadLengthPxOrZero(PropertyId.BorderBottomWidth),
-            cbExtent: cb.BlockSize);
+            cbExtent: cb.BlockSize,
+            isInlineAxis: false);
 
         // SolveAxis already clamps a negative resolved content size to
         // 0 (CSS clamps used width/height to >= 0), so inlineSize /
@@ -107,7 +114,7 @@ internal static class AbsoluteLayouter
         double? insetStart, double? insetEnd, double? size,
         double? marginStart, double? marginEnd,
         double borderStart, double paddingStart, double paddingEnd, double borderEnd,
-        double cbExtent)
+        double cbExtent, bool isInlineAxis)
     {
         var chrome = borderStart + paddingStart + paddingEnd + borderEnd;
         var startAuto = insetStart is null;
@@ -124,9 +131,26 @@ internal static class AbsoluteLayouter
             double mS, mE;
             if (marginStart is null && marginEnd is null)
             {
-                // Both auto → center (split slack; may be negative).
-                mS = slack / 2.0;
-                mE = slack - mS;
+                if (isInlineAxis && slack < 0)
+                {
+                    // CSS 2.1 §10.3.7 (inline axis): equal centering may
+                    // NOT make the auto margins negative. For LTR, pin
+                    // margin-left (start) to 0 and let margin-right (end)
+                    // absorb the negative slack — the over-wide box stays
+                    // anchored at its `left` inset instead of shifting
+                    // left of it. (§10.6.4, the block axis, has NO such
+                    // clause: top/bottom auto margins split equally even
+                    // when negative — the else branch below.)
+                    mS = 0;
+                    mE = slack;
+                }
+                else
+                {
+                    // Both auto → center (split the slack equally). Block
+                    // axis (§10.6.4) reaches here even for negative slack.
+                    mS = slack / 2.0;
+                    mE = slack - mS;
+                }
             }
             else if (marginStart is null)
             {
@@ -157,6 +181,12 @@ internal static class AbsoluteLayouter
         // (not needed for the border-box offset, which keys off start).
         double usedStart;
         double usedSize;
+        // True for the END-anchored auto-size case (start auto, size
+        // auto, end given): usedStart is derived from the end inset
+        // AFTER the size clamp so a clamped-to-zero size still preserves
+        // the end inset (a negative start offset) rather than re-pinning
+        // to the static position.
+        var endAnchored = false;
 
         if (sizeAuto)
         {
@@ -178,10 +208,14 @@ internal static class AbsoluteLayouter
             }
             else if (!endAuto)
             {
-                // end given, start auto → fill from CB start to end inset,
-                // start anchored at CB origin (static-position = 0).
+                // end given, start auto → END-anchored. Size fills from
+                // the CB start to the end inset; the box's end edge stays
+                // pinned at the end inset. usedStart is recomputed from
+                // that anchor AFTER the clamp (below) so a clamped-to-
+                // zero size still honors the end inset.
                 usedSize = cbExtent - insetEnd!.Value - marS - marE - chrome;
-                usedStart = StaticPosition;
+                usedStart = StaticPosition;  // provisional; recomputed post-clamp
+                endAnchored = true;
             }
             else
             {
@@ -212,7 +246,16 @@ internal static class AbsoluteLayouter
             }
         }
 
-        if (usedSize < 0) usedSize = 0;  // clamp; caller treats <0 as drop via the border-box check
+        if (usedSize < 0) usedSize = 0;  // CSS used size >= 0.
+        if (endAnchored)
+        {
+            // Preserve the end inset after the clamp: place the (possibly
+            // zero-size) border box so its end edge stays at
+            // cbExtent - insetEnd - marE. For an un-clamped (positive)
+            // size this reproduces the static-position offset (0); for a
+            // clamped size it yields the correct negative start offset.
+            usedStart = cbExtent - insetEnd!.Value - marE - chrome - usedSize - marS;
+        }
         return (usedStart + marS, chrome + usedSize);
     }
 

--- a/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
@@ -8,144 +8,274 @@ using NetPdf.Layout.Boxes;
 namespace NetPdf.Layout.Layouters;
 
 /// <summary>
-/// Per Phase 3 Task 19 cycle 1 — pure placement math for
-/// <c>position: absolute</c> boxes per CSS Positioned Layout L3 §6.
-/// Kept side-effect-free (no sink, no fragmentainer) so the offset/size
-/// resolution is unit-testable in isolation; <c>BlockLayouter</c> owns
-/// the containing-block derivation + fragment emission + inner-content
-/// dispatch.
+/// Per Phase 3 Task 19 — pure placement math for <c>position: absolute</c>
+/// boxes per CSS 2.1 §10.3.7 (inline-axis width / left / right) +
+/// §10.6.4 (block-axis height / top / bottom). Side-effect-free (no
+/// sink, no fragmentainer) so the constraint solving is unit-testable
+/// in isolation; <c>BlockLayouter</c> owns the containing-block
+/// derivation + fragment emission + inner-content dispatch.
 ///
-/// <para><b>Cycle 1 scope</b>: only EXPLICIT pixel <c>top</c> +
-/// <c>left</c> + <c>width</c> + <c>height</c>, resolved against the
-/// containing block's content-box origin. Any deferred feature
-/// (<c>auto</c> offset, percentage, <c>right</c>/<c>bottom</c>
-/// anchoring, <c>auto</c> width/height) returns
-/// <see cref="AbsolutePlacement.Unresolved"/> with a human-readable
-/// reason so the caller can drop the box + surface
-/// <c>LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001</c> instead of
-/// mis-placing it. The full §6 resolution (static position, over-
-/// constrained left/right/width, percentage bases, shrink-to-fit) is
-/// cycle 2+. See <c>docs/deferrals.md#abspos-cycle-1-explicit-only</c>.</para>
+/// <para><b>Cycle 2b — the full §6 constraint solver</b>: each axis
+/// resolves the (inset-start, size, inset-end, margin-start, margin-end)
+/// system against the containing-block extent, honoring
+/// <c>auto</c> + percentage values, the over-constrained "ignore the
+/// end inset" rule (LTR / top-to-bottom), and auto-margin centering.
+/// Border + padding are folded into the box-model chrome.</para>
+///
+/// <para><b>Two documented approximations</b> (need machinery beyond
+/// this pure solver):</para>
+/// <list type="bullet">
+///   <item><b>Shrink-to-fit / content height</b> — when a size is
+///   <c>auto</c> and NOT pinned by both insets, the spec uses
+///   shrink-to-fit (inline) / content height (block), which need
+///   intrinsic-size measurement. Cycle 2b approximates as the
+///   AVAILABLE extent (CB minus the resolved inset(s) + margins +
+///   chrome). For the common pinned-both-insets case the result is
+///   EXACT (= fill).</item>
+///   <item><b>Static position</b> — when both insets on an axis are
+///   <c>auto</c>, the spec uses the box's normal-flow static position.
+///   Cycle 2b approximates as the CB content origin (offset 0), which
+///   is exact when the box would have been the first in-flow child.</item>
+/// </list>
+/// <para>See <c>docs/deferrals.md#abspos-cycle-1-explicit-only</c>.</para>
 /// </summary>
 internal static class AbsoluteLayouter
 {
-    /// <summary>Resolve an <c>position: absolute</c> box's border-box
+    /// <summary>Resolve a <c>position: absolute</c> box's border-box
     /// rectangle in the SAME coordinate space as
-    /// <paramref name="containingBlock"/> (= the caller's sink
-    /// coordinates). Returns <see cref="AbsolutePlacement.Unresolved"/>
-    /// when the box uses a cycle-1-deferred feature.</summary>
+    /// <paramref name="cb"/> (= the caller's sink coordinates). Returns
+    /// <see cref="AbsolutePlacement.Unresolved"/> only for the
+    /// genuinely-invalid case (negative resolved size).</summary>
     public static AbsolutePlacement ResolvePlacement(
-        Box box, AbsoluteContainingBlock containingBlock)
+        Box box, AbsoluteContainingBlock cb)
     {
         var style = box.Style;
 
-        // Per post-PR-#112 review C1 — `right` / `bottom` anchoring +
-        // over-constrained resolution (CSS Positioned Layout L3 §6) are
-        // a documented cycle-2 deferral. If the author specified an
-        // EXPLICIT `right` or `bottom` (a length OR percentage — not the
-        // `auto` default), cycle 1 cannot honor it: defer the whole box
-        // rather than silently ignoring it + placing via top/left. This
-        // matches the contract in
-        // `docs/deferrals.md#abspos-cycle-1-explicit-only` (right/bottom
-        // → LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001). Cycle 2 implements
-        // the full §6 constraint solver (incl. the over-constrained LTR
-        // "ignore right/bottom" rule).
-        if (IsExplicitlySpecified(style, PropertyId.Right))
-        {
-            return AbsolutePlacement.Unresolved(
-                "`right` is specified — cycle 1 anchors via top/left only; "
-                + "right/bottom anchoring + over-constrained resolution is cycle 2");
-        }
-        if (IsExplicitlySpecified(style, PropertyId.Bottom))
-        {
-            return AbsolutePlacement.Unresolved(
-                "`bottom` is specified — cycle 1 anchors via top/left only; "
-                + "right/bottom anchoring + over-constrained resolution is cycle 2");
-        }
+        // Inline axis (LTR, horizontal writing mode): left = inset-start,
+        // right = inset-end, width = size. Percentages resolve against
+        // the CB inline extent; padding percentages too (CSS 2.1 §8.4).
+        var (inlineOffset, inlineSize) = SolveAxis(
+            insetStart: ReadAutoOrPx(style, PropertyId.Left, cb.InlineSize),
+            insetEnd: ReadAutoOrPx(style, PropertyId.Right, cb.InlineSize),
+            size: ReadAutoOrPx(style, PropertyId.Width, cb.InlineSize),
+            marginStart: ReadMarginAutoOrPx(style, PropertyId.MarginLeft, cb.InlineSize),
+            marginEnd: ReadMarginAutoOrPx(style, PropertyId.MarginRight, cb.InlineSize),
+            borderStart: style.ReadLengthPxOrZero(PropertyId.BorderLeftWidth),
+            paddingStart: ReadPxOrPct(style, PropertyId.PaddingLeft, cb.InlineSize),
+            paddingEnd: ReadPxOrPct(style, PropertyId.PaddingRight, cb.InlineSize),
+            borderEnd: style.ReadLengthPxOrZero(PropertyId.BorderRightWidth),
+            cbExtent: cb.InlineSize);
 
-        // Cycle 1 requires explicit pixel top + left. `auto` (the
-        // default) lands as an Unset/Keyword slot; percentages land as
-        // a Percentage slot. Both defer.
-        if (!TryReadExplicitPx(style, PropertyId.Top, out var top))
-        {
-            return AbsolutePlacement.Unresolved(
-                "`top` is auto/percentage/unset — cycle 1 needs an explicit "
-                + "pixel value (static-position + percentage resolution is cycle 2)");
-        }
-        if (!TryReadExplicitPx(style, PropertyId.Left, out var left))
-        {
-            return AbsolutePlacement.Unresolved(
-                "`left` is auto/percentage/unset — cycle 1 needs an explicit "
-                + "pixel value (static-position + percentage resolution is cycle 2)");
-        }
-        if (!TryReadExplicitPx(style, PropertyId.Width, out var width))
-        {
-            return AbsolutePlacement.Unresolved(
-                "`width` is auto/percentage/unset — cycle 1 needs an explicit "
-                + "pixel value (shrink-to-fit + offset-derived width is cycle 2)");
-        }
-        if (!TryReadExplicitPx(style, PropertyId.Height, out var height))
-        {
-            return AbsolutePlacement.Unresolved(
-                "`height` is auto/percentage/unset — cycle 1 needs an explicit "
-                + "pixel value (content-derived + offset-derived height is cycle 2)");
-        }
+        // Block axis: top = inset-start, bottom = inset-end, height =
+        // size. Per CSS 2.1 percentage top/bottom/height resolve against
+        // the CB BLOCK extent; percentage padding (block axis) resolves
+        // against the CB INLINE extent per §8.4 — but that's a rarely-
+        // used corner; cycle 2b resolves block-axis padding percentages
+        // against the inline extent to match §8.4.
+        var (blockOffset, blockSize) = SolveAxis(
+            insetStart: ReadAutoOrPx(style, PropertyId.Top, cb.BlockSize),
+            insetEnd: ReadAutoOrPx(style, PropertyId.Bottom, cb.BlockSize),
+            size: ReadAutoOrPx(style, PropertyId.Height, cb.BlockSize),
+            marginStart: ReadMarginAutoOrPx(style, PropertyId.MarginTop, cb.InlineSize),
+            marginEnd: ReadMarginAutoOrPx(style, PropertyId.MarginBottom, cb.InlineSize),
+            borderStart: style.ReadLengthPxOrZero(PropertyId.BorderTopWidth),
+            paddingStart: ReadPxOrPct(style, PropertyId.PaddingTop, cb.InlineSize),
+            paddingEnd: ReadPxOrPct(style, PropertyId.PaddingBottom, cb.InlineSize),
+            borderEnd: style.ReadLengthPxOrZero(PropertyId.BorderBottomWidth),
+            cbExtent: cb.BlockSize);
 
-        // Negative width/height are invalid per CSS Sizing; treat as a
-        // deferred/dropped case rather than emitting a negative-extent
-        // fragment.
-        if (width < 0 || height < 0)
-        {
-            return AbsolutePlacement.Unresolved(
-                "negative `width`/`height` is invalid; box dropped");
-        }
-
-        // Per §6 the offsets are measured from the containing block's
-        // padding edge (= its content-box origin in cycle 1's content-
-        // box CB approximation). LTR + horizontal writing mode: left
-        // anchors the inline-start edge, top the block-start edge.
-        var inlineOffset = containingBlock.InlineOrigin + left;
-        var blockOffset = containingBlock.BlockOrigin + top;
-        return AbsolutePlacement.Resolved(inlineOffset, blockOffset, width, height);
+        // SolveAxis already clamps a negative resolved content size to
+        // 0 (CSS clamps used width/height to >= 0), so inlineSize /
+        // blockSize are non-negative here — the box always resolves.
+        // AbsolutePlacement.Unresolved is retained for the API contract
+        // (EmitOneAbsoluteBox's IsResolved check) but the §6 solver no
+        // longer produces it; the BlockLayouter's null-CB path (relative-
+        // offset ancestor / unrecorded ancestor) is the drop site.
+        return AbsolutePlacement.Resolved(
+            cb.InlineOrigin + inlineOffset,
+            cb.BlockOrigin + blockOffset,
+            inlineSize,
+            blockSize);
     }
 
-    /// <summary>Read a <see cref="PropertyId"/> as an explicit CSS-px
-    /// length. Returns <see langword="false"/> for the
-    /// <c>auto</c>/unset path (Keyword/Unset slot) AND for percentages
-    /// (Percentage slot) — both are cycle-2 deferrals.</summary>
-    private static bool TryReadExplicitPx(ComputedStyle style, PropertyId id, out double px)
+    /// <summary>Solve one axis of the §10.3.7 / §10.6.4 system. All
+    /// inputs are post-resolution: a non-null value is a used length in
+    /// px; <see langword="null"/> means <c>auto</c>. Returns the box's
+    /// BORDER-BOX start offset from the CB content origin + the
+    /// border-box size (= chrome + content size).</summary>
+    private static (double offset, double borderBoxSize) SolveAxis(
+        double? insetStart, double? insetEnd, double? size,
+        double? marginStart, double? marginEnd,
+        double borderStart, double paddingStart, double paddingEnd, double borderEnd,
+        double cbExtent)
+    {
+        var chrome = borderStart + paddingStart + paddingEnd + borderEnd;
+        var startAuto = insetStart is null;
+        var endAuto = insetEnd is null;
+        var sizeAuto = size is null;
+
+        // ---- Over-constrained case: inset-start, size, inset-end all
+        // given. The end inset is "ignored" (LTR / ttb), BUT auto
+        // margins first absorb the slack (centering / one-sided).
+        if (!startAuto && !sizeAuto && !endAuto)
+        {
+            var slack = cbExtent - insetStart!.Value - insetEnd!.Value
+                - chrome - size!.Value;
+            double mS, mE;
+            if (marginStart is null && marginEnd is null)
+            {
+                // Both auto → center (split slack; may be negative).
+                mS = slack / 2.0;
+                mE = slack - mS;
+            }
+            else if (marginStart is null)
+            {
+                mS = slack - marginEnd!.Value;
+                mE = marginEnd.Value;
+            }
+            else if (marginEnd is null)
+            {
+                mS = marginStart.Value;
+                mE = slack - marginStart.Value;
+            }
+            else
+            {
+                // Fully specified → over-constrained; ignore the END
+                // inset (LTR). Margins stay as authored.
+                mS = marginStart.Value;
+                mE = marginEnd.Value;
+            }
+            return (insetStart.Value + mS, chrome + size.Value);
+        }
+
+        // ---- Not over-constrained: auto margins resolve to 0.
+        var marS = marginStart ?? 0;
+        var marE = marginEnd ?? 0;
+
+        // Resolve (usedStart, usedSize) per the auto pattern. The end
+        // inset, when present, anchors; when auto, it's the remainder
+        // (not needed for the border-box offset, which keys off start).
+        double usedStart;
+        double usedSize;
+
+        if (sizeAuto)
+        {
+            // Size auto → shrink-to-fit (inline) / content height
+            // (block), approximated as the AVAILABLE extent. EXACT when
+            // both insets pin it (fill).
+            if (!startAuto && !endAuto)
+            {
+                // Fill: both insets given → size = remaining space.
+                usedStart = insetStart!.Value;
+                usedSize = cbExtent - insetStart.Value - insetEnd!.Value
+                    - marS - marE - chrome;
+            }
+            else if (!startAuto)
+            {
+                // start given, end auto → available from start to CB end.
+                usedStart = insetStart!.Value;
+                usedSize = cbExtent - insetStart.Value - marS - marE - chrome;
+            }
+            else if (!endAuto)
+            {
+                // end given, start auto → fill from CB start to end inset,
+                // start anchored at CB origin (static-position = 0).
+                usedSize = cbExtent - insetEnd!.Value - marS - marE - chrome;
+                usedStart = StaticPosition;
+            }
+            else
+            {
+                // all auto → start = static position; size = available.
+                usedStart = StaticPosition;
+                usedSize = cbExtent - StaticPosition - marS - marE - chrome;
+            }
+        }
+        else
+        {
+            usedSize = size!.Value;
+            if (!startAuto)
+            {
+                // start given (size given, end auto OR end given handled
+                // above) → anchor at start.
+                usedStart = insetStart!.Value;
+            }
+            else if (!endAuto)
+            {
+                // start auto, size + end given → start = remainder.
+                usedStart = cbExtent - insetEnd!.Value - marE - chrome
+                    - usedSize - marS;
+            }
+            else
+            {
+                // start + end auto, size given → start = static position.
+                usedStart = StaticPosition;
+            }
+        }
+
+        if (usedSize < 0) usedSize = 0;  // clamp; caller treats <0 as drop via the border-box check
+        return (usedStart + marS, chrome + usedSize);
+    }
+
+    /// <summary>The static-position approximation per the class doc: the
+    /// CB content origin (offset 0). Exact when the box would have been
+    /// the first in-flow child of its containing block.</summary>
+    private const double StaticPosition = 0.0;
+
+    /// <summary>Read an inset / size / margin property as a used px
+    /// length, OR <see langword="null"/> for <c>auto</c> (the Unset /
+    /// Keyword slot). Percentages resolve against
+    /// <paramref name="pctBase"/>.</summary>
+    private static double? ReadAutoOrPx(ComputedStyle style, PropertyId id, double pctBase)
     {
         var slot = style.Get(id);
-        if (slot.Tag == ComputedSlotTag.LengthPx)
+        return slot.Tag switch
         {
-            px = slot.AsLengthPx();
-            return true;
-        }
-        px = 0;
-        return false;
+            ComputedSlotTag.LengthPx => slot.AsLengthPx(),
+            ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * pctBase,
+            // Unset / Keyword (auto) / anything else → auto.
+            _ => null,
+        };
     }
 
-    /// <summary>Per post-PR-#112 review C1 — was an inset property
-    /// (<c>top</c>/<c>right</c>/<c>bottom</c>/<c>left</c>) EXPLICITLY
-    /// specified to a non-<c>auto</c> value? <c>auto</c> is the initial
-    /// value + lands as an Unset / Keyword slot; an explicit length or
-    /// percentage lands as a LengthPx / Percentage slot. Used to detect
-    /// <c>right</c>/<c>bottom</c> presence so cycle 1 can defer rather
-    /// than silently ignore them.</summary>
-    private static bool IsExplicitlySpecified(ComputedStyle style, PropertyId id)
+    /// <summary>Read a margin property as a used px length, OR
+    /// <see langword="null"/> for an EXPLICIT <c>margin: auto</c> (a
+    /// Keyword slot). Differs from <see cref="ReadAutoOrPx"/> for the
+    /// UNSET case: a margin's CSS initial value is <c>0</c> (NOT
+    /// <c>auto</c>), so an unset margin resolves to 0 — only an explicit
+    /// <c>auto</c> participates in the §10.3.7 auto-margin (centering)
+    /// resolution.</summary>
+    private static double? ReadMarginAutoOrPx(ComputedStyle style, PropertyId id, double pctBase)
     {
-        var tag = style.Get(id).Tag;
-        return tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
+        var slot = style.Get(id);
+        return slot.Tag switch
+        {
+            ComputedSlotTag.LengthPx => slot.AsLengthPx(),
+            ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * pctBase,
+            ComputedSlotTag.Keyword => null,  // explicit `auto`
+            _ => 0.0,                          // unset → initial 0
+        };
+    }
+
+    /// <summary>Read a padding property as a used px length (px OR
+    /// percentage-of-<paramref name="pctBase"/>); <c>auto</c> isn't
+    /// valid for padding so the fallback is 0.</summary>
+    private static double ReadPxOrPct(ComputedStyle style, PropertyId id, double pctBase)
+    {
+        var slot = style.Get(id);
+        return slot.Tag switch
+        {
+            ComputedSlotTag.LengthPx => slot.AsLengthPx(),
+            ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * pctBase,
+            _ => 0.0,
+        };
     }
 }
 
-/// <summary>Per Phase 3 Task 19 cycle 1 — the containing block for an
+/// <summary>Per Phase 3 Task 19 — the containing block for an
 /// absolutely-positioned box, in the caller's sink coordinate space.
-/// Cycle 1 derives this as the establishing <c>BlockLayouter</c>'s
-/// content area (= the fragmentainer content box for the top-level
-/// case, which coincides with the initial containing block + with a
-/// positioned root's content box). The spec-correct nearest-positioned-
-/// ancestor PADDING box + the ancestor walk is cycle 2.</summary>
+/// Origin + size are the nearest positioned ancestor's PADDING box
+/// (cycle 2a), or the initial containing block (= fragmentainer content
+/// area) when there's no positioned ancestor.</summary>
 internal readonly record struct AbsoluteContainingBlock(
     double InlineOrigin,
     double BlockOrigin,
@@ -154,7 +284,7 @@ internal readonly record struct AbsoluteContainingBlock(
 
 /// <summary>Per Phase 3 Task 19 cycle 1 — the resolved border-box
 /// rectangle for an absolutely-positioned box, OR an unresolved marker
-/// carrying the cycle-1 defer reason.</summary>
+/// carrying the defer reason.</summary>
 internal readonly record struct AbsolutePlacement(
     bool IsResolved,
     double InlineOffset,

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -3629,12 +3629,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     ///   OR via the table-cell / grid-item / forced-overflow paths that
     ///   don't record) → DEFER. Falling back to the ICB here would
     ///   silently MISPLACE the box at the wrong origin.</item>
-    ///   <item>Per P2#1 — a <c>position: relative</c> ancestor with an
-    ///   explicit inset (<c>top</c>/<c>right</c>/<c>bottom</c>/<c>left</c>)
-    ///   → DEFER. Relative-offset application (shifting the ancestor's
-    ///   visual box + therefore its abspos descendants' CB origin) is
-    ///   unimplemented; using the unshifted flow position would place
-    ///   the descendant against the wrong origin.</item>
+    ///   <item>Per cycle 2b — a <c>position: relative</c> ancestor with
+    ///   explicit inset offsets has its relative shift APPLIED to the CB
+    ///   origin (CSS 2.1 §9.4.3): the abspos descendant anchors to the
+    ///   ancestor's VISUALLY-SHIFTED padding box. (Cycle 2a deferred
+    ///   this; cycle 2b applies it.)</item>
     /// </list></summary>
     private AbsoluteContainingBlock? ResolveContainingBlock(
         Box absBox, AbsoluteContainingBlock icb)
@@ -3642,16 +3641,6 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         for (var ancestor = absBox.Parent; ancestor is not null; ancestor = ancestor.Parent)
         {
             if (!ancestor.Style.EstablishesAbsoluteContainingBlock()) continue;
-
-            // P2#1 — a relative ancestor with explicit inset offsets
-            // can't have its (unimplemented) relative shift applied to
-            // the CB origin → defer rather than anchor to the unshifted
-            // flow position.
-            if (ancestor.Style.ReadPosition() == PositionValue.Relative
-                && HasExplicitInset(ancestor.Style))
-            {
-                return null;
-            }
 
             // Found the nearest positioned ancestor. Use its padding
             // box IFF its geometry was recorded during in-flow emit.
@@ -3662,37 +3651,66 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 var bt = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderTopWidth);
                 var br = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderRightWidth);
                 var bb = ancestor.Style.ReadLengthPxOrZero(PropertyId.BorderBottomWidth);
+
+                // Cycle 2b — apply the ancestor's relative-position shift
+                // (CSS 2.1 §9.4.3) to the CB origin. The recorded
+                // geometry is the ancestor's UNSHIFTED flow position
+                // (in-flow emit doesn't apply relative offsets yet); for
+                // a `position: relative` ancestor we add the shift here
+                // so abspos descendants anchor to the visually-shifted
+                // box. inline shift = left (or -right); block shift =
+                // top (or -bottom). Non-relative ancestors (absolute /
+                // fixed / sticky) already have their final position
+                // baked into the recorded geometry → zero shift.
+                var (relInline, relBlock) =
+                    ancestor.Style.ReadPosition() == PositionValue.Relative
+                        ? ComputeRelativeShift(ancestor.Style, borderBox.InlineSize)
+                        : (0.0, 0.0);
+
                 return new AbsoluteContainingBlock(
-                    InlineOrigin: borderBox.InlineOffset + bl,
-                    BlockOrigin: borderBox.BlockOffset + bt,
+                    InlineOrigin: borderBox.InlineOffset + bl + relInline,
+                    BlockOrigin: borderBox.BlockOffset + bt + relBlock,
                     InlineSize: System.Math.Max(0, borderBox.InlineSize - bl - br),
                     BlockSize: System.Math.Max(0, borderBox.BlockSize - bt - bb));
             }
-            // P1#1 — positioned ancestor found but geometry NOT recorded.
-            // Defer (drop + diagnose) instead of misplacing at the ICB.
+            // Per PR-#113 review P1#1 — positioned ancestor found but
+            // geometry NOT recorded (laid out via a path that doesn't
+            // record). Defer (drop + diagnose) instead of misplacing at
+            // the ICB.
             return null;
         }
         // No positioned ancestor → the ICB IS the containing block.
         return icb;
     }
 
-    /// <summary>Per post-PR-#113 review P2#1 — true when any physical
-    /// inset (<c>top</c>/<c>right</c>/<c>bottom</c>/<c>left</c>) is
-    /// explicitly specified (a length or percentage, not the
-    /// <c>auto</c> default). Used to detect a <c>position: relative</c>
-    /// ancestor whose unimplemented relative shift would otherwise
-    /// corrupt an abspos descendant's containing-block origin.</summary>
-    private static bool HasExplicitInset(ComputedStyle style)
+    /// <summary>Per Phase 3 Task 19 cycle 2b — compute the
+    /// relative-positioning shift (CSS 2.1 §9.4.3) for a
+    /// <c>position: relative</c> box. LTR / horizontal: inline shift =
+    /// <c>left</c> if specified else <c>-right</c> else 0; block shift =
+    /// <c>top</c> if specified else <c>-bottom</c> else 0. Percentages
+    /// resolve against <paramref name="cbInlineSize"/> (the ancestor's
+    /// own containing block ≈ its inline extent for this approximation;
+    /// §9.4.3 uses the containing-block dimensions).</summary>
+    private static (double inline, double block) ComputeRelativeShift(
+        ComputedStyle style, double cbInlineSize)
     {
-        return IsExplicitInset(style, PropertyId.Top)
-            || IsExplicitInset(style, PropertyId.Right)
-            || IsExplicitInset(style, PropertyId.Bottom)
-            || IsExplicitInset(style, PropertyId.Left);
+        var left = ReadInsetPxOrNull(style, PropertyId.Left, cbInlineSize);
+        var right = ReadInsetPxOrNull(style, PropertyId.Right, cbInlineSize);
+        var top = ReadInsetPxOrNull(style, PropertyId.Top, cbInlineSize);
+        var bottom = ReadInsetPxOrNull(style, PropertyId.Bottom, cbInlineSize);
+        var inline = left ?? (right is { } r ? -r : 0.0);
+        var block = top ?? (bottom is { } b ? -b : 0.0);
+        return (inline, block);
 
-        static bool IsExplicitInset(ComputedStyle s, PropertyId id)
+        static double? ReadInsetPxOrNull(ComputedStyle s, PropertyId id, double pctBase)
         {
-            var tag = s.Get(id).Tag;
-            return tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
+            var slot = s.Get(id);
+            return slot.Tag switch
+            {
+                ComputedSlotTag.LengthPx => slot.AsLengthPx(),
+                ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * pctBase,
+                _ => (double?)null,
+            };
         }
     }
 
@@ -3747,12 +3765,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 diagnostics,
                 new PaginateDiagnostic(
                     PaginateDiagnosticCodes.LayoutAbsoluteFeatureUnsupported001,
-                    "position:absolute box dropped (cycle-2a): its containing block "
-                    + "(nearest positioned ancestor) could not be resolved on this "
-                    + "page — the ancestor was laid out via an unrecorded path "
-                    + "(later page / table-cell / grid-item / forced-overflow) OR is "
-                    + "`position: relative` with explicit inset offsets (relative-"
-                    + "offset application is a later cycle).",
+                    "position:absolute box dropped: its containing block (nearest "
+                    + "positioned ancestor) could not be resolved on this page — the "
+                    + "ancestor was laid out via a path that doesn't record geometry "
+                    + "(later page / table-cell / grid-item). Cycle 2b records the "
+                    + "block-flow / recursive / forced-overflow sites.",
                     PaginateDiagnosticSeverity.Warning));
             return;
         }

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -3567,14 +3567,20 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     ///
     /// <para><b>Whole-subtree collection.</b> Abspos boxes appear at
     /// ANY depth (real HTML nests them inside <c>&lt;body&gt;</c> etc.),
-    /// so this walks <see cref="_rootBox"/>'s entire descendant tree.
-    /// The in-flow passes (top-level loop + EmitBlockSubtreeRecursive)
-    /// skip abspos boxes, so emitting them here is the single emission
-    /// site (no double-emit). The walk does NOT descend INTO an abspos
+    /// so this walks <see cref="_rootBox"/>'s descendant tree. The
+    /// in-flow passes (top-level loop + EmitBlockSubtreeRecursive) skip
+    /// abspos boxes, so for THIS formatting context emitting them here is
+    /// the single emission site. The walk does NOT descend INTO an abspos
     /// box's own subtree — that box's descendants are laid out by the
     /// inner sub-BlockLayouter (their own nested abspos boxes anchor to
     /// the inner box once it's a positioned CB; cycle-1 they'd anchor
-    /// to the inner box's content area via that recursion).</para>
+    /// to the inner box's content area via that recursion). Nor does it
+    /// cross a DELEGATION boundary into a grid item or table cell/caption
+    /// (post-PR-#114 review P2#4) — those subtrees are owned by a nested
+    /// BlockLayouter that runs its own abspos pass, so descending here
+    /// would double-emit. (Flex is NOT a boundary — FlexLayouter spawns
+    /// no per-item layouter; see
+    /// <see cref="EmitAbsolutelyPositionedDescendants"/>.)</para>
     ///
     /// <para>Each box's offsets/size are resolved by the pure
     /// <see cref="AbsoluteLayouter.ResolvePlacement"/>; unresolved
@@ -3664,7 +3670,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // baked into the recorded geometry → zero shift.
                 var (relInline, relBlock) =
                     ancestor.Style.ReadPosition() == PositionValue.Relative
-                        ? ComputeRelativeShift(ancestor.Style, borderBox.InlineSize)
+                        ? ComputeRelativeShift(
+                            ancestor.Style, borderBox.InlineSize, borderBox.BlockSize)
                         : (0.0, 0.0);
 
                 return new AbsoluteContainingBlock(
@@ -3673,31 +3680,49 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     InlineSize: System.Math.Max(0, borderBox.InlineSize - bl - br),
                     BlockSize: System.Math.Max(0, borderBox.BlockSize - bt - bb));
             }
+            // Per post-PR-#114 review P2#4 — the positioned ancestor is
+            // THIS formatting context's own root box. The ICB this
+            // layouter was handed already IS that root's content box: a
+            // grid item / table cell / abspos box is laid out by a nested
+            // BlockLayouter whose fragmentainer == the (positioned) root's
+            // content area. So anchor to the ICB rather than dropping —
+            // without this, an abspos descendant of a positioned grid
+            // item / cell would be dropped (its CB ancestor is the nested
+            // root, never recorded in this layouter's in-flow geometry
+            // map). NB this resolves to the content box; the padding-box
+            // inset is absorbed by the nested fragmentainer already.
+            if (ReferenceEquals(ancestor, _rootBox)) return icb;
+
             // Per PR-#113 review P1#1 — positioned ancestor found but
-            // geometry NOT recorded (laid out via a path that doesn't
-            // record). Defer (drop + diagnose) instead of misplacing at
-            // the ICB.
+            // geometry NOT recorded AND it isn't this layouter's root
+            // (laid out via a path that doesn't record, e.g. a positioned
+            // ancestor ABOVE this layouter's subtree). Defer (drop +
+            // diagnose) instead of misplacing at the ICB.
             return null;
         }
         // No positioned ancestor → the ICB IS the containing block.
         return icb;
     }
 
-    /// <summary>Per Phase 3 Task 19 cycle 2b — compute the
-    /// relative-positioning shift (CSS 2.1 §9.4.3) for a
-    /// <c>position: relative</c> box. LTR / horizontal: inline shift =
-    /// <c>left</c> if specified else <c>-right</c> else 0; block shift =
-    /// <c>top</c> if specified else <c>-bottom</c> else 0. Percentages
-    /// resolve against <paramref name="cbInlineSize"/> (the ancestor's
-    /// own containing block ≈ its inline extent for this approximation;
-    /// §9.4.3 uses the containing-block dimensions).</summary>
+    /// <summary>Per Phase 3 Task 19 cycle 2b (+ post-PR-#114 review
+    /// P1#2) — compute the relative-positioning shift (CSS 2.1 §9.4.3)
+    /// for a <c>position: relative</c> box. LTR / horizontal: inline
+    /// shift = <c>left</c> if specified else <c>-right</c> else 0; block
+    /// shift = <c>top</c> if specified else <c>-bottom</c> else 0.
+    /// PERCENTAGES resolve per-axis against the containing-block
+    /// dimensions: <c>left</c>/<c>right</c> against
+    /// <paramref name="cbInlineSize"/> (width), <c>top</c>/<c>bottom</c>
+    /// against <paramref name="cbBlockSize"/> (HEIGHT) — using the
+    /// inline base for the block axis would shift along the wrong extent
+    /// whenever the two differ (the P1#2 fix). The ancestor's own
+    /// border-box extents approximate its containing block here.</summary>
     private static (double inline, double block) ComputeRelativeShift(
-        ComputedStyle style, double cbInlineSize)
+        ComputedStyle style, double cbInlineSize, double cbBlockSize)
     {
         var left = ReadInsetPxOrNull(style, PropertyId.Left, cbInlineSize);
         var right = ReadInsetPxOrNull(style, PropertyId.Right, cbInlineSize);
-        var top = ReadInsetPxOrNull(style, PropertyId.Top, cbInlineSize);
-        var bottom = ReadInsetPxOrNull(style, PropertyId.Bottom, cbInlineSize);
+        var top = ReadInsetPxOrNull(style, PropertyId.Top, cbBlockSize);
+        var bottom = ReadInsetPxOrNull(style, PropertyId.Bottom, cbBlockSize);
         var inline = left ?? (right is { } r ? -r : 0.0);
         var block = top ?? (bottom is { } b ? -b : 0.0);
         return (inline, block);
@@ -3714,13 +3739,38 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         }
     }
 
-    /// <summary>Per Phase 3 Task 19 cycle 1 — recursively walk
-    /// <paramref name="box"/>'s children, emitting each
-    /// <c>position: absolute</c> descendant against
+    /// <summary>Per Phase 3 Task 19 cycle 1 (+ post-PR-#114 review
+    /// P2#4) — recursively walk <paramref name="box"/>'s children,
+    /// emitting each <c>position: absolute</c> descendant against
     /// <paramref name="containingBlock"/>. Does NOT recurse into an
     /// abspos box's own subtree (the inner sub-BlockLayouter owns
     /// that); DOES recurse through in-flow boxes to find abspos boxes
-    /// nested at any depth.</summary>
+    /// nested at any depth — EXCEPT across a delegation boundary.
+    ///
+    /// <para><b>Delegation boundary (P2#4 — emit exactly once):</b>
+    /// <see cref="GridLayouter"/> lays out each grid ITEM, and
+    /// <see cref="TableLayouter"/> each table CELL + CAPTION, via a
+    /// NESTED <c>BlockLayouter</c> (constructed with
+    /// <c>incomingContinuation: null</c>), so each of those runs its OWN
+    /// post-flow abspos pass over its subtree. Recursing into those
+    /// subtrees here too would emit the same abspos descendant a SECOND
+    /// time (at a different anchor). So this walk does NOT descend into a
+    /// grid container's in-flow children (= items), nor into a
+    /// <see cref="BoxKind.TableCell"/> / <see cref="BoxKind.TableCaption"/>.
+    /// It STILL emits abspos DIRECT children of a grid container
+    /// (out-of-flow → never items → no nested layouter sees them) and
+    /// STILL descends through table-internal boxes that aren't
+    /// cells/captions (rows / row-groups) so an abspos child of a row
+    /// isn't silently dropped.</para>
+    ///
+    /// <para><b>Why FLEX is NOT a boundary:</b> unlike grid/table,
+    /// <see cref="FlexLayouter"/> constructs NO per-item nested
+    /// BlockLayouter — it emits each flex item's border box only. A flex
+    /// item's subtree (including any abspos descendant) is walked +
+    /// emitted by THIS (outer) pass, so flex items must be recursed into
+    /// — skipping them would silently DROP their abspos descendants. Add
+    /// flex here only once FlexLayouter dispatches item content through a
+    /// nested BlockLayouter.</para></summary>
     private void EmitAbsolutelyPositionedDescendants(
         Box box,
         AbsoluteContainingBlock containingBlock,
@@ -3728,6 +3778,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         ref LayoutContext layout,
         CancellationToken cancellationToken)
     {
+        // A grid container delegates EVERY in-flow child to a nested item
+        // BlockLayouter (which owns that item's abspos emission). Table
+        // cells/captions (also nested-BlockLayouter-owned) are detected
+        // per-child below. Flex is deliberately excluded (see summary).
+        var delegatesItemsToNestedLayouter = IsGridContainer(box);
         foreach (var child in box.Children)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -3738,6 +3793,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // Do NOT descend into the abspos box here — its own
                 // descendants are laid out by the inner sub-BlockLayouter
                 // dispatched inside EmitOneAbsoluteBox.
+                continue;
+            }
+            // In-flow box. Stop at a delegation boundary: a grid item, or
+            // a table cell/caption — the nested BlockLayouter that lays
+            // out that subtree already emits its abspos descendants
+            // (recursing here would double-emit).
+            if (delegatesItemsToNestedLayouter
+                || child.Kind is BoxKind.TableCell or BoxKind.TableCaption)
+            {
                 continue;
             }
             // In-flow box: recurse to find deeper abspos descendants.

--- a/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
@@ -101,10 +101,11 @@ public sealed class AbsoluteLayouterProductionTests
     }
 
     [Fact]
-    public async Task Cycle1_production_abspos_auto_offset_dropped_with_diagnostic()
+    public async Task Cycle2b_production_abspos_auto_offsets_use_static_position()
     {
-        // No top/left set (= auto) → cycle-1 deferral → box dropped +
-        // LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001.
+        // Per Phase 3 Task 19 cycle 2b — no top/left (both auto) is no
+        // longer a deferral: both insets auto → static position (CB /
+        // ICB origin 0,0). The box emits at (0, 0) sized 50×30.
         const string html = """
             <!DOCTYPE html><html><head><style>
                 .abs {
@@ -116,10 +117,38 @@ public sealed class AbsoluteLayouterProductionTests
             </body></html>
             """;
 
-        var (sink, diag) = await RenderAsync(html);
-        Assert.Null(FindByClass(sink, "abs"));
-        Assert.Contains(diag.Diagnostics, d =>
-            d.Code == PaginateDiagnosticCodes.LayoutAbsoluteFeatureUnsupported001);
+        var (sink, _) = await RenderAsync(html);
+        var abs = FindByClass(sink, "abs");
+        Assert.NotNull(abs);
+        Assert.Equal(0.0, abs!.Value.InlineOffset, precision: 3);
+        Assert.Equal(0.0, abs.Value.BlockOffset, precision: 3);
+        Assert.Equal(50.0, abs.Value.InlineSize, precision: 3);
+        Assert.Equal(30.0, abs.Value.BlockSize, precision: 3);
+    }
+
+    [Fact]
+    public async Task Cycle2b_production_abspos_right_anchored()
+    {
+        // right:20 + width:50, left auto → left = ICB(600) - 20 - 50 =
+        // 530. End-to-end right-anchoring through the §6 solver.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .abs {
+                    position: absolute;
+                    top: 5px; right: 20px;
+                    width: 50px; height: 30px;
+                }
+            </style></head><body>
+            <div class="abs"></div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var abs = FindByClass(sink, "abs");
+        Assert.NotNull(abs);
+        Assert.Equal(530.0, abs!.Value.InlineOffset, precision: 3);
+        Assert.Equal(5.0, abs.Value.BlockOffset, precision: 3);
+        Assert.Equal(50.0, abs.Value.InlineSize, precision: 3);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterProductionTests.cs
@@ -312,6 +312,114 @@ public sealed class AbsoluteLayouterProductionTests
         Assert.Single(absFrags);
     }
 
+    [Fact]
+    public async Task PostPr114_abspos_in_positioned_grid_item_emits_once_anchored_to_item()
+    {
+        // Per post-PR-#114 review P2#4 — a POSITIONED grid item containing
+        // an absolute child. The item's content is laid out by a NESTED
+        // BlockLayouter (GridLayouter spawns one per item) whose abspos
+        // pass owns the child; the outer pass must NOT also emit it. The
+        // item is the second (row-2) grid cell → block origin 50, so the
+        // abspos (top:5 left:5) anchored to the ITEM lands at (5, 55) —
+        // proving it emitted ONCE and anchored to the positioned item
+        // (not the page origin, which would be (5, 5)).
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .grid {
+                    display: grid;
+                    grid-template-rows: 50px 100px;
+                    grid-template-columns: 100px;
+                    width: 100px;
+                }
+                .item { position: relative; }
+                .abs {
+                    position: absolute;
+                    top: 5px; left: 5px; width: 30px; height: 30px;
+                }
+            </style></head><body>
+            <div class="grid">
+              <div class="pad"></div>
+              <div class="item"><div class="abs"></div></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var absFrags = sink.Fragments.Where(f =>
+            f.Box.SourceElement?.GetAttribute("class")?.Split(' ').Contains("abs") == true)
+            .ToList();
+        Assert.Single(absFrags);
+        Assert.Equal(5.0, absFrags[0].InlineOffset, precision: 3);
+        Assert.Equal(55.0, absFrags[0].BlockOffset, precision: 3);  // item at block 50 + top 5
+    }
+
+    [Fact]
+    public async Task PostPr114_abspos_in_grid_item_content_emits_once_not_doubled()
+    {
+        // Per post-PR-#114 review P2#4 — the genuine double-emit case: an
+        // abspos box inside a (non-positioned) grid item's CONTENT with no
+        // positioned ancestor. Pre-fix BOTH the grid item's nested
+        // BlockLayouter AND the outer pass (which recursed into the item
+        // subtree) emitted it → two fragments. The delegation boundary
+        // stops the outer recursion at the grid item → exactly one.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .grid {
+                    display: grid;
+                    grid-template-rows: 100px;
+                    grid-template-columns: 100px;
+                    width: 100px;
+                }
+                .abs {
+                    position: absolute;
+                    top: 5px; left: 5px; width: 30px; height: 30px;
+                }
+            </style></head><body>
+            <div class="grid">
+              <div class="item"><div class="abs"></div></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var absFrags = sink.Fragments.Where(f =>
+            f.Box.SourceElement?.GetAttribute("class")?.Split(' ').Contains("abs") == true)
+            .ToList();
+        Assert.Single(absFrags);
+    }
+
+    [Fact]
+    public async Task PostPr114_abspos_in_flex_item_content_emits_once_not_dropped()
+    {
+        // Per post-PR-#114 review P2#4 — flex is DELIBERATELY NOT a
+        // delegation boundary: FlexLayouter spawns no per-item nested
+        // BlockLayouter (it emits item border boxes only), so an abspos
+        // box inside a flex item's content is walked + emitted by the
+        // OUTER pass. This guards against regressing flex into the
+        // boundary (which would DROP the box → zero fragments). Exactly
+        // one fragment expected, anchored to the page ICB at (5, 5).
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+                .flex { display: flex; width: 300px; }
+                .item { width: 100px; height: 50px; }
+                .abs {
+                    position: absolute;
+                    top: 5px; left: 5px; width: 30px; height: 30px;
+                }
+            </style></head><body>
+            <div class="flex">
+              <div class="item"><div class="abs"></div></div>
+            </div>
+            </body></html>
+            """;
+
+        var (sink, _) = await RenderAsync(html);
+        var absFrags = sink.Fragments.Where(f =>
+            f.Box.SourceElement?.GetAttribute("class")?.Split(' ').Contains("abs") == true)
+            .ToList();
+        Assert.Single(absFrags);
+    }
+
     // NB: the PADDING-box border inset (CB = positioned ancestor's
     // padding box, not border box) is proven deterministically by the
     // BlockLayouterTests integration test

--- a/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterTests.cs
@@ -32,7 +32,8 @@ public sealed class AbsoluteLayouterTests
         double? width = null, double? height = null,
         bool topPercent = false, bool widthAuto = false,
         double? right = null, double? bottom = null,
-        bool rightPercent = false, bool inlineMarginsAuto = false)
+        bool rightPercent = false, bool inlineMarginsAuto = false,
+        bool blockMarginsAuto = false)
     {
         var style = MakeStyle();
         // position: absolute = keyword id 2.
@@ -42,6 +43,12 @@ public sealed class AbsoluteLayouterTests
             // explicit `margin-left/right: auto` (Keyword slot).
             style.Set(PropertyId.MarginLeft, ComputedSlot.FromKeyword(0));
             style.Set(PropertyId.MarginRight, ComputedSlot.FromKeyword(0));
+        }
+        if (blockMarginsAuto)
+        {
+            // explicit `margin-top/bottom: auto` (Keyword slot).
+            style.Set(PropertyId.MarginTop, ComputedSlot.FromKeyword(0));
+            style.Set(PropertyId.MarginBottom, ComputedSlot.FromKeyword(0));
         }
         if (topPercent)
         {
@@ -258,5 +265,74 @@ public sealed class AbsoluteLayouterTests
         Assert.True(p.IsResolved);
         Assert.Equal(0.0, p.InlineOffset, precision: 3);
         Assert.Equal(0.0, p.BlockOffset, precision: 3);
+    }
+
+    // ============================================================
+    // Post-PR-#114 review — §10.3.7 negative-slack margin rule
+    // (inline-only) + end-anchored auto-size clamp.
+    // ============================================================
+
+    [Fact]
+    public void Over_wide_box_auto_inline_margins_stays_start_anchored_ltr()
+    {
+        // P1#1 — left:0; right:0; width:800 (> CB inline 600) with BOTH
+        // inline margins auto. Equal centering would set each margin to
+        // -100, shifting the box LEFT of its `left` inset (offset -100).
+        // CSS 2.1 §10.3.7 forbids negative auto margins via centering:
+        // for LTR pin margin-left to 0, margin-right absorbs the slack →
+        // the box stays anchored at left:0.
+        var box = BuildAbsoluteBox(
+            top: 10, left: 0, width: 800, height: 30, right: 0,
+            inlineMarginsAuto: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(0.0, p.InlineOffset, precision: 3);   // start-anchored, NOT -100
+        Assert.Equal(800.0, p.InlineSize, precision: 3);
+    }
+
+    [Fact]
+    public void Over_tall_box_auto_block_margins_center_even_when_negative()
+    {
+        // P1#1 asymmetry — the §10.3.7 negative-slack rule is INLINE-only.
+        // top:0; bottom:0; height:1000 (> CB block 800) with both block
+        // margins auto → CSS 2.1 §10.6.4 has NO "may not be negative"
+        // clause, so the margins split equally to -100 each and the box
+        // is centered: block offset -100 (NOT 0). Proves the block axis
+        // does NOT inherit the inline rule.
+        var box = BuildAbsoluteBox(
+            top: 0, left: 0, width: 50, height: 1000, bottom: 0,
+            blockMarginsAuto: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(-100.0, p.BlockOffset, precision: 3);  // centered, even negative
+        Assert.Equal(1000.0, p.BlockSize, precision: 3);
+    }
+
+    [Fact]
+    public void Right_only_auto_width_preserves_right_inset_after_clamp()
+    {
+        // P2#3 — right:700 (> CB inline 600), width auto, left auto.
+        // Available width = 600 - 700 = -100 → clamps to 0, but the RIGHT
+        // inset must be preserved: the zero-width box's end edge stays at
+        // 600 - 700 = -100, so its left offset is -100 (NOT re-pinned to
+        // the static position 0).
+        var box = BuildAbsoluteBox(top: 10, height: 30, right: 700, widthAuto: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(0.0, p.InlineSize, precision: 3);
+        Assert.Equal(-100.0, p.InlineOffset, precision: 3);
+    }
+
+    [Fact]
+    public void Bottom_only_auto_height_preserves_bottom_inset_after_clamp()
+    {
+        // P2#3 (block axis) — bottom:900 (> CB block 800), height auto,
+        // top auto. Available height = 800 - 900 = -100 → clamps to 0;
+        // the bottom inset is preserved → block offset -100 (NOT 0).
+        var box = BuildAbsoluteBox(left: 20, width: 50, bottom: 900);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(0.0, p.BlockSize, precision: 3);
+        Assert.Equal(-100.0, p.BlockOffset, precision: 3);
     }
 }

--- a/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/AbsoluteLayouterTests.cs
@@ -32,11 +32,17 @@ public sealed class AbsoluteLayouterTests
         double? width = null, double? height = null,
         bool topPercent = false, bool widthAuto = false,
         double? right = null, double? bottom = null,
-        bool rightPercent = false)
+        bool rightPercent = false, bool inlineMarginsAuto = false)
     {
         var style = MakeStyle();
         // position: absolute = keyword id 2.
         style.Set(PropertyId.Position, ComputedSlot.FromKeyword(2));
+        if (inlineMarginsAuto)
+        {
+            // explicit `margin-left/right: auto` (Keyword slot).
+            style.Set(PropertyId.MarginLeft, ComputedSlot.FromKeyword(0));
+            style.Set(PropertyId.MarginRight, ComputedSlot.FromKeyword(0));
+        }
         if (topPercent)
         {
             style.Set(PropertyId.Top, ComputedSlot.FromPercentage(top ?? 0));
@@ -96,59 +102,152 @@ public sealed class AbsoluteLayouterTests
         Assert.Equal(30.0, p.BlockSize, precision: 3);
     }
 
+    // ============================================================
+    // Cycle 2b — the full §10.3.7 / §10.6.4 constraint solver.
+    // CB = OriginCb (origin 0, inline 600, block 800; margins 0,
+    // chrome 0 unless noted).
+    // ============================================================
+
     [Fact]
-    public void Auto_top_defers()
+    public void Auto_top_uses_static_position()
     {
-        // top unset (= auto default) → unresolved.
+        // top auto + bottom auto + height given → top = static position
+        // (CB origin = 0).
         var box = BuildAbsoluteBox(left: 20, width: 50, height: 30);
         var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("top", p.DeferReason);
+        Assert.True(p.IsResolved);
+        Assert.Equal(20.0, p.InlineOffset, precision: 3);
+        Assert.Equal(0.0, p.BlockOffset, precision: 3);
+        Assert.Equal(30.0, p.BlockSize, precision: 3);
     }
 
     [Fact]
-    public void Auto_left_defers()
+    public void Auto_left_uses_static_position()
     {
         var box = BuildAbsoluteBox(top: 10, width: 50, height: 30);
         var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("left", p.DeferReason);
+        Assert.True(p.IsResolved);
+        Assert.Equal(0.0, p.InlineOffset, precision: 3);   // static position
+        Assert.Equal(10.0, p.BlockOffset, precision: 3);
     }
 
     [Fact]
-    public void Auto_width_defers()
+    public void Auto_width_with_left_fills_available()
     {
+        // left given, right auto, width auto → width = available from
+        // left to CB inline-end = 600 - 20 = 580 (shrink-to-fit approx).
         var box = BuildAbsoluteBox(top: 10, left: 20, height: 30, widthAuto: true);
         var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("width", p.DeferReason);
+        Assert.True(p.IsResolved);
+        Assert.Equal(20.0, p.InlineOffset, precision: 3);
+        Assert.Equal(580.0, p.InlineSize, precision: 3);
     }
 
     [Fact]
-    public void Auto_height_defers()
+    public void Auto_height_with_top_fills_available()
     {
         var box = BuildAbsoluteBox(top: 10, left: 20, width: 50);
         var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("height", p.DeferReason);
+        Assert.True(p.IsResolved);
+        Assert.Equal(10.0, p.BlockOffset, precision: 3);
+        Assert.Equal(790.0, p.BlockSize, precision: 3);  // 800 - 10
     }
 
     [Fact]
-    public void Percentage_top_defers()
+    public void Percentage_top_resolves_against_cb_block_extent()
     {
+        // top: 50% of CB block (800) = 400; height 30 given; bottom auto.
         var box = BuildAbsoluteBox(top: 50, left: 20, width: 50, height: 30, topPercent: true);
         var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("top", p.DeferReason);
+        Assert.True(p.IsResolved);
+        Assert.Equal(400.0, p.BlockOffset, precision: 3);
+        Assert.Equal(30.0, p.BlockSize, precision: 3);
     }
 
     [Fact]
-    public void Negative_width_defers()
+    public void Right_anchored_resolves_left_from_remainder()
     {
-        var box = BuildAbsoluteBox(top: 10, left: 20, width: -50, height: 30);
+        // left auto, right=100, width=50 → left = 600 - 100 - 50 = 450.
+        var box = BuildAbsoluteBox(top: 10, width: 50, height: 30, right: 100);
         var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("negative", p.DeferReason);
+        Assert.True(p.IsResolved);
+        Assert.Equal(450.0, p.InlineOffset, precision: 3);
+        Assert.Equal(50.0, p.InlineSize, precision: 3);
+    }
+
+    [Fact]
+    public void Bottom_anchored_resolves_top_from_remainder()
+    {
+        // top auto, bottom=200, height=30 → top = 800 - 200 - 30 = 570.
+        var box = BuildAbsoluteBox(left: 10, width: 50, height: 30, bottom: 200);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(570.0, p.BlockOffset, precision: 3);
+        Assert.Equal(30.0, p.BlockSize, precision: 3);
+    }
+
+    [Fact]
+    public void Both_insets_with_auto_width_fills()
+    {
+        // left=20, right=30, width auto → width = 600 - 20 - 30 = 550.
+        var box = BuildAbsoluteBox(top: 10, left: 20, height: 30, right: 30, widthAuto: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(20.0, p.InlineOffset, precision: 3);
+        Assert.Equal(550.0, p.InlineSize, precision: 3);
+    }
+
+    [Fact]
+    public void Over_constrained_ignores_right_inset_ltr()
+    {
+        // left=20, width=50, right=0 ALL given, margins 0 (initial) →
+        // over-constrained: ignore `right` (LTR), anchor via left.
+        var box = BuildAbsoluteBox(top: 10, left: 20, width: 50, height: 30, right: 0);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(20.0, p.InlineOffset, precision: 3);
+        Assert.Equal(50.0, p.InlineSize, precision: 3);
+    }
+
+    [Fact]
+    public void Over_constrained_percentage_right_ignored()
+    {
+        // left=20, width=50, right=25% (=150), margins 0 → over-
+        // constrained, ignore right, anchor via left.
+        var box = BuildAbsoluteBox(
+            top: 10, left: 20, width: 50, height: 30, right: 25, rightPercent: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(20.0, p.InlineOffset, precision: 3);
+        Assert.Equal(50.0, p.InlineSize, precision: 3);
+    }
+
+    [Fact]
+    public void Over_constrained_with_auto_margins_centers()
+    {
+        // left=20, width=50, right=0 all given + BOTH margins auto →
+        // §10.3.7 centering: margins split the slack
+        // (600 - 20 - 0 - 50 = 530) → each 265. Border-box left =
+        // left(20) + marginLeft(265) = 285.
+        var box = BuildAbsoluteBox(top: 10, left: 20, width: 50, height: 30, right: 0,
+            inlineMarginsAuto: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(285.0, p.InlineOffset, precision: 3);
+        Assert.Equal(50.0, p.InlineSize, precision: 3);
+    }
+
+    [Fact]
+    public void Negative_resolved_size_clamps_to_zero()
+    {
+        // left=400, right=400, width auto → fill = 600-400-400 = -200;
+        // CSS clamps used width to >= 0, so the box resolves with
+        // width 0 (not dropped).
+        var box = BuildAbsoluteBox(top: 10, left: 400, height: 30, right: 400, widthAuto: true);
+        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
+        Assert.True(p.IsResolved);
+        Assert.Equal(0.0, p.InlineSize, precision: 3);
+        Assert.Equal(400.0, p.InlineOffset, precision: 3);
     }
 
     [Fact]
@@ -159,52 +258,5 @@ public sealed class AbsoluteLayouterTests
         Assert.True(p.IsResolved);
         Assert.Equal(0.0, p.InlineOffset, precision: 3);
         Assert.Equal(0.0, p.BlockOffset, precision: 3);
-    }
-
-    // ============================================================
-    // Post-PR-#112 review C1 — explicit right/bottom defers (cycle 1
-    // anchors via top/left only; right/bottom anchoring + over-
-    // constrained resolution is cycle 2). The box must NOT silently
-    // resolve via top/left while ignoring right/bottom.
-    // ============================================================
-
-    [Fact]
-    public void Explicit_right_defers_even_with_full_top_left_width_height()
-    {
-        // Over-specified (top+left+width+height ALL set) + an explicit
-        // right. Cycle 1 defers rather than silently ignoring `right`.
-        var box = BuildAbsoluteBox(top: 10, left: 20, width: 50, height: 30, right: 0);
-        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("right", p.DeferReason);
-    }
-
-    [Fact]
-    public void Explicit_bottom_defers()
-    {
-        var box = BuildAbsoluteBox(top: 10, left: 20, width: 50, height: 30, bottom: 0);
-        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("bottom", p.DeferReason);
-    }
-
-    [Fact]
-    public void Percentage_right_defers()
-    {
-        var box = BuildAbsoluteBox(
-            top: 10, left: 20, width: 50, height: 30, right: 25, rightPercent: true);
-        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.False(p.IsResolved);
-        Assert.Contains("right", p.DeferReason);
-    }
-
-    [Fact]
-    public void No_right_bottom_still_resolves()
-    {
-        // Sanity: the C1 fix doesn't break the happy path — a box with
-        // NO right/bottom (the default auto) resolves normally.
-        var box = BuildAbsoluteBox(top: 10, left: 20, width: 50, height: 30);
-        var p = AbsoluteLayouter.ResolvePlacement(box, OriginCb);
-        Assert.True(p.IsResolved);
     }
 }

--- a/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
@@ -6113,34 +6113,35 @@ public sealed class BlockLayouterTests
     }
 
     [Fact]
-    public void Cycle1_abspos_with_auto_offset_dropped_with_diagnostic()
+    public void Cycle2b_abspos_auto_top_uses_static_position()
     {
-        // `top` left auto (unset) → cycle-1 deferral → box dropped +
-        // LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001 emitted.
+        // Per Phase 3 Task 19 cycle 2b — `top` auto (unset) is no longer
+        // a deferral: top auto + bottom auto + height given → top =
+        // static position (CB origin 0). The box emits at (left, 0).
         var sink = new RecordingFragmentSink();
-        var diag = new RecordingDiagnosticsSink();
         var root = Box.CreateRoot(MakeStyle());
 
         var absStyle = MakeStyle();
         SetKeyword(absStyle, PropertyId.Position, 2);
-        // top intentionally unset (auto).
+        // top intentionally unset (auto) → static position.
         SetLengthPx(absStyle, PropertyId.Left, 20);
         SetLengthPx(absStyle, PropertyId.Width, 50);
         SetLengthPx(absStyle, PropertyId.Height, 30);
         var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
         root.AppendChild(abs);
 
-        using var layouter = new BlockLayouter(root, sink, diagnostics: diag);
+        using var layouter = new BlockLayouter(root, sink);
         var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
-        var layoutCtx = new LayoutContext(ctx) { Diagnostics = diag };
+        var layoutCtx = new LayoutContext(ctx);
         using var resolver = new BreakResolver();
 
         layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
 
-        // No fragment for the dropped box.
-        Assert.DoesNotContain(sink.Fragments, f => ReferenceEquals(f.Box, abs));
-        Assert.Contains(diag.Diagnostics, d =>
-            d.Code == PaginateDiagnosticCodes.LayoutAbsoluteFeatureUnsupported001);
+        var absFrag = sink.Fragments.First(f => ReferenceEquals(f.Box, abs));
+        Assert.Equal(20.0, absFrag.InlineOffset, precision: 3);
+        Assert.Equal(0.0, absFrag.BlockOffset, precision: 3);  // static position
+        Assert.Equal(50.0, absFrag.InlineSize, precision: 3);
+        Assert.Equal(30.0, absFrag.BlockSize, precision: 3);
     }
 
     [Fact]
@@ -6275,16 +6276,16 @@ public sealed class BlockLayouterTests
     }
 
     [Fact]
-    public void Cycle2a_abspos_under_relative_ancestor_with_offsets_dropped_with_diagnostic()
+    public void Cycle2b_abspos_under_relative_ancestor_with_offsets_applies_shift()
     {
-        // Per post-PR-#113 review P2#1 — a `position: relative` ancestor
-        // with explicit inset offsets (top/left) would visually shift,
-        // moving its abspos descendants' CB origin. Relative-offset
-        // application is unimplemented, so the abspos child is DROPPED +
-        // LAYOUT-ABSOLUTE-FEATURE-UNSUPPORTED-001 emitted rather than
-        // anchored to the unshifted flow position.
+        // Per Phase 3 Task 19 cycle 2b — a `position: relative` ancestor
+        // with explicit inset offsets (top/left) has its §9.4.3 shift
+        // APPLIED to the abspos descendant's CB origin (cycle 2a
+        // deferred this). The relative parent's flow position is (0, 0)
+        // (first child, no border); its relative shift is (left 10,
+        // top 50) → shifted padding-box origin (10, 50). The abspos
+        // child top:0 left:0 → (10, 50).
         var sink = new RecordingFragmentSink();
-        var diag = new RecordingDiagnosticsSink();
         var root = Box.CreateRoot(MakeStyle());
 
         var relStyle = MakeStyle();
@@ -6304,16 +6305,18 @@ public sealed class BlockLayouterTests
         var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
         rel.AppendChild(abs);
 
-        using var layouter = new BlockLayouter(root, sink, diagnostics: diag);
+        using var layouter = new BlockLayouter(root, sink);
         var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
-        var layoutCtx = new LayoutContext(ctx) { Diagnostics = diag };
+        var layoutCtx = new LayoutContext(ctx);
         using var resolver = new BreakResolver();
 
         layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
 
-        Assert.DoesNotContain(sink.Fragments, f => ReferenceEquals(f.Box, abs));
-        Assert.Contains(diag.Diagnostics, d =>
-            d.Code == PaginateDiagnosticCodes.LayoutAbsoluteFeatureUnsupported001);
+        var absFrag = sink.Fragments.First(f => ReferenceEquals(f.Box, abs));
+        // CB origin = rel flow (0,0) + relative shift (10, 50); abspos
+        // top:0 left:0 → (10, 50).
+        Assert.Equal(10.0, absFrag.InlineOffset, precision: 3);
+        Assert.Equal(50.0, absFrag.BlockOffset, precision: 3);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockLayouterTests.cs
@@ -6355,10 +6355,58 @@ public sealed class BlockLayouterTests
         Assert.Equal(10.0, absFrag.BlockOffset, precision: 3);
     }
 
+    [Fact]
+    public void PostPr114_abspos_relative_ancestor_percent_offsets_resolve_per_axis()
+    {
+        // Per post-PR-#114 review P1#2 — a `position: relative` ancestor
+        // with PERCENTAGE inset offsets shifts per-axis: left/right
+        // resolve against the containing-block WIDTH, top/bottom against
+        // its HEIGHT. The ancestor fills the 600px content width and is
+        // 400px tall (distinct extents) with left:50% top:50%. inline
+        // shift = 50% × 600 = 300; block shift = 50% × 400 = 200 (NOT 50%
+        // × 600 = 300, the pre-fix wrong-axis result that resolved top
+        // against the inline extent). The abspos child (top:0 left:0)
+        // anchors to the shifted padding-box origin (300, 200) — the
+        // block offset (200 ≠ 300) is the proof the fix uses the HEIGHT.
+        var sink = new RecordingFragmentSink();
+        var root = Box.CreateRoot(MakeStyle());
+
+        var relStyle = MakeStyle();
+        SetKeyword(relStyle, PropertyId.Position, 1); // relative
+        SetLengthPx(relStyle, PropertyId.Height, 400);
+        SetPercentage(relStyle, PropertyId.Left, 50);
+        SetPercentage(relStyle, PropertyId.Top, 50);
+        var rel = Box.ForElement(BoxKind.BlockContainer, relStyle, MakeElement());
+        root.AppendChild(rel);
+
+        var absStyle = MakeStyle();
+        SetKeyword(absStyle, PropertyId.Position, 2); // absolute
+        SetLengthPx(absStyle, PropertyId.Top, 0);
+        SetLengthPx(absStyle, PropertyId.Left, 0);
+        SetLengthPx(absStyle, PropertyId.Width, 30);
+        SetLengthPx(absStyle, PropertyId.Height, 30);
+        var abs = Box.ForElement(BoxKind.BlockContainer, absStyle, MakeElement());
+        rel.AppendChild(abs);
+
+        using var layouter = new BlockLayouter(root, sink);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        var absFrag = sink.Fragments.First(f => ReferenceEquals(f.Box, abs));
+        Assert.Equal(300.0, absFrag.InlineOffset, precision: 3);  // 50% × width 600
+        Assert.Equal(200.0, absFrag.BlockOffset, precision: 3);   // 50% × HEIGHT 400
+    }
+
     private static ComputedStyle MakeStyle() => ComputedStyle.RentForExclusiveTesting();
 
     private static void SetLengthPx(ComputedStyle style, PropertyId id, double px) =>
         style.Set(id, ComputedSlot.FromLengthPx(px));
+
+    private static void SetPercentage(ComputedStyle style, PropertyId id, double pct) =>
+        style.Set(id, ComputedSlot.FromPercentage(pct));
 
     private static void SetKeyword(ComputedStyle style, PropertyId id, int keywordIndex) =>
         style.Set(id, ComputedSlot.FromKeyword(keywordIndex));


### PR DESCRIPTION
## Summary

Completes `position: absolute` resolution (the rest of cycle 2 in one PR). Replaces the cycle-1 explicit-only placement with the full **CSS 2.1 §10.3.7 (inline) + §10.6.4 (block)** constraint solver, plus **relative-offset application** to the containing block.

**`AbsoluteLayouter.SolveAxis`** resolves the (inset-start, size, inset-end, margin-start, margin-end) system per axis:
- `auto` + percentage insets/sizes/margins (percentages vs CB extent; margin initial `0`, only explicit `auto` centers);
- `right`/`bottom` anchoring; over-constrained → ignore the end inset (LTR/ttb) unless auto margins absorb the slack (centering);
- fill (auto size + both insets) — EXACT; auto size otherwise → available-extent approximation;
- `auto` both insets → static-position approximation (CB origin); negative resolved size → clamped to 0.

**`BlockLayouter.ResolveContainingBlock`** now applies a `position: relative` ancestor's §9.4.3 shift (`left`/`top` or `-right`/`-bottom`) to the abspos CB origin (cycle 2a deferred this).

## Deferred (later refinements, documented)

True shrink-to-fit (inline) / content height (block) — need intrinsic-size measurement; the relative box's OWN-fragment shift; z-index paint order; positioned grid/flex/table containers as CB establishers (still cycle-2a-recorded only for block-flow paths).

## Test plan

- [x] `AbsoluteLayouterTests` rewritten for every §6 case (static-position, fill, right/bottom anchoring, percentages, over-constrained ignore-end-inset, auto-margin centering, negative→0 clamp)
- [x] `BlockLayouterTests` + `AbsoluteLayouterProductionTests`: auto-offset static position, relative-ancestor shift, right-anchored end-to-end
- [x] 5,327 unit + 97 RealDocuments + 30 LayoutSnapshots + 4 AotJitParity green
- [x] AOT/JIT byte-parity preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)