### PR TITLE
Phase 3 PR 2 (tasks 4-5): direction resolution pipeline + RTL text-align start/end swap

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,7 @@
 
 > **Current state (2026-06-18):** Phase 3's layout + pagination **engine is feature-complete and multi-page rendering is live**. What's left to *finish* Phase 3 is (a) wiring W3C conformance **measurement**, (b) a curated **feature/polish backlog**, (c) **confirming** the perf/memory gates, and (d) the **`0.7.0-beta` release**. The recommended next step is **PR 1 — Conformance measurement** (see the roadmap).
 >
-> Active branch: PR [#195](https://github.com/raroche/NetPdf/pull/195) (inline-level alignment finish) in review. `git log --oneline -1` shows the exact commit.
+> Active branch: `phase3-direction-pipeline-rtl-textalign` — PR 2 tasks 4–5 (the `direction` resolution pipeline + RTL `text-align`/atomic swap). PR 1 (conformance) awaits Roland's approach decision; task 6 (RTL flex flip) is the remaining PR-2 task. `git log --oneline -1` shows the exact commit.
 >
 > This file was consolidated from a 1.1 MB chronological log on 2026-06-18; the full per-subtask history is archived in [docs/progress-archive.md](docs/progress-archive.md). **Keep this file compact** — roll the roadmap as each PR lands; don't grow a blow-by-blow log here.
 
@@ -17,7 +17,7 @@
 | 4 | Visual parity (gradients, shadows, filters, SVG) | ⏸️ Not started |
 | 5 | Packaging + release | 🔵 Interleaved — layout→PDF wiring done |
 
-**Gates (all green, 2026-06-18):** 7043 unit / 5 skip · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
+**Gates (all green, 2026-06-18):** 7078 unit / 5 skip · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
 
 ## Phase 3 — what's shipped (consolidated)
 
@@ -58,9 +58,9 @@ Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order.
 3. **Flexbox + Grid pass-rates** — wire those subsets, gate ≥ 85% / ≥ 70%, publish the four numbers in the README.
 
 ### PR 2 — Direction / bidi pipeline  [feature; several deferrals block on this]
-4. A shared `direction` / writing-mode resolution pipeline (the missing infra many deferrals cite).
-5. RTL `text-align` (start/end swap) + RTL inline-atomic alignment.
-6. RTL flex main-axis flip (`flex-direction: row` under `direction: rtl`).
+4. ✅ A shared `direction` resolution pipeline — `DirectionStyleExtensions` (`ReadDirection`/`IsRtl`/`ReadParagraphDirection`); `direction` registered (inherited, `ltr`/`rtl`); bidi base direction now CSS-driven at the inline-layout seam. Writing-mode stays horizontal-tb (the seam composes vertical modes later).
+5. ✅ RTL `text-align` start/end swap (`ReadInlineAlignFactor` direction-aware — `start`→right in RTL) + RTL inline-atomic alignment (atomic shifts to the right edge). LTR output byte-identical.
+6. RTL flex main-axis flip (`flex-direction: row` under `direction: rtl`) — **remaining**; FlexLayouter adopts the now-existing pipeline (skip'd test `…pending_flex_direction_adoption`). *Residual direction gaps* (see `rtl-fragment-reversal`): UAX #9 L2 slice reversal, `dir` HTML attribute → `direction`, margin-box base direction.
 
 ### PR 3 — Inline-text polish  [feature]
 7. Line-edge `vertical-align` line growth — contain a tall `top/bottom/middle/text-*` run (the PR #195 deferral).

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -159,19 +159,33 @@ grepping the ID).
 
 - **ID** — `rtl-fragment-reversal`
 - **Status** — `approximated`.
-- **Behavior** — HarfBuzz shapes RTL runs in visual (reversed) order
-  internally; `LineFragment.Slices` stays in document order. Painters
-  walk per-shaped-run glyph arrays as-is. Single-direction LTR
-  paragraphs paint correctly. Single-direction RTL paragraphs walk in
-  the wrong visual order at the fragment level.
-- **Missing** — Fragment-level slice reversal for RTL paragraph base
-  direction so the painter consumes slices visually right-to-left.
+- **Behavior** — The paragraph BASE direction is now CSS-driven (PR 2
+  task 4 — a `direction: rtl` block resolves to bidi base level 1 and
+  RIGHT-aligns via the `text-align` start/end swap, task 5). HarfBuzz
+  shapes RTL runs in visual (reversed) order internally; but
+  `LineFragment.Slices` stays in DOCUMENT order. Painters walk
+  per-shaped-run glyph arrays as-is. Single-direction LTR paragraphs
+  paint correctly. Single-direction RTL paragraphs are right-aligned
+  but walk in the wrong visual order at the fragment level (the levels
+  are correct; only the slice ORDER is wrong).
+- **Missing** — Fragment-level slice reversal (UAX #9 L2) for RTL
+  paragraph base direction so the painter consumes slices visually
+  right-to-left. Plus two residual direction-pipeline gaps: the `dir`
+  HTML attribute is NOT mapped to the `direction` property (only CSS
+  `direction` works), and `PageMarginBoxPainter` inline text still
+  hardcodes LTR base direction.
 - **Trigger** — RTL primary direction (Arabic / Hebrew) enters the
-  corpus, OR a user reports right-to-left mis-rendering.
+  corpus, OR a user reports right-to-left mis-rendering / a `dir="rtl"`
+  attribute having no effect.
 - **Owner files** — `src/NetPdf.Layout/Inline/LineBuilder.cs::Wrap`
   emission site (`EmitDrawableRange`) — reverse slice order when the
-  paragraph base direction is `ParagraphDirection.RightToLeft`.
-- **Added** — Phase 3 Task 10 cycle 1 documented the deferral.
+  paragraph base direction is `ParagraphDirection.RightToLeft`. The
+  base direction itself is resolved by
+  `DirectionStyleExtensions.ReadParagraphDirection` (PR 2 task 4).
+- **Added** — Phase 3 Task 10 cycle 1 documented the deferral; PR 2
+  task 4 wired CSS-driven base direction (levels + alignment are now
+  correct; the visual slice reversal + `dir` attribute + margin-box
+  base direction remain).
 - **Removal condition** — Wrap reverses slice order for RTL paragraphs
   AND the painter consumes them visually.
 
@@ -274,15 +288,19 @@ grepping the ID).
   - A `text-align: justify` line carrying an inline ATOMIC now DISTRIBUTES inter-word gaps AND shifts the
     atomic right by the gaps before it (the shared `InlineJustify` helper — the painter + the inline-atomic
     placement can't disagree); `justify-all` justifies the LAST line too. Deferred: an internal
-    `<br>`-terminated line stays start-aligned even under justify-all; RTL paragraphs don't shift the atomic
-    with the text. (center / right / end also shift the atomic — body text-align cycle.)
+    `<br>`-terminated line stays start-aligned even under justify-all. (center / right / end shift the atomic
+    — body text-align cycle; and the direction-relative `start`/`end` shift it to the RIGHT edge in an RTL
+    block — direction pipeline, PR 2 task 5. What remains: the atomic's bidi VISUAL ORDER within a
+    mixed-direction line is still document-order — see `rtl-fragment-reversal`.)
   - An inline-block's `auto` width shrink-to-fit uses the MAX-CONTENT measured at the available width (no
     separate min-content pass); deeply nested inline-blocks recurse through `NestedContentMeasurer` (bounded
     by document depth, not a dedicated cap); LTR horizontal-tb.
   - `inline-flex` / `inline-grid` / `inline-table` atomics (which need a laid-out sub-box of a non-block
     formatting context) remain deferred.
-- **Trigger** — an RTL inline `<img>` or inline-block, a line-edge text `vertical-align` (`top`/`bottom`/
-  `middle`/`text-*`) on a run TALLER than its line (overflow), or an `inline-flex`/`-grid`/`-table` span.
+- **Trigger** — a mixed-direction line needing bidi VISUAL reordering of an inline `<img>` / inline-block
+  (the RTL text-align alignment is already honoured — PR 2 task 5), a line-edge text `vertical-align`
+  (`top`/`bottom`/`middle`/`text-*`) on a run TALLER than its line (overflow), or an
+  `inline-flex`/`-grid`/`-table` span.
 - **Owner files** —
   - `src/NetPdf.Layout/Inline/InlineAtomic.cs` — the atomic primitive (box + used width/height).
   - `src/NetPdf.Layout/Inline/{TextRun,ShapedRun}.cs` — the optional `Atomic` payload.
@@ -299,9 +317,9 @@ grepping the ID).
 - **Added** — Phase 3 Task 11 sub-cycle 1 review Finding #4; inline `<img>` first cut shipped in the
   inline-atomic-boxes cycle; inline-block first cut shipped in the inline-block cycle.
 - **Removal condition** — line-edge text `vertical-align` GROWS its line (no overflow for a tall run), RTL
-  alignment honoured for inline atomics, the inline-block's last-line baseline using true per-RUN content
-  metrics + min-content shrink-to-fit, and inline-flex / -grid / -table atomics laid out (no longer
-  `LAYOUT-INLINE-ATOMIC-NOT-SUPPORTED-001`).
+  bidi VISUAL ORDER honoured for inline atomics (the text-align alignment is already honoured — PR 2 task 5),
+  the inline-block's last-line baseline using true per-RUN content metrics + min-content shrink-to-fit, and
+  inline-flex / -grid / -table atomics laid out (no longer `LAYOUT-INLINE-ATOMIC-NOT-SUPPORTED-001`).
 
 ---
 
@@ -1066,14 +1084,15 @@ grepping the ID).
     to-left along the inline axis (physically equivalent to LTR
     `row-reverse`); `row` in vertical-rl swaps the main + cross
     axes onto the block + inline directions of the rotated writing
-    mode. L7+ scope — requires plumbing `direction` +
-    `writing-mode` properties through the layout pipeline (L6
-    shipped `flex-wrap: wrap` without addressing this gap). Pinned
-    by the Skip'd
-    `L5_known_gap_rtl_row_should_flip_main_axis_but_no_direction_pipeline_yet`
-    test — when L7+ adds the direction pipeline, that test should
-    flip to spec-correct expectations + this bullet should be
-    removed.
+    mode. The shared direction pipeline now EXISTS
+    (`DirectionStyleExtensions.ReadDirection` / `IsRtl`, PR 2 task 4);
+    the remaining work (PR 2 task 6) is FlexLayouter ADOPTING it — read
+    the cascaded `direction` and flip the `row` main-axis mapping to
+    right-to-left under RTL (`writing-mode` vertical modes stay out of
+    scope). Pinned by the Skip'd
+    `L5_known_gap_rtl_row_should_flip_main_axis_pending_flex_direction_adoption`
+    test — when task 6 wires the adoption, that test should flip to
+    spec-correct expectations + this bullet should be removed.
   - Outer-main-size + auto-margins in `justify-content` free-space
     calculation (CSS Flexbox L1 §9.5): L2's pre-pass sums only
     declared `width`, ignoring item margins / padding / borders /

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -191,6 +191,36 @@ grepping the ID).
 
 ---
 
+## text-align-match-parent
+
+- **ID** — `text-align-match-parent`
+- **Status** — `approximated`.
+- **Behavior** — `text-align: match-parent` (CSS Text 3 §7.1) is approximated as a
+  fixed physical LEFT (line-align factor 0), direction-INSENSITIVE. Per spec it
+  should take the PARENT's computed `text-align`, resolve a `start`/`end` value
+  against the PARENT's `direction` to physical left/right, and inherit that matched
+  alignment. The approximation diverges whenever the parent's resolved alignment is
+  not physical-left — e.g. parent `direction: ltr; text-align: start` with child
+  `direction: rtl; text-align: match-parent` should align LEFT (the parent's start
+  resolved in LTR), and a parent `text-align: center` should make the child center.
+- **Missing** — Parent-aware resolution at cascade / computed-value time:
+  `match-parent` needs the PARENT element's computed `text-align` + `direction`,
+  which the layout-time `ReadInlineAlignFactor` reader does not have.
+- **Trigger** — a document uses `text-align: match-parent` (rare) AND the parent's
+  resolved alignment is not physical-left (parent not `start`-in-LTR), or the child
+  overrides `direction`.
+- **Owner files** — `src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs`
+  (`ReadInlineAlignFactor`, the `6 => 0.0` branch). True resolution belongs in the
+  cascade / box-builder walk where the parent computed style is available.
+- **Added** — PR 2 task 5 review (P2): the direction pipeline made `start`/`end`
+  direction-aware; `match-parent` was carved OUT of the direction-aware `start`
+  path into a fixed approximation so it does not masquerade as spec-correct
+  (a `direction: rtl` child would otherwise have right-aligned).
+- **Removal condition** — `match-parent` resolves against the PARENT's `text-align`
+  + `direction` at computed-value time and inherits the matched alignment.
+
+---
+
 ## phase-4-painter-wiring
 
 - **ID** — `phase-4-painter-wiring`

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/KeywordResolver.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/KeywordResolver.cs
@@ -209,6 +209,11 @@ internal static class KeywordResolver
             "nw-resize", "se-resize", "sw-resize", "ew-resize", "ns-resize", "nesw-resize",
             "nwse-resize", "zoom-in", "zoom-out");
 
+        // direction — CSS Writing Modes 4 §2.1. Sets the inline base direction of
+        // the box's content. ids ltr=0, rtl=1 — the contract the layout-side
+        // ComputedStyle.ReadDirection() / ReadParagraphDirection() readers switch on.
+        b[PropertyId.Direction] = T("ltr", "rtl");
+
         // display — CSS Display 3 §2 (the common single-keyword forms; multi-keyword
         // syntax `inline flex` etc. is out-of-scope for cycle 1).
         b[PropertyId.Display] = T("block", "inline", "inline-block", "list-item", "flex",

--- a/src/NetPdf.Css/properties.json
+++ b/src/NetPdf.Css/properties.json
@@ -44,6 +44,7 @@
     { "name": "column-width", "id": "ColumnWidth", "type": "Length", "default": "auto", "inherit": false, "applies_to": "BlockOnly", "computed": "Specified" },
     { "name": "content", "id": "Content", "type": "Content", "default": "normal", "inherit": false, "applies_to": "All", "computed": "Specified" },
     { "name": "cursor", "id": "Cursor", "type": "Keyword", "default": "auto", "inherit": true, "applies_to": "All", "computed": "Specified" },
+    { "name": "direction", "id": "Direction", "type": "Keyword", "default": "ltr", "inherit": true, "applies_to": "All", "computed": "Specified" },
     { "name": "display", "id": "Display", "type": "Keyword", "default": "inline", "inherit": false, "applies_to": "All", "computed": "Specified" },
     { "name": "flex-basis", "id": "FlexBasis", "type": "FlexBasis", "default": "auto", "inherit": false, "applies_to": "FlexItems", "computed": "Specified" },
     { "name": "flex-direction", "id": "FlexDirection", "type": "Keyword", "default": "row", "inherit": false, "applies_to": "FlexContainers", "computed": "Specified" },

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7019,7 +7019,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 resolver: _shaperResolver!,
                 scriptIso15924: "Latn",
                 language: "en",
-                paragraphDirection: ParagraphDirection.LeftToRight,
+                // Direction pipeline — the paragraph base direction is the block's
+                // computed `direction` (CSS Writing Modes 4 §2.1), not a hardcoded
+                // LTR. An RTL block (`direction: rtl`) lays its inline formatting
+                // context out right-to-left (bidi base level 1); a default/LTR block
+                // is byte-identical to the pre-pipeline output.
+                paragraphDirection: inlineOnlyBlock.Style.ReadParagraphDirection(),
                 hyphenator: null,
                 cancellationToken: cancellationToken,
                 // Per Phase 3 Task 12 sub-cycle 5 hardening Finding 5
@@ -7097,8 +7102,9 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// (0.8 / −0.2 em — the layout layer has no font-metric access; the painter uses the REAL font
     /// metrics for glyphs, so an atomic's bottom aligns to the text baseline within typical-font
     /// tolerance); the line's <c>text-align</c> offset shifts the atomic WITH its text (body
-    /// text-align cycle — center / right / end; <c>justify</c> + RTL still leave it start-relative);
-    /// and only <c>vertical-align: baseline</c> is honoured.</para></summary>
+    /// text-align cycle — center / right / end, plus the direction-relative <c>start</c>/<c>end</c>
+    /// so an RTL block's atomic shifts to the RIGHT edge; <c>justify</c> still leaves it
+    /// start-relative); and only <c>vertical-align: baseline</c> is honoured.</para></summary>
     private (IReadOnlyList<double>? PerLineHeightsPx,
              IReadOnlyList<double>? PerLineBaselineTopPx,
              IReadOnlyList<InlineAtomicPlacement> Placements,
@@ -7111,8 +7117,9 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         var shapedRuns = inlineResult.ShapedRuns;
         // Body text-align cycle — each line shifts by (content width − line advance) × factor, the
         // SAME shift TextPainter applies to the glyph lines (so an inline atomic moves WITH its
-        // text under text-align: center / right). 0 (start) leaves the start-relative placement
-        // byte-identical to the pre-cycle output.
+        // text under text-align: center / right, and to the RIGHT edge under an RTL `start` —
+        // ReadInlineAlignFactor resolves start/end against `direction`). A factor of 0 leaves the
+        // start-relative placement byte-identical to the pre-cycle output.
         var alignFactor = blockStyle.ReadInlineAlignFactor();
 
         // Approximate Latin font ascent/descent as a fraction of font-size (consistent with the

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -165,20 +165,34 @@ internal static class ComputedStyleLayoutExtensions
 
     /// <summary>Body text-align cycle — the horizontal line-alignment FACTOR (CSS Text 3 §7.1)
     /// for inline content: the fraction of a line's free space (content width − line advance) the
-    /// line shifts by. <c>center</c> → 0.5; <c>end</c> / <c>right</c> → 1.0 (right-align);
-    /// <c>start</c> / <c>left</c> → 0 (no shift, the initial). <c>justify</c> / <c>justify-all</c>
-    /// return 0 HERE — they distribute inter-word (not a whole-line shift) via
-    /// <see cref="ReadInlineJustify"/>, falling back to start (0) for the non-justified last line.
-    /// <c>match-parent</c> stays approximated as <c>start</c>. LTR horizontal-tb (RTL would swap
-    /// start/end — deferred). Consumed by <c>TextPainter</c> (the glyph lines, via
-    /// <c>BoxFragment.LineAlignFactor</c>) + the inline-atomic placement, so both shift together.</summary>
-    public static double ReadInlineAlignFactor(this ComputedStyle s) =>
-        s.ReadKeywordOrDefault(PropertyId.TextAlign, defaultIndex: 0) switch
+    /// line shifts by. <c>center</c> → 0.5; physical <c>right</c> → 1.0, physical <c>left</c> → 0.
+    /// <c>justify</c> / <c>justify-all</c> return 0 HERE — they distribute inter-word (not a
+    /// whole-line shift) via <see cref="ReadInlineJustify"/>, falling back to start for the
+    /// non-justified last line.
+    ///
+    /// <para><b>Direction-relative start/end (direction pipeline).</b> <c>start</c> / <c>end</c>
+    /// resolve against the box's computed <c>direction</c> (<see cref="DirectionStyleExtensions.IsRtl"/>):
+    /// in LTR <c>start</c> → 0 (left), <c>end</c> → 1 (right); in RTL the start edge is the RIGHT
+    /// edge, so <c>start</c> → 1 and <c>end</c> → 0. The initial <c>text-align: start</c> therefore
+    /// RIGHT-aligns an RTL block. <c>match-parent</c> stays approximated as <c>start</c>. An LTR box
+    /// is byte-identical to the pre-pipeline mapping.</para>
+    ///
+    /// <para>Consumed by <c>TextPainter</c> (the glyph lines, via <c>BoxFragment.LineAlignFactor</c>)
+    /// + the inline-atomic placement, so the glyphs AND any inline atomic shift together — including
+    /// to the right under an RTL <c>start</c>.</para></summary>
+    public static double ReadInlineAlignFactor(this ComputedStyle s)
+    {
+        var rtl = s.IsRtl();
+        return s.ReadKeywordOrDefault(PropertyId.TextAlign, defaultIndex: 0) switch
         {
-            4 => 0.5,        // center
-            1 or 3 => 1.0,   // end / right
-            _ => 0.0,        // start(0) / left(2) / justify(5) / match-parent(6) / justify-all(7)
+            2 => 0.0,              // left  (physical)
+            3 => 1.0,              // right (physical)
+            4 => 0.5,              // center
+            5 or 7 => 0.0,         // justify / justify-all — distributed, not a whole-line shift
+            1 => rtl ? 0.0 : 1.0,  // end   → left in RTL, right in LTR
+            _ => rtl ? 1.0 : 0.0,  // start(0) / match-parent(6) → right in RTL, left in LTR
         };
+    }
 
     /// <summary>text-align: justify cycle — whether inline content should be JUSTIFIED (CSS Text 3
     /// §7.3 inter-word distribution): the line's free space (content width − line advance) is spread

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -174,8 +174,14 @@ internal static class ComputedStyleLayoutExtensions
     /// resolve against the box's computed <c>direction</c> (<see cref="DirectionStyleExtensions.IsRtl"/>):
     /// in LTR <c>start</c> → 0 (left), <c>end</c> → 1 (right); in RTL the start edge is the RIGHT
     /// edge, so <c>start</c> → 1 and <c>end</c> → 0. The initial <c>text-align: start</c> therefore
-    /// RIGHT-aligns an RTL block. <c>match-parent</c> stays approximated as <c>start</c>. An LTR box
-    /// is byte-identical to the pre-pipeline mapping.</para>
+    /// RIGHT-aligns an RTL block. An LTR box is byte-identical to the pre-pipeline mapping.</para>
+    ///
+    /// <para><b><c>match-parent</c> is a DEFERRED approximation</b> — a fixed physical LEFT (factor 0),
+    /// direction-INSENSITIVE. Spec-correct <c>match-parent</c> (CSS Text 3 §7.1) takes the PARENT's
+    /// <c>text-align</c>, resolves a <c>start</c>/<c>end</c> against the PARENT's <c>direction</c>, and
+    /// inherits that matched alignment — which needs the parent computed style at cascade time, not
+    /// available to this layout-time reader. Carved out of the direction-aware <c>start</c> path so it
+    /// does NOT masquerade as spec-correct. See <c>deferrals.md#text-align-match-parent</c>.</para>
     ///
     /// <para>Consumed by <c>TextPainter</c> (the glyph lines, via <c>BoxFragment.LineAlignFactor</c>)
     /// + the inline-atomic placement, so the glyphs AND any inline atomic shift together — including
@@ -190,7 +196,8 @@ internal static class ComputedStyleLayoutExtensions
             4 => 0.5,              // center
             5 or 7 => 0.0,         // justify / justify-all — distributed, not a whole-line shift
             1 => rtl ? 0.0 : 1.0,  // end   → left in RTL, right in LTR
-            _ => rtl ? 1.0 : 0.0,  // start(0) / match-parent(6) → right in RTL, left in LTR
+            6 => 0.0,              // match-parent — DEFERRED fixed approximation (left); see XML doc
+            _ => rtl ? 1.0 : 0.0,  // start(0) → right in RTL, left in LTR
         };
     }
 

--- a/src/NetPdf.Layout/Layouters/InlineDirection.cs
+++ b/src/NetPdf.Layout/Layouters/InlineDirection.cs
@@ -1,0 +1,61 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.Properties;
+using NetPdf.Text.Bidi;
+
+namespace NetPdf.Layout.Layouters;
+
+/// <summary>The resolved inline base direction of a box (CSS Writing Modes 4 §2.1
+/// <c>direction</c>). LTR / RTL only — the <c>direction</c> property admits no
+/// <c>auto</c> (unlike the bidi paragraph level, which can be auto-detected).</summary>
+internal enum InlineDirection
+{
+    /// <summary><c>direction: ltr</c> — keyword id 0 (the initial value).</summary>
+    Ltr,
+
+    /// <summary><c>direction: rtl</c> — keyword id 1.</summary>
+    Rtl,
+}
+
+/// <summary>
+/// The shared direction / writing-mode resolution pipeline — the ONE seam that maps a
+/// box's computed <c>direction</c> (+ writing-mode, fixed at horizontal-tb today) onto
+/// the values layout consumes: the bidi paragraph base direction and the
+/// inline-start ↔ left/right mapping that <c>text-align</c> (and, when picked up,
+/// floats / <c>clear</c> / <c>caption-side</c>) need.
+///
+/// <para><b>Why one seam.</b> Several LTR-only approximations across the layouters
+/// (<see cref="ComputedStyleLayoutExtensions.ReadInlineAlignFactor"/>'s start/end swap,
+/// <see cref="ComputedStyleLayoutExtensions.ReadFloatSide"/> /
+/// <see cref="ComputedStyleLayoutExtensions.ReadCaptionSide"/> inline-start/end
+/// resolution) cite "resolve against writing-mode + direction" as their pickup trigger.
+/// This is that resolution. Writing mode is horizontal-tb only for now (the property is
+/// not yet registered), so the inline axis is horizontal and <c>direction</c> alone
+/// decides whether the inline-start edge is left or right; when vertical writing modes
+/// land they compose HERE, leaving the call sites unchanged.</para>
+/// </summary>
+internal static class DirectionStyleExtensions
+{
+    /// <summary>The box's computed inline base direction (CSS Writing Modes 4 §2.1).
+    /// <c>ltr</c>(0, the initial) / <c>rtl</c>(1) — the
+    /// <c>KeywordResolver</c> id contract.</summary>
+    public static InlineDirection ReadDirection(this ComputedStyle s) =>
+        s.ReadKeywordOrDefault(PropertyId.Direction, defaultIndex: 0) == 1
+            ? InlineDirection.Rtl
+            : InlineDirection.Ltr;
+
+    /// <summary>True when the box's inline base direction is RTL.</summary>
+    public static bool IsRtl(this ComputedStyle s) =>
+        s.ReadDirection() == InlineDirection.Rtl;
+
+    /// <summary>Map the computed <c>direction</c> onto the bidi paragraph base
+    /// direction. An explicit <c>direction</c> pre-empts the UAX #9 P2/P3 first-
+    /// strong-character heuristic: <c>rtl</c> forces paragraph level 1,
+    /// <c>ltr</c> forces level 0. Consumed at the inline-layout seam
+    /// (<c>BlockLayouter</c> → <c>InlineLayouter.LayoutPerRun</c>) so an RTL block
+    /// lays its paragraph out right-to-left.</summary>
+    public static ParagraphDirection ReadParagraphDirection(this ComputedStyle s) =>
+        s.IsRtl() ? ParagraphDirection.RightToLeft : ParagraphDirection.LeftToRight;
+}

--- a/tests/NetPdf.RealDocuments/Css/PropertyCoverageCorpusTests.cs
+++ b/tests/NetPdf.RealDocuments/Css/PropertyCoverageCorpusTests.cs
@@ -90,7 +90,9 @@ public sealed class PropertyCoverageCorpusTests
         "orphans", "widows",
         "z-index", "visibility",
         "opacity",
-        "direction", "unicode-bidi",
+        // `direction` REMOVED from this allowlist (PR 2 task 4 — the direction pipeline) — it's now
+        // registered in properties.json + resolved by KeywordResolver; `unicode-bidi` stays deferred.
+        "unicode-bidi",
         "text-indent", "text-overflow", "text-wrap",
         // Per Phase 3 Task 10 cycle 2 + post-cycle-2 review (User #4):
         // word-break / overflow-wrap / hyphens REMOVED from this

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/KeywordResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/KeywordResolverTests.cs
@@ -52,6 +52,22 @@ public sealed class KeywordResolverTests
     [Fact] public void BoxSizing_border_box_resolves()    => AssertResolves("border-box", PropertyId.BoxSizing);
     [Fact] public void TextAlign_center_resolves()        => AssertResolves("center", PropertyId.TextAlign);
     [Fact] public void TextAlign_justify_resolves()       => AssertResolves("justify", PropertyId.TextAlign);
+    // direction — CSS Writing Modes 4 §2.1 (direction pipeline).
+    [Fact] public void Direction_ltr_resolves()           => AssertResolves("ltr", PropertyId.Direction);
+    [Fact] public void Direction_rtl_resolves()           => AssertResolves("rtl", PropertyId.Direction);
+    [Fact] public void Direction_RTL_resolves_case_insensitive() => AssertResolves("RTL", PropertyId.Direction);
+    [Fact] public void Direction_bogus_emits_diagnostic() => AssertInvalid("ttb", PropertyId.Direction);
+
+    [Fact]
+    public void Direction_keyword_ids_are_ltr0_rtl1()
+    {
+        // The id contract the layout-side ReadDirection() / ReadParagraphDirection() readers
+        // switch on (rtl → bidi base level 1). Reordering would silently flip RTL detection.
+        Assert.True(KeywordResolver.TryGetId(PropertyId.Direction, "ltr", out var ltr));
+        Assert.Equal(0, ltr);
+        Assert.True(KeywordResolver.TryGetId(PropertyId.Direction, "rtl", out var rtl));
+        Assert.Equal(1, rtl);
+    }
     [Fact] public void FlexDirection_row_reverse_resolves() => AssertResolves("row-reverse", PropertyId.FlexDirection);
     [Fact] public void BorderTopStyle_solid_resolves()    => AssertResolves("solid", PropertyId.BorderTopStyle);
     [Fact] public void BorderTopStyle_dotted_resolves()   => AssertResolves("dotted", PropertyId.BorderTopStyle);

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -44,6 +44,7 @@ public sealed class DeferralsParityTests
         "hyphens-auto-language-routing",
         "uax-24-script-detection",
         "rtl-fragment-reversal",
+        "text-align-match-parent",
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",
         "inline-atomic-boxes",

--- a/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
@@ -1285,6 +1285,75 @@ public sealed class BlockInlineIntegrationTests
         Assert.Equal(544, right, precision: 1);
     }
 
+    [Theory]
+    [InlineData(0, 1.0)]   // start → RIGHT edge in RTL (the swap)
+    [InlineData(1, 0.0)]   // end   → LEFT edge in RTL (the swap)
+    [InlineData(2, 0.0)]   // left  stays physical-left
+    [InlineData(3, 1.0)]   // right stays physical-right
+    [InlineData(4, 0.5)]   // center symmetric
+    public void Rtl_text_align_swaps_inline_line_align_factor(int textAlignKeyword, double expectedFactor)
+    {
+        // Direction pipeline + task 5 — `direction: rtl` makes `text-align: start/end` direction-
+        // relative end-to-end: the cascade resolves direction, BlockLayouter reads it (the emitted
+        // fragment's LineAlignFactor = ReadInlineAlignFactor), and start/end swap (start → right edge).
+        // Physical left/right and center are unchanged, mirroring the LTR theory above.
+        var sink = new RecordingFragmentSink();
+        using var resolver = new SyntheticShaperResolver();
+
+        var blockStyle = MakeStyle();
+        blockStyle.Set(PropertyId.Direction, ComputedSlot.FromKeyword(1));   // rtl
+        blockStyle.Set(PropertyId.TextAlign, ComputedSlot.FromKeyword(textAlignKeyword));
+        var root = Box.CreateRoot(MakeStyle());
+        var block = Box.ForElement(BoxKind.BlockContainer, blockStyle, MakeElement());
+        block.AppendChild(Box.TextRun("A", MakeStyle()));
+        root.AppendChild(block);
+
+        using var layouter = new BlockLayouter(root, sink, null, null, resolver);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var br = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, br, LayoutAttemptStrategy.Strict);
+
+        var fragment = Assert.Single(sink.Fragments);
+        Assert.Equal(expectedFactor, fragment.LineAlignFactor, precision: 3);
+    }
+
+    [Fact]
+    public void Rtl_inline_atomic_shifts_to_right_edge_under_default_start()
+    {
+        // RTL inline-atomic alignment — a `direction: rtl` block with the initial `text-align: start`
+        // right-aligns, so a 50px inline-block alone on a 600px line shifts to the RIGHT edge
+        // (600 − 50 = 550); the same default in LTR leaves it at 0. The atomic moves WITH its line
+        // because the placement reads the SAME ReadInlineAlignFactor the glyph painter does.
+        static double DecorationX(int direction)
+        {
+            var sink = new RecordingFragmentSink();
+            using var resolver = new SyntheticShaperResolver();
+            var blockStyle = MakeStyle();
+            blockStyle.Set(PropertyId.Direction, ComputedSlot.FromKeyword(direction));
+            var ibStyle = MakeStyle();
+            ibStyle.Set(PropertyId.Width, ComputedSlot.FromLengthPx(50));
+            ibStyle.Set(PropertyId.Height, ComputedSlot.FromLengthPx(30));
+            var inlineBlock = Box.ForElement(BoxKind.InlineBlockContainer, ibStyle, MakeElement());
+            inlineBlock.AppendChild(Box.TextRun("A", MakeStyle()));
+            var root = Box.CreateRoot(MakeStyle());
+            var block = Box.ForElement(BoxKind.BlockContainer, blockStyle, MakeElement());
+            block.AppendChild(inlineBlock);
+            root.AppendChild(block);
+            using var layouter = new BlockLayouter(root, sink, null, null, resolver);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var layoutCtx = new LayoutContext(ctx);
+            using var br = new BreakResolver();
+            layouter.AttemptLayout(ctx, ref layoutCtx, br, LayoutAttemptStrategy.Strict);
+            foreach (var f in sink.Fragments)
+                if (ReferenceEquals(f.Box, inlineBlock) && f.InlineLayout is null) return f.InlineOffset;
+            throw new Xunit.Sdk.XunitException("no inline-block decoration fragment");
+        }
+
+        Assert.Equal(550, DecorationX(1), precision: 1);   // rtl: 600 − 50, the right edge
+        Assert.Equal(0, DecorationX(0), precision: 1);     // ltr: start = left
+    }
+
     [Fact]
     public void Block_with_margin_border_padding_honors_box_model()
     {

--- a/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
@@ -1355,6 +1355,40 @@ public sealed class BlockInlineIntegrationTests
     }
 
     [Fact]
+    public void Rtl_block_threads_rtl_base_direction_into_bidi_levels()
+    {
+        // PR 2 review P3 — prove the production wiring BlockLayouter → InlineLayouter.LayoutPerRun(
+        // paragraphDirection: ReadParagraphDirection()) actually reaches the BIDI algorithm, not just the
+        // align factor. The SAME Latin "A" itemizes to bidi level 0 under an LTR base paragraph but level 2
+        // under an RTL base (UAX #9 I2 lifts an L run one level above the odd RTL base level 1). A differing
+        // level on identical text is direct evidence the CSS `direction` set the paragraph base direction
+        // threaded into LayoutPerRun — independent of ReadInlineAlignFactor (which drives the x-position).
+        static int BaseDirectionBidiLevel(int direction)
+        {
+            var sink = new RecordingFragmentSink();
+            using var resolver = new SyntheticShaperResolver();
+            var blockStyle = MakeStyle();
+            blockStyle.Set(PropertyId.Direction, ComputedSlot.FromKeyword(direction));
+            var root = Box.CreateRoot(MakeStyle());
+            var block = Box.ForElement(BoxKind.BlockContainer, blockStyle, MakeElement());
+            block.AppendChild(Box.TextRun("A", MakeStyle()));
+            root.AppendChild(block);
+            using var layouter = new BlockLayouter(root, sink, null, null, resolver);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var layoutCtx = new LayoutContext(ctx);
+            using var br = new BreakResolver();
+            layouter.AttemptLayout(ctx, ref layoutCtx, br, LayoutAttemptStrategy.Strict);
+            foreach (var f in sink.Fragments)
+                if (f.InlineLayout is { } il && il.ShapedRuns.Count > 0)
+                    return il.ShapedRuns[0].Source.BidiLevel;
+            throw new Xunit.Sdk.XunitException("no inline-layout fragment with shaped runs");
+        }
+
+        Assert.Equal(0, BaseDirectionBidiLevel(0));   // ltr base → "A" stays at level 0
+        Assert.Equal(2, BaseDirectionBidiLevel(1));   // rtl base → "A" (L) lifted to level 2 (UAX #9 I2)
+    }
+
+    [Fact]
     public void Block_with_margin_border_padding_honors_box_model()
     {
         // Per Finding #5 — margin/border/padding/width applied to the

--- a/tests/NetPdf.UnitTests/Phase3/DirectionResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/DirectionResolverTests.cs
@@ -1,0 +1,109 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.Properties;
+using NetPdf.Layout.Layouters;
+using NetPdf.Text.Bidi;
+using Xunit;
+
+namespace NetPdf.UnitTests.Phase3;
+
+/// <summary>
+/// Direction pipeline (PR 2 task 4) + RTL text-align swap (task 5). The shared
+/// <c>direction</c> resolution maps a box's computed <c>direction</c> onto the bidi
+/// paragraph base direction and the inline-start ↔ left/right mapping that
+/// <c>text-align</c> consumes. Covers the readers (<c>ReadDirection</c> /
+/// <c>IsRtl</c> / <c>ReadParagraphDirection</c>) and the direction-relative
+/// <c>start</c>/<c>end</c> swap in <c>ReadInlineAlignFactor</c>.
+/// </summary>
+public sealed class DirectionResolverTests
+{
+    private static ComputedStyle Style() => ComputedStyle.RentForExclusiveTesting();
+
+    private static ComputedStyle StyleWith(int? direction = null, int? textAlign = null)
+    {
+        var s = Style();
+        if (direction is { } d) s.Set(PropertyId.Direction, ComputedSlot.FromKeyword(d));
+        if (textAlign is { } t) s.Set(PropertyId.TextAlign, ComputedSlot.FromKeyword(t));
+        return s;
+    }
+
+    // ---- readers (task 4) ----
+
+    [Fact]
+    public void Default_direction_is_ltr()
+    {
+        // No explicit `direction` → the slot is Unset → the reader defaults to ltr (the
+        // CSS initial value), so an unstyled block is byte-identical to the pre-pipeline path.
+        var s = Style();
+        Assert.Equal(InlineDirection.Ltr, s.ReadDirection());
+        Assert.False(s.IsRtl());
+        Assert.Equal(ParagraphDirection.LeftToRight, s.ReadParagraphDirection());
+    }
+
+    [Fact]
+    public void Direction_ltr_keyword_reads_ltr()
+    {
+        var s = StyleWith(direction: 0);
+        Assert.Equal(InlineDirection.Ltr, s.ReadDirection());
+        Assert.False(s.IsRtl());
+        Assert.Equal(ParagraphDirection.LeftToRight, s.ReadParagraphDirection());
+    }
+
+    [Fact]
+    public void Direction_rtl_keyword_reads_rtl_and_maps_to_bidi_rtl()
+    {
+        // `direction: rtl` (keyword id 1) → InlineDirection.Rtl → bidi paragraph base
+        // direction RightToLeft (UAX #9 level 1), the value threaded to LayoutPerRun.
+        var s = StyleWith(direction: 1);
+        Assert.Equal(InlineDirection.Rtl, s.ReadDirection());
+        Assert.True(s.IsRtl());
+        Assert.Equal(ParagraphDirection.RightToLeft, s.ReadParagraphDirection());
+    }
+
+    // ---- text-align start/end swap (task 5) ----
+    // Keyword ids: start=0, end=1, left=2, right=3, center=4, justify=5, match-parent=6, justify-all=7.
+
+    [Theory]
+    [InlineData(0, 0.0)]   // start → left edge (the initial)
+    [InlineData(1, 1.0)]   // end → right edge
+    [InlineData(2, 0.0)]   // left (physical)
+    [InlineData(3, 1.0)]   // right (physical)
+    [InlineData(4, 0.5)]   // center
+    [InlineData(5, 0.0)]   // justify — distributed, no whole-line shift
+    [InlineData(6, 0.0)]   // match-parent → start → left
+    [InlineData(7, 0.0)]   // justify-all — distributed
+    public void Ltr_align_factor_is_physical(int textAlign, double expected)
+    {
+        var s = StyleWith(direction: 0, textAlign: textAlign);
+        Assert.Equal(expected, s.ReadInlineAlignFactor(), precision: 3);
+    }
+
+    [Theory]
+    [InlineData(0, 1.0)]   // start → RIGHT edge in RTL (the swap)
+    [InlineData(1, 0.0)]   // end → LEFT edge in RTL (the swap)
+    [InlineData(2, 0.0)]   // left STAYS physical-left under RTL
+    [InlineData(3, 1.0)]   // right STAYS physical-right under RTL
+    [InlineData(4, 0.5)]   // center is symmetric
+    [InlineData(5, 0.0)]   // justify distributes regardless of direction
+    [InlineData(6, 1.0)]   // match-parent → start → RIGHT in RTL
+    [InlineData(7, 0.0)]   // justify-all distributes
+    public void Rtl_align_factor_swaps_start_end(int textAlign, double expected)
+    {
+        var s = StyleWith(direction: 1, textAlign: textAlign);
+        Assert.Equal(expected, s.ReadInlineAlignFactor(), precision: 3);
+    }
+
+    [Fact]
+    public void Rtl_default_text_align_start_right_aligns()
+    {
+        // The headline behavior of tasks 4+5: a `direction: rtl` block with NO author
+        // text-align (the initial `start`) RIGHT-aligns its content (factor 1.0), where
+        // the same default in LTR left-aligns (factor 0.0).
+        var rtl = StyleWith(direction: 1);   // text-align unset → start
+        var ltr = StyleWith(direction: 0);
+        Assert.Equal(1.0, rtl.ReadInlineAlignFactor(), precision: 3);
+        Assert.Equal(0.0, ltr.ReadInlineAlignFactor(), precision: 3);
+    }
+}

--- a/tests/NetPdf.UnitTests/Phase3/DirectionResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/DirectionResolverTests.cs
@@ -72,8 +72,8 @@ public sealed class DirectionResolverTests
     [InlineData(3, 1.0)]   // right (physical)
     [InlineData(4, 0.5)]   // center
     [InlineData(5, 0.0)]   // justify — distributed, no whole-line shift
-    [InlineData(6, 0.0)]   // match-parent → start → left
     [InlineData(7, 0.0)]   // justify-all — distributed
+    // match-parent(6) is a deferred approximation — see Match_parent_is_a_deferred_left_approximation.
     public void Ltr_align_factor_is_physical(int textAlign, double expected)
     {
         var s = StyleWith(direction: 0, textAlign: textAlign);
@@ -87,8 +87,8 @@ public sealed class DirectionResolverTests
     [InlineData(3, 1.0)]   // right STAYS physical-right under RTL
     [InlineData(4, 0.5)]   // center is symmetric
     [InlineData(5, 0.0)]   // justify distributes regardless of direction
-    [InlineData(6, 1.0)]   // match-parent → start → RIGHT in RTL
     [InlineData(7, 0.0)]   // justify-all distributes
+    // match-parent(6) is a deferred approximation — see Match_parent_is_a_deferred_left_approximation.
     public void Rtl_align_factor_swaps_start_end(int textAlign, double expected)
     {
         var s = StyleWith(direction: 1, textAlign: textAlign);
@@ -105,5 +105,19 @@ public sealed class DirectionResolverTests
         var ltr = StyleWith(direction: 0);
         Assert.Equal(1.0, rtl.ReadInlineAlignFactor(), precision: 3);
         Assert.Equal(0.0, ltr.ReadInlineAlignFactor(), precision: 3);
+    }
+
+    [Fact]
+    public void Match_parent_is_a_deferred_left_approximation()
+    {
+        // `text-align: match-parent` (CSS Text 3 §7.1, keyword id 6) should take the PARENT's
+        // `text-align`, resolve a start/end against the PARENT's `direction`, and inherit that matched
+        // alignment — which needs parent context at cascade time. It is DEFERRED
+        // (deferrals.md#text-align-match-parent) and approximated as a fixed physical LEFT (factor 0),
+        // direction-INSENSITIVE — deliberately NOT direction-aware, so it does not masquerade as
+        // spec-correct. (Pinning 0 in BOTH directions documents the approximation; the review carved it
+        // out of the direction-aware `start` path that would otherwise right-align it in RTL.)
+        Assert.Equal(0.0, StyleWith(direction: 0, textAlign: 6).ReadInlineAlignFactor(), precision: 3);
+        Assert.Equal(0.0, StyleWith(direction: 1, textAlign: 6).ReadInlineAlignFactor(), precision: 3);
     }
 }

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
@@ -2720,22 +2720,25 @@ public sealed class FlexLayouterTests
 
     // -- F#1 (P2) — direction/writing-mode pipeline known gap -----------
 
-    [Fact(Skip = "L6+ — direction/writing-mode pipeline not implemented; tracked in flex-layouter-features deferral")]
-    public void L5_known_gap_rtl_row_should_flip_main_axis_but_no_direction_pipeline_yet()
+    [Fact(Skip = "PR 2 task 6 — FlexLayouter has not yet ADOPTED the direction pipeline; the shared reader " +
+        "(DirectionStyleExtensions.ReadDirection, added in task 4) exists, but the RTL row → main-axis flip is the " +
+        "remaining work. Tracked in flex-layouter-features deferral.")]
+    public void L5_known_gap_rtl_row_should_flip_main_axis_pending_flex_direction_adoption()
     {
         // Per CSS Flexbox §3.1 axis-mapping: `row` in RTL writing mode
         // means right-to-left (= same physical layout as `row-reverse`
         // in LTR). With L5's LTR-only main-axis mapping, an RTL
         // container with `flex-direction: row` would still emit items
-        // left-to-right (= InlineOffsets 0/50/100). When L6+ adds the
-        // direction pipeline, this test will pin the spec-correct
-        // behavior: items emitted in physical right-to-left order so
-        // DOM 0 lands at the right edge (= InlineOffset 350 for 3×50
-        // items in 400px), DOM 1 at 300, DOM 2 at 250 — matching the
+        // left-to-right (= InlineOffsets 0/50/100). When task 6 wires
+        // FlexLayouter to the direction pipeline, this test will pin the
+        // spec-correct behavior: items emitted in physical right-to-left
+        // order so DOM 0 lands at the right edge (= InlineOffset 350 for
+        // 3×50 items in 400px), DOM 1 at 300, DOM 2 at 250 — matching the
         // current `row-reverse` LTR output for the same fixture.
         //
-        // When the L6+ pipeline lands:
-        //   1. Plumb `direction` (cascaded) into FlexLayouter.
+        // When task 6 lands (the pipeline ALREADY exists post-task-4):
+        //   1. Read the cascaded `direction` via DirectionStyleExtensions.
+        //      ReadDirection / IsRtl inside FlexLayouter.
         //   2. The axis mapping switches from "row → inline left-to-
         //      right" to "row → inline right-to-left" under RTL.
         //   3. Drop this test's [Skip] + assert spec-correct offsets.

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -783,6 +783,29 @@ public sealed class HtmlPdfConvertTests
     }
 
     [Fact]
+    public void Direction_rtl_inherits_and_right_aligns_default_start_text()
+    {
+        // Direction pipeline (PR 2 tasks 4+5) end-to-end through the REAL cascade: `direction` is an
+        // INHERITED property (CSS Writing Modes 4 §2.1), so declaring `direction:rtl` on <body> reaches
+        // the child <div> that emits the line, and the initial `text-align:start` then RIGHT-aligns it.
+        // Off the LTR-start control (left edge), RTL-start shifts right — landing at the SAME right edge
+        // as physical `text-align:right` (start resolves to the end/right edge in RTL; both factor 1.0).
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        double LineX(string bodyStyle) => FirstTd(Latin1(HtmlPdf.Convert(
+            "<!DOCTYPE html><html><body style=\"" + bodyStyle + "\"><div>A</div></body></html>", opts))).X;
+
+        var ltrStart = LineX("");                  // LTR + start (control) → left edge
+        var ltrRight = LineX("text-align:right");  // LTR + right → right edge (the geometry reference)
+        var rtlStart = LineX("direction:rtl");     // RTL + INHERITED start → right edge
+
+        // Inheritance reached the div AND start swapped: the RTL line shifts right of the LTR-start control.
+        Assert.True(rtlStart > ltrStart + 1.0, $"rtl start should right-align: {ltrStart} → {rtlStart}");
+        // start-in-RTL lands at the same right edge as physical right (both align factor 1.0).
+        Assert.True(System.Math.Abs(rtlStart - ltrRight) < 1.0,
+            $"rtl start should match physical right: rtlStart={rtlStart} ltrRight={ltrRight}");
+    }
+
+    [Fact]
     public void Text_align_justify_spreads_words_and_pushes_the_last_word_right()
     {
         // text-align: justify cycle (CSS Text 3 §7.3) — a wrapping paragraph distributes each NON-LAST


### PR DESCRIPTION
## Summary

Phase 3 roadmap **PR 2, tasks 4–5** — the shared `direction` resolution pipeline and its first consumer (RTL `text-align`). PR 1 (conformance measurement) is gated on the still-pending approach decision, so this is the handoff's pre-authorized unblocked alternative. Task 6 (RTL flex main-axis flip) remains for the next PR.

### Task 4 — shared `direction` resolution pipeline
- **Register `direction`** (CSS Writing Modes 4 §2.1): inherited, initial `ltr`, keywords `ltr`=0 / `rtl`=1 — `properties.json` + the `KeywordResolver` table.
- **`DirectionStyleExtensions`** (new `InlineDirection.cs`): `ReadDirection` / `IsRtl` / `ReadParagraphDirection` — the one seam mapping a box's computed `direction` onto the bidi paragraph base direction. Writing-mode stays horizontal-tb; the seam is where vertical modes + float/`caption-side` start/end will compose later (the infra several deferrals cite).
- **Wire the inline-layout call** (`BlockLayouter` → `InlineLayouter.LayoutPerRun`) to read the block's `direction` instead of a hardcoded LTR, so an RTL block lays its inline formatting context out at bidi base level 1.

### Task 5 — RTL `text-align` start/end swap + RTL inline-atomic alignment
- **`ReadInlineAlignFactor` is now direction-aware**: `start`/`end` resolve against `direction` (`start` → right edge in RTL, `end` → left); physical `left`/`right`/`center` and `justify` are unchanged. The inline-atomic placement reads the *same* factor, so glyphs **and** an inline atomic shift together — to the right edge under an RTL `start`.
- The initial `text-align: start` therefore right-aligns an RTL block.

**LTR output is byte-identical** (`direction` defaults to `ltr`; the LTR factor mapping is unchanged) — no snapshot / golden / real-document drift.

## Tests
- `KeywordResolver` — `direction` ltr/rtl/case-insensitive/invalid + the `ltr`=0/`rtl`=1 id contract.
- `DirectionResolverTests` (new) — readers + the full LTR/RTL align-factor matrix.
- `BlockInlineIntegrationTests` — RTL `LineAlignFactor` swap (through the real layouter) + RTL inline-atomic shifts to the right edge.
- `HtmlPdfConvertTests` — end-to-end facade test: `direction:rtl` on `<body>` inherits to the child `<div>` and right-aligns (matches physical `text-align:right`).
- Removed `direction` from the RealDocuments unsupported-allowlist (now registered — the parity gate caught this).

## Gates (all green)
Release build 0-warning · 7078 unit / 5 skip · 30 LayoutSnapshots · 97 RealDocuments · PaginationGolden · RenderingCorpus · W3cConformance (smoke) · AOT/JIT parity (byte-identical) · determinism.

## Deferrals rolled
`rtl-fragment-reversal` (base direction now CSS-driven; UAX #9 L2 slice reversal, `dir` HTML attribute → `direction`, and margin-box base direction remain), `inline-atomic-boxes` (RTL text-align honored; bidi visual order still document-order), `flex-layouter-features` (pipeline now exists — task 6 is FlexLayouter adopting it). PROGRESS roadmap advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)