### PR TITLE
Phase 3 (tasks 6-8): RTL flex flip · line-edge vertical-align line growth · line-height cascade wiring

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,7 @@
 
 > **Current state (2026-06-18):** Phase 3's layout + pagination **engine is feature-complete and multi-page rendering is live**. What's left to *finish* Phase 3 is (a) wiring W3C conformance **measurement**, (b) a curated **feature/polish backlog**, (c) **confirming** the perf/memory gates, and (d) the **`0.7.0-beta` release**. The recommended next step is **PR 1 — Conformance measurement** (see the roadmap).
 >
-> Active branch: `phase3-direction-pipeline-rtl-textalign` — PR 2 tasks 4–5 (the `direction` resolution pipeline + RTL `text-align`/atomic swap). PR 1 (conformance) awaits Roland's approach decision; task 6 (RTL flex flip) is the remaining PR-2 task. `git log --oneline -1` shows the exact commit.
+> Active branch: `phase3-rtl-flex-vertalign-lineheight` — tasks 6–8 (RTL flex main-axis flip · line-edge `vertical-align` line growth · `line-height` length/number/% cascade wiring). PR 2 (direction/bidi, tasks 4–6) is now COMPLETE. PR 1 (conformance) still awaits Roland's approach decision; PR-3 task 9 (inline-block per-run baseline + justify-all on `<br>`) is the next remaining item. `git log --oneline -1` shows the exact commit.
 >
 > This file was consolidated from a 1.1 MB chronological log on 2026-06-18; the full per-subtask history is archived in [docs/progress-archive.md](docs/progress-archive.md). **Keep this file compact** — roll the roadmap as each PR lands; don't grow a blow-by-blow log here.
 
@@ -17,7 +17,7 @@
 | 4 | Visual parity (gradients, shadows, filters, SVG) | ⏸️ Not started |
 | 5 | Packaging + release | 🔵 Interleaved — layout→PDF wiring done |
 
-**Gates (all green, 2026-06-18):** 7078 unit / 5 skip · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
+**Gates (all green, 2026-06-19):** 7103 unit / 4 skip · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
 
 ## Phase 3 — what's shipped (consolidated)
 
@@ -60,12 +60,12 @@ Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order.
 ### PR 2 — Direction / bidi pipeline  [feature; several deferrals block on this]
 4. ✅ A shared `direction` resolution pipeline — `DirectionStyleExtensions` (`ReadDirection`/`IsRtl`/`ReadParagraphDirection`); `direction` registered (inherited, `ltr`/`rtl`); bidi base direction now CSS-driven at the inline-layout seam. Writing-mode stays horizontal-tb (the seam composes vertical modes later).
 5. ✅ RTL `text-align` start/end swap (`ReadInlineAlignFactor` direction-aware — `start`→right in RTL) + RTL inline-atomic alignment (atomic shifts to the right edge). LTR output byte-identical.
-6. RTL flex main-axis flip (`flex-direction: row` under `direction: rtl`) — **remaining**; FlexLayouter adopts the now-existing pipeline (skip'd test `…pending_flex_direction_adoption`). *Residual direction gaps* (see `rtl-fragment-reversal`): UAX #9 L2 slice reversal, `dir` HTML attribute → `direction`, margin-box base direction.
+6. ✅ RTL flex main-axis flip (`flex-direction: row` under `direction: rtl`) — FlexLayouter XORs its reverse flag via `IsRtl` (row+rtl ≡ row-reverse+ltr); LTR byte-identical. *Residual direction gaps* (see `rtl-fragment-reversal`): UAX #9 L2 slice reversal, `dir` HTML attribute → `direction`, margin-box base direction, flex COLUMN cross-axis RTL.
 
 ### PR 3 — Inline-text polish  [feature]
-7. Line-edge `vertical-align` line growth — contain a tall `top/bottom/middle/text-*` run (the PR #195 deferral).
-8. `line-height: <length>` cascade fix — a CSS length line-height currently doesn't reach the computed style (found 2026-06-18; investigate then fix; a task chip was spawned).
-9. inline-block per-run baseline metrics + justify-all on internal `<br>` lines.
+7. ✅ Line-edge `vertical-align` line growth — a tall `top/bottom/middle/text-*` run now GROWS its line (`InlineVerticalAlign.TextLineEdgeGrowth`); the painter follows via the shared per-line metrics.
+8. ✅ `line-height` cascade wiring — `LineHeightResolver` + `ReadLineHeightPx` resolve the full `normal | <number> | <length> | <percentage>` grammar (was UNWIRED → silently font-size × 1.2). Residual: `%` inherit-as-length (`line-height-percentage-inheritance` deferral).
+9. inline-block per-run baseline metrics + justify-all on internal `<br>` lines — **remaining** (the next PR-3 task).
 
 ### PR 4 — Paged-media completion  [feature]
 10. Running-element real nested **block** layout (sub-boxes, not flattened text).

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -251,6 +251,33 @@ grepping the ID).
 
 ---
 
+## margin-box-line-height
+
+- **ID** — `margin-box-line-height`
+- **Status** — `approximated`.
+- **Behavior** — Literal `@page` margin-box content (e.g. `@top-center { content: "..."; }`)
+  uses `font-size × 1.2` for its line pitch regardless of a declared `line-height` —
+  `PageMarginBoxPainter` reads font-size × `NormalLineHeightFactor`, and `line-height` is
+  NOT in `MarginBoxStyle`'s inherited longhand set, so the slot isn't even present on a
+  margin-box style. The BODY layout path was wired in the line-height cycle
+  (`ReadLineHeightPx`), but the margin-box path was not. (The `element()` /
+  `position: running()` running-element segment path parses line-height through a separate
+  manual route, distinct from this.)
+- **Missing** — `PropertyId.LineHeight` in `MarginBoxStyle.SupportedStyleIds` (so it
+  inherits page-context → margin box) + `PageMarginBoxPainter` reading it via
+  `ReadLineHeightPx` (with the `?? font-size × 1.2` fallback).
+- **Trigger** — a MULTI-LINE `@page` margin box (wrapping content) with a declared
+  `line-height` (e.g. `@bottom-center { line-height: 2 }`) — the line pitch stays
+  font-size × 1.2 instead of the declared value.
+- **Owner files** — `src/NetPdf/Rendering/MarginBoxStyle.cs` (`SupportedStyleIds`) +
+  `src/NetPdf/Rendering/PageMarginBoxPainter.cs` (the `lineHeightPx` computation).
+- **Added** — post-PR-#197 review P3 — the line-height cycle wired the body path; the
+  margin-box path is the residual.
+- **Removal condition** — a margin box's declared `line-height` drives its line pitch via
+  `ReadLineHeightPx`.
+
+---
+
 ## phase-4-painter-wiring
 
 - **ID** — `phase-4-painter-wiring`

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1107,22 +1107,17 @@ grepping the ID).
     The cascade slot is lossless so pre-authored
     `align-content: baseline` declarations activate the new behavior
     without a re-author.
-  - Writing-mode and `direction` integration for `flex-direction`
-    axis mapping (CSS Flexbox §3.1): all 4 directions are honored
-    for LTR horizontal-tb but the axis mapping differs in RTL +
-    vertical writing modes. For example, `row` in RTL means right-
-    to-left along the inline axis (physically equivalent to LTR
-    `row-reverse`); `row` in vertical-rl swaps the main + cross
-    axes onto the block + inline directions of the rotated writing
-    mode. The shared direction pipeline now EXISTS
-    (`DirectionStyleExtensions.ReadDirection` / `IsRtl`, PR 2 task 4);
-    the remaining work (PR 2 task 6) is FlexLayouter ADOPTING it — read
-    the cascaded `direction` and flip the `row` main-axis mapping to
-    right-to-left under RTL (`writing-mode` vertical modes stay out of
-    scope). Pinned by the Skip'd
-    `L5_known_gap_rtl_row_should_flip_main_axis_pending_flex_direction_adoption`
-    test — when task 6 wires the adoption, that test should flip to
-    spec-correct expectations + this bullet should be removed.
+  - Writing-mode + column-cross-axis `direction` integration for
+    `flex-direction` axis mapping (CSS Flexbox §3.1). **Shipped** (task 6):
+    `flex-direction: row` / `row-reverse` under `direction: rtl` flip the
+    physical MAIN axis right-to-left (row+rtl ≡ row-reverse+ltr) —
+    FlexLayouter XORs its reverse flag via `DirectionStyleExtensions.IsRtl`,
+    pinned by `Rtl_row_flips_main_axis_like_row_reverse_ltr`. **Still
+    deferred**: the COLUMN cross-axis under RTL (a column's cross axis is the
+    inline axis, so RTL flips cross-start — `align-items`/`align-self`
+    anchors), and all VERTICAL writing modes (`writing-mode` is not yet a
+    registered property; `row` in vertical-rl swaps the main + cross axes
+    onto the rotated block + inline directions).
   - Outer-main-size + auto-margins in `justify-content` free-space
     calculation (CSS Flexbox L1 §9.5): L2's pre-pass sums only
     declared `width`, ignoring item margins / padding / borders /

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -301,10 +301,13 @@ grepping the ID).
     `text-bottom` (bounded first cut — position the run at the line-box top/bottom, the line middle, or the
     parent text content-area, via `InlineVerticalAlign.TextLineEdgeBaselineTopPx`). All GATED to
     inline-level runs (a block / table cell's own vertical-align doesn't shift its text — the
-    reference-equality gate; non-inherited so `<sub>`/`<sup>`/`<span>` work). Deferred for text: a line-edge
-    run TALLER than the baseline-sized line OVERFLOWS it (no line growth for non-baseline-aligned content
-    yet); the parent metrics use the 0.8/−0.2-em + 0.5-em-x-height approximation; a deferred (non-LengthPx)
-    declared line-height isn't read as the `%` base (falls back to font-size × 1.2).
+    reference-equality gate; non-inherited so `<sub>`/`<sup>`/`<span>` work). A line-edge run TALLER than the
+    baseline-sized line now GROWS the line so it is CONTAINED (PR 3 task 7 —
+    `InlineVerticalAlign.TextLineEdgeGrowth`: `text-top`/`text-bottom`/`middle` grow the max-ascent
+    ascent/descent extents, `top`/`bottom` contribute a content-box floor; the painter positions the run
+    within the grown line via the shared helper). Deferred for text: the parent metrics use the
+    0.8/−0.2-em + 0.5-em-x-height approximation; a deferred (non-LengthPx) declared line-height isn't read
+    as the `%` base (falls back to font-size × 1.2).
   - An inline-block aligns by its LAST in-flow line box's baseline (CSS 2.2 §10.8.1 — it sits ON the
     surrounding text baseline; the line box is sized by the max-ascent model). The last line's descent is
     captured from the ACTUAL deepest line-bearing fragment's metrics (`BufferingMeasureSink.LastLineBox
@@ -328,9 +331,8 @@ grepping the ID).
   - `inline-flex` / `inline-grid` / `inline-table` atomics (which need a laid-out sub-box of a non-block
     formatting context) remain deferred.
 - **Trigger** — a mixed-direction line needing bidi VISUAL reordering of an inline `<img>` / inline-block
-  (the RTL text-align alignment is already honoured — PR 2 task 5), a line-edge text `vertical-align`
-  (`top`/`bottom`/`middle`/`text-*`) on a run TALLER than its line (overflow), or an
-  `inline-flex`/`-grid`/`-table` span.
+  (the RTL text-align alignment is already honoured — PR 2 task 5), or an `inline-flex`/`-grid`/`-table`
+  span. (Line-edge text `vertical-align` line growth shipped in PR 3 task 7.)
 - **Owner files** —
   - `src/NetPdf.Layout/Inline/InlineAtomic.cs` — the atomic primitive (box + used width/height).
   - `src/NetPdf.Layout/Inline/{TextRun,ShapedRun}.cs` — the optional `Atomic` payload.
@@ -346,10 +348,10 @@ grepping the ID).
   - `src/NetPdf/Rendering/TextPainter.cs` — skip the atomic's synthetic glyph.
 - **Added** — Phase 3 Task 11 sub-cycle 1 review Finding #4; inline `<img>` first cut shipped in the
   inline-atomic-boxes cycle; inline-block first cut shipped in the inline-block cycle.
-- **Removal condition** — line-edge text `vertical-align` GROWS its line (no overflow for a tall run), RTL
-  bidi VISUAL ORDER honoured for inline atomics (the text-align alignment is already honoured — PR 2 task 5),
-  the inline-block's last-line baseline using true per-RUN content metrics + min-content shrink-to-fit, and
-  inline-flex / -grid / -table atomics laid out (no longer `LAYOUT-INLINE-ATOMIC-NOT-SUPPORTED-001`).
+- **Removal condition** — RTL bidi VISUAL ORDER honoured for inline atomics (the text-align alignment is
+  already honoured — PR 2 task 5; line-edge text line growth shipped — PR 3 task 7), the inline-block's
+  last-line baseline using true per-RUN content metrics + min-content shrink-to-fit, and inline-flex /
+  -grid / -table atomics laid out (no longer `LAYOUT-INLINE-ATOMIC-NOT-SUPPORTED-001`).
 
 ---
 

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -221,6 +221,36 @@ grepping the ID).
 
 ---
 
+## line-height-percentage-inheritance
+
+- **ID** — `line-height-percentage-inheritance`
+- **Status** — `approximated`.
+- **Behavior** — A `<percentage>` `line-height` (e.g. `line-height: 150%`) resolves to a
+  `Percentage` slot, and `ReadLineHeightPx` computes the used px at READ time as % × the
+  READING element's font-size. Per CSS Inline 3 §4.2 the COMPUTED value should be a
+  LENGTH (% × the DECLARING element's font-size), and that length inherits — so a child
+  with a DIFFERENT font-size that inherits a percentage line-height should keep the
+  parent's computed length, not recompute against its own font-size. Correct for the
+  declaring element and for same-font-size inheritance (the common cases); divergent only
+  when a percentage line-height is inherited across a font-size change. A `<number>`
+  line-height is unaffected (it correctly inherits AS the number and re-multiplies), and a
+  `<length>` is absolute.
+- **Missing** — Resolving `%` → length at computed-value time (the declaring element's
+  font-size), so the inherited value is a length. Needs font-size context at resolve time
+  (the box-builder's `DeferredLengthResolver` has it but currently skips `%` terms).
+- **Trigger** — a percentage `line-height` inherited to a descendant whose font-size
+  differs from the declaring element's.
+- **Owner files** — `src/NetPdf.Css/ComputedValues/PropertyResolvers/LineHeightResolver.cs`
+  (produces the `Percentage` slot) +
+  `src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs` (`ReadLineHeightPx`
+  read-time resolution). Spec-correct resolution belongs at computed-value time.
+- **Added** — the line-height cycle wired `line-height` (was UNWIRED — every value fell to
+  font-size × 1.2); the percentage inherit-as-length subtlety is the residual.
+- **Removal condition** — a percentage `line-height` resolves to a length at the declaring
+  element's font-size and inherits that length.
+
+---
+
 ## phase-4-painter-wiring
 
 - **ID** — `phase-4-painter-wiring`
@@ -306,8 +336,9 @@ grepping the ID).
     `InlineVerticalAlign.TextLineEdgeGrowth`: `text-top`/`text-bottom`/`middle` grow the max-ascent
     ascent/descent extents, `top`/`bottom` contribute a content-box floor; the painter positions the run
     within the grown line via the shared helper). Deferred for text: the parent metrics use the
-    0.8/−0.2-em + 0.5-em-x-height approximation; a deferred (non-LengthPx) declared line-height isn't read
-    as the `%` base (falls back to font-size × 1.2).
+    0.8/−0.2-em + 0.5-em-x-height approximation. (A declared `line-height` IS now read as the
+    vertical-align `%` base — `OwnLineHeightPx` reads it via `ReadLineHeightPx`, the line-height cycle —
+    so a number/length/% line-height no longer silently falls back to font-size × 1.2.)
   - An inline-block aligns by its LAST in-flow line box's baseline (CSS 2.2 §10.8.1 — it sits ON the
     surrounding text baseline; the line box is sized by the max-ascent model). The last line's descent is
     captured from the ACTUAL deepest line-bearing fragment's metrics (`BufferingMeasureSink.LastLineBox

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/LineHeightResolver.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/LineHeightResolver.cs
@@ -1,0 +1,92 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System;
+using System.Globalization;
+using NetPdf.Css.Diagnostics;
+using NetPdf.Css.Parser;
+using NetPdf.Css.Properties;
+
+namespace NetPdf.Css.ComputedValues.PropertyResolvers;
+
+/// <summary>
+/// Resolves the CSS <c>line-height</c> value (CSS 2.2 §10.8.1 / CSS Inline 3):
+/// <c>normal | &lt;number&gt; | &lt;length&gt; | &lt;percentage&gt;</c>.
+/// <list type="bullet">
+///   <item><c>normal</c> → a <c>Keyword</c> slot (id <see cref="Normal"/> = 0); the layout readers
+///   treat any non-numeric slot as "use font-size × 1.2" (the UA default).</item>
+///   <item>A unitless <c>&lt;number&gt;</c> (≥ 0) → a <c>Number</c> slot — the multiplier. The used
+///   line-height is number × the element's OWN font-size; the COMPUTED value is the number itself, so a
+///   child inherits the number and re-multiplies by ITS font-size (CSS Inline 3 §4.2).</item>
+///   <item><c>&lt;length&gt;</c> / <c>&lt;percentage&gt;</c> → delegated to <see cref="LengthResolver"/>
+///   as a <see cref="PropertyType.LengthPercentage"/>: an absolute length → <c>LengthPx</c>; a
+///   font-/viewport-relative length (<c>em</c>/<c>rem</c>/<c>vw</c>…) → Deferred raw (the box-builder's
+///   <c>DeferredLengthResolver</c> folds it against font-size); a percentage → a <c>Percentage</c> slot
+///   (used = % × font-size).</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>Pre-fix <c>line-height</c> was UNWIRED in <see cref="PropertyResolverDispatch"/> — every value
+/// fell through to <c>UnsupportedUnvalidated</c>, so a declared <c>line-height: 24px</c> never reached
+/// the computed style and layout/paint fell back to font-size × 1.2 regardless.</para>
+/// <para><b>Non-negative.</b> <c>line-height</c> is a non-negative property
+/// (<c>NonNegativeProperties</c>): a negative <c>&lt;number&gt;</c> is rejected here (Invalid), a
+/// negative <c>&lt;length&gt;</c> by <see cref="LengthResolver"/>.</para>
+/// </remarks>
+internal static class LineHeightResolver
+{
+    /// <summary>The <c>normal</c> keyword id — also the fallback meaning of any non-numeric slot.</summary>
+    public const int Normal = 0;
+
+    public static ResolverResult Resolve(
+        string value,
+        PropertyId propertyId,
+        string propertyName,
+        ICssDiagnosticsSink? diagnostics,
+        CssSourceLocation location)
+    {
+        var trimmed = value.Trim();
+
+        // `normal` — the initial; a Keyword(0) slot the readers map to font-size × 1.2.
+        if (trimmed.Equals("normal", StringComparison.OrdinalIgnoreCase))
+            return ResolverResult.Resolved(ComputedSlot.FromKeyword(Normal));
+
+        // A unitless <number> (the multiplier) — distinguished from a <length> by carrying no unit and
+        // no `%`. A non-negative number → a Number slot; a negative one is invalid (line-height ≥ 0).
+        if (IsUnitlessNumber(trimmed))
+        {
+            if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var number)
+                && number >= 0)
+            {
+                return ResolverResult.Resolved(ComputedSlot.FromNumber(number));
+            }
+            var safe = DiagnosticTextSanitizer.Sanitize(value);
+            diagnostics?.Emit(new CssDiagnostic(
+                CssDiagnosticCodes.CssPropertyValueInvalid001,
+                $"'{propertyName}: {safe}' — line-height must be a non-negative number.",
+                CssDiagnosticSeverity.Warning,
+                location));
+            return ResolverResult.Invalid();
+        }
+
+        // <length> / <percentage> — the dimension grammar; line-height is non-negative so a negative
+        // literal is rejected on the unit path (NonNegativeProperties). An absolute length → LengthPx,
+        // em/rem/vw → Deferred raw (folded by DeferredLengthResolver), a percentage → a Percentage slot.
+        return LengthResolver.Resolve(
+            trimmed, PropertyType.LengthPercentage, propertyId, propertyName, diagnostics, location);
+    }
+
+    /// <summary>True when <paramref name="value"/> is a bare number (digits / sign / decimal point /
+    /// exponent) with NO unit and NO <c>%</c> — so a <c>&lt;length&gt;</c> (<c>24px</c>) or a
+    /// <c>&lt;percentage&gt;</c> (<c>150%</c>) falls through to <see cref="LengthResolver"/>.</summary>
+    private static bool IsUnitlessNumber(string value)
+    {
+        if (value.Length == 0) return false;
+        foreach (var c in value)
+        {
+            var numeric = (c >= '0' && c <= '9') || c == '.' || c == '+' || c == '-' || c == 'e' || c == 'E';
+            if (!numeric) return false;
+        }
+        return true;
+    }
+}

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/LineHeightResolver.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/LineHeightResolver.cs
@@ -55,8 +55,11 @@ internal static class LineHeightResolver
         // no `%`. A non-negative number → a Number slot; a negative one is invalid (line-height ≥ 0).
         if (IsUnitlessNumber(trimmed))
         {
+            // double.IsFinite guards the overflow path — `line-height: 1e309` parses to +Infinity, which
+            // is `>= 0` but would THROW from ComputedSlot.FromNumber; reject it as invalid CSS instead
+            // (matching NumberResolver's finite check) so untrusted input never crashes the pipeline.
             if (double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var number)
-                && number >= 0)
+                && number >= 0 && double.IsFinite(number))
             {
                 return ResolverResult.Resolved(ComputedSlot.FromNumber(number));
             }

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/NonNegativeProperties.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/NonNegativeProperties.cs
@@ -86,6 +86,10 @@ internal static class NonNegativeProperties
         // §3.4). FontSizeResolver delegates absolute <length> forms to
         // LengthResolver, which consults this set to reject a negative size.
         PropertyId.FontSize,
+        // line-height cycle — line-height is non-negative (CSS Inline 3 §4.2:
+        // negative values are invalid). LineHeightResolver rejects a negative
+        // <number> directly; a negative <length> is rejected via this set.
+        PropertyId.LineHeight,
         // Per the margin-box-border-radius cycle (PR #174 review P2) — a border-radius
         // is non-negative (CSS Backgrounds & Borders 3 §6.1: negative values are
         // invalid), so a negative corner radius invalidates cleanly + falls back to the

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/PropertyResolverDispatch.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/PropertyResolverDispatch.cs
@@ -30,9 +30,9 @@ namespace NetPdf.Css.ComputedValues.PropertyResolvers;
 /// without context"; <see cref="ResolutionState.UnsupportedUnvalidated"/> means
 /// "no resolver wired yet — raw text passed through unchecked, cycle-2 work
 /// surface". Treating them identically would silently let typos through for
-/// cycle-2 PropertyTypes. Still unwired: <c>LineHeight</c>,
-/// <c>VerticalAlign</c>, <c>Content</c>, <c>Url</c>, <c>String</c>, <c>Time</c>,
-/// <c>Angle</c>, <c>Resolution</c>.
+/// cycle-2 PropertyTypes. Still unwired: <c>Content</c>, <c>Url</c>, <c>String</c>,
+/// <c>Time</c>, <c>Angle</c>, <c>Resolution</c>. (<c>LineHeight</c> + <c>VerticalAlign</c>
+/// are now wired — <see cref="LineHeightResolver"/> / <see cref="VerticalAlignResolver"/>.)
 /// </para>
 /// </remarks>
 internal static class PropertyResolverDispatch
@@ -161,6 +161,14 @@ internal static class PropertyResolverDispatch
             // text-top / text-bottom / middle / top / bottom) → a Keyword slot; <length> / <percentage>
             // → a LengthPercentage slot (may be negative). Consumed by the inline-atomic placement.
             PropertyType.VerticalAlign => VerticalAlignResolver.Resolve(
+                trimmed, propertyId, meta.Name, diagnostics, location),
+
+            // line-height cycle (CSS 2.2 §10.8.1 / CSS Inline 3) — `normal` → Keyword(0); a unitless
+            // <number> → a Number slot (the multiplier, × the element's own font-size at use time);
+            // <length>/<percentage> → LengthResolver (absolute → LengthPx, em/rem → Deferred raw the
+            // box-builder folds, % → a Percentage slot). Pre-fix line-height was UNWIRED (every value →
+            // UnsupportedUnvalidated), so a declared `line-height: 24px` never reached layout/paint.
+            PropertyType.LineHeight => LineHeightResolver.Resolve(
                 trimmed, propertyId, meta.Name, diagnostics, location),
 
             // Cycle-2 PropertyTypes — return UnsupportedUnvalidated (NOT Deferred)

--- a/src/NetPdf.Layout/Inline/InlineVerticalAlign.cs
+++ b/src/NetPdf.Layout/Inline/InlineVerticalAlign.cs
@@ -101,19 +101,18 @@ internal static class InlineVerticalAlign
     /// contribute a content-box <c>Floor</c> the line height must reach. <c>baseline</c> / <c>sub</c> /
     /// <c>super</c> / a <c>&lt;length&gt;</c> / <c>&lt;percentage&gt;</c> (the RAISE path, see
     /// <see cref="TextRaisePx"/>) and block-direct text (the inline-level gate, <paramref name="runStyle"/>
-    /// IS <paramref name="blockStyle"/>) return (0,0,0). The run's content box is approximated as the
-    /// 0.8 / 0.2-em ascent / descent (matching <see cref="TextRaisePx"/> + the layout's atomic extents);
-    /// <paramref name="parentDescentPx"/> is NEGATIVE.</summary>
+    /// IS <paramref name="blockStyle"/>) return (0,0,0). The box height is the run's INLINE-BOX height —
+    /// its used <paramref name="runLineHeightPx"/> (post-PR-#197 review P2) — so a tall <c>line-height</c>
+    /// (not only a large <c>font-size</c>) grows the line; <paramref name="parentDescentPx"/> is
+    /// NEGATIVE.</summary>
     public static (double Above, double Below, double Floor) TextLineEdgeGrowth(
-        ComputedStyle runStyle, ComputedStyle blockStyle, double runFontSizePx,
+        ComputedStyle runStyle, ComputedStyle blockStyle, double runLineHeightPx,
         double parentAscentPx, double parentDescentPx, double parentFontSizePx)
     {
         if (ReferenceEquals(runStyle, blockStyle)) return (0.0, 0.0, 0.0);   // block-direct — inline-level gate
         var slot = runStyle.Get(PropertyId.VerticalAlign);
         if (slot.Tag != ComputedSlotTag.Keyword) return (0.0, 0.0, 0.0);     // length / % → raise path
-        var runAscentPx = 0.8 * runFontSizePx;
-        var runDescentPx = -0.2 * runFontSizePx;        // negative (the font descender)
-        var runHeightPx = runAscentPx - runDescentPx;   // ≈ runFontSizePx (content box)
+        var runHeightPx = runLineHeightPx;   // the run's INLINE-BOX height (its used line-height)
         return slot.AsKeyword() switch
         {
             3 => (parentAscentPx, runHeightPx - parentAscentPx, 0.0),                                          // text-top
@@ -129,7 +128,8 @@ internal static class InlineVerticalAlign
     /// vertical-align <c>%</c> (CSS 2.2 §10.8.1).</summary>
     public static double OwnLineHeightPx(ComputedStyle runStyle, double fontSizePx)
     {
-        var declared = runStyle.ReadLineHeightPx(fontSizePx);   // line-height cycle — number/length/% honored
-        return declared > 0 ? declared : fontSizePx * 1.2;
+        // line-height cycle — number/length/% honored; null = `normal` → font-size × 1.2 (an explicit 0
+        // returns a 0 base, so a percentage vertical-align against a 0 line-height is 0).
+        return runStyle.ReadLineHeightPx(fontSizePx) ?? fontSizePx * 1.2;
     }
 }

--- a/src/NetPdf.Layout/Inline/InlineVerticalAlign.cs
+++ b/src/NetPdf.Layout/Inline/InlineVerticalAlign.cs
@@ -59,11 +59,12 @@ internal static class InlineVerticalAlign
     /// the run's midpoint at the line baseline + half the parent x-height), or the PARENT text
     /// content-area (<c>text-top</c> / <c>text-bottom</c> — the run's top / bottom at the parent font's
     /// ascent / descent above / below the line baseline).
-    /// <para><b>Bounded first cut.</b> The run is positioned WITHIN the line box AS SIZED by its baseline
-    /// content; a run TALLER than that line OVERFLOWS it (line growth for non-baseline-aligned content is
-    /// deferred). Parent metrics use the 0.8 / 0.2-em ascent / descent + 0.5-em x-height approximation
-    /// (the same the layout uses). <paramref name="descentPx"/> is NEGATIVE (the font descender), so the
-    /// run spans [<paramref name="lineBaselineTopPx"/> result − ascent, − descent].</para>
+    /// <para><b>Line growth (PR 3 task 7).</b> The line box GROWS to contain a line-edge-aligned run (see
+    /// <see cref="TextLineEdgeGrowth"/>, called by the layout line-box sizing) — a tall <c>top</c> /
+    /// <c>bottom</c> / <c>middle</c> / <c>text-*</c> run no longer overflows. This method positions the run
+    /// WITHIN that (now grown) line. Parent metrics use the 0.8 / 0.2-em ascent / descent + 0.5-em x-height
+    /// approximation (the same the layout uses). <paramref name="descentPx"/> is NEGATIVE (the font
+    /// descender), so the run spans [<paramref name="lineBaselineTopPx"/> result − ascent, − descent].</para>
     /// <para><b>Inline-level gate.</b> Block-direct text (<paramref name="runStyle"/> IS
     /// <paramref name="blockStyle"/>) returns <see langword="null"/> — a block's / cell's own
     /// vertical-align doesn't apply to its inline content (§10.8.1), same as <see cref="TextRaisePx"/>.</para></summary>
@@ -87,6 +88,39 @@ internal static class InlineVerticalAlign
             4 => lineBaselineTopPx - parentDescentPx + descentPx,            // text-bottom: run bottom at parent descent
             5 => lineBaselineTopPx - parentHalfXHeightPx + (ascentPx + descentPx) / 2.0, // middle
             _ => null,                                                       // baseline / sub / super → raise path
+        };
+    }
+
+    /// <summary>text vertical-align line-growth (CSS 2.2 §10.8.1, PR 3 task 7) — the line-box GROWTH a
+    /// LINE-EDGE-aligned inline TEXT run (<c>top</c> / <c>bottom</c> / <c>middle</c> / <c>text-top</c> /
+    /// <c>text-bottom</c>) forces so a run TALLER than the baseline-sized line is CONTAINED instead of
+    /// overflowing. Returns <c>(Above, Below, Floor)</c>: <c>text-top</c> / <c>text-bottom</c> /
+    /// <c>middle</c> grow the baseline-relative ascent / descent (the §10.8.1 max-ascent model, mirroring
+    /// the atomic <c>AtomicBaselineExtents</c> path), so <c>(Above, Below)</c> are the run's extents above /
+    /// below the LINE baseline; <c>top</c> / <c>bottom</c> are line-EDGE-relative (circular) and instead
+    /// contribute a content-box <c>Floor</c> the line height must reach. <c>baseline</c> / <c>sub</c> /
+    /// <c>super</c> / a <c>&lt;length&gt;</c> / <c>&lt;percentage&gt;</c> (the RAISE path, see
+    /// <see cref="TextRaisePx"/>) and block-direct text (the inline-level gate, <paramref name="runStyle"/>
+    /// IS <paramref name="blockStyle"/>) return (0,0,0). The run's content box is approximated as the
+    /// 0.8 / 0.2-em ascent / descent (matching <see cref="TextRaisePx"/> + the layout's atomic extents);
+    /// <paramref name="parentDescentPx"/> is NEGATIVE.</summary>
+    public static (double Above, double Below, double Floor) TextLineEdgeGrowth(
+        ComputedStyle runStyle, ComputedStyle blockStyle, double runFontSizePx,
+        double parentAscentPx, double parentDescentPx, double parentFontSizePx)
+    {
+        if (ReferenceEquals(runStyle, blockStyle)) return (0.0, 0.0, 0.0);   // block-direct — inline-level gate
+        var slot = runStyle.Get(PropertyId.VerticalAlign);
+        if (slot.Tag != ComputedSlotTag.Keyword) return (0.0, 0.0, 0.0);     // length / % → raise path
+        var runAscentPx = 0.8 * runFontSizePx;
+        var runDescentPx = -0.2 * runFontSizePx;        // negative (the font descender)
+        var runHeightPx = runAscentPx - runDescentPx;   // ≈ runFontSizePx (content box)
+        return slot.AsKeyword() switch
+        {
+            3 => (parentAscentPx, runHeightPx - parentAscentPx, 0.0),                                          // text-top
+            4 => (runHeightPx + parentDescentPx, -parentDescentPx, 0.0),                                       // text-bottom (descent < 0)
+            5 => (0.25 * parentFontSizePx + runHeightPx / 2.0, runHeightPx / 2.0 - 0.25 * parentFontSizePx, 0.0), // middle
+            6 or 7 => (0.0, 0.0, runHeightPx),                                                                  // top / bottom — line floor
+            _ => (0.0, 0.0, 0.0),                                                                              // baseline / sub / super → raise path
         };
     }
 

--- a/src/NetPdf.Layout/Inline/InlineVerticalAlign.cs
+++ b/src/NetPdf.Layout/Inline/InlineVerticalAlign.cs
@@ -129,7 +129,7 @@ internal static class InlineVerticalAlign
     /// vertical-align <c>%</c> (CSS 2.2 §10.8.1).</summary>
     public static double OwnLineHeightPx(ComputedStyle runStyle, double fontSizePx)
     {
-        var declared = runStyle.ReadLengthPxOrZero(PropertyId.LineHeight);
+        var declared = runStyle.ReadLineHeightPx(fontSizePx);   // line-height cycle — number/length/% honored
         return declared > 0 ? declared : fontSizePx * 1.2;
     }
 }

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -6765,10 +6765,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             PaddingBlockEnd: block.Style.ReadLengthOrPercentPx(PropertyId.PaddingBottom, containingInlinePx),
             DeclaredWidthPx: block.Style.ReadLengthOrPercentPx(PropertyId.Width, containingInlinePx),
             // line-height: read from the block's own style (sub-cycle
-            // 1 simple rule — uniform across the block). Sub-cycle 2
-            // will read per-TextRun + apply the CSS Text L3 strut
-            // rule (max of constituent runs' line-heights).
-            LineHeightOverridePx: block.Style.ReadLengthPxOrZero(PropertyId.LineHeight));
+            // 1 simple rule — uniform across the block). The line-height
+            // cycle reads the full grammar (normal/number/length/%) via
+            // ReadLineHeightPx — a unitless number multiplies the block's
+            // own font-size; 0 = `normal` → the font-size × 1.2 fallback.
+            LineHeightOverridePx: block.Style.ReadLineHeightPx(
+                block.Style.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16)));
     }
 
     /// <summary>Whether the box DECLARES an explicit <c>width</c> — a LengthPx or Percentage
@@ -7434,8 +7436,9 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// element's own line-height, not the parent's or the grown line box).</summary>
     private static double OwnLineHeightPx(ComputedStyle style)
     {
-        var declared = style.ReadLengthPxOrZero(PropertyId.LineHeight);
-        return declared > 0 ? declared : style.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16) * 1.2;
+        var fontSizePx = style.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
+        var declared = style.ReadLineHeightPx(fontSizePx);   // line-height cycle — number/length/% honored
+        return declared > 0 ? declared : fontSizePx * 1.2;
     }
 
     /// <summary>vertical-align cycle (CSS 2.2 §10.8.1) — an atomic's extent ABOVE / BELOW the line

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7143,6 +7143,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         for (var li = 0; li < lines.Length; li++)
         {
             double maxAtomicMarginBoxHeight = 0;
+            double maxLineEdgeTextHeight = 0;   // text vertical-align line-growth — top/bottom run content-box floor.
             var ascentAbove = textAscentAbovePx;
             var descentBelow = textDescentBelowPx;
             var lineNeedsMaxAscent = false;
@@ -7212,21 +7213,55 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                         if (runAscentAbovePx + raisePx > ascentAbove) ascentAbove = runAscentAbovePx + raisePx;
                         if (runDescentBelowPx - raisePx > descentBelow) descentBelow = runDescentBelowPx - raisePx;
                     }
+                    else
+                    {
+                        // text vertical-align line-growth cycle (PR 3 task 7) — a LINE-EDGE-aligned inline
+                        // text run (top/bottom/middle/text-top/text-bottom) GROWS the line so a run TALLER
+                        // than the baseline-sized line is CONTAINED (it previously overflowed — the PR #195
+                        // deferral). text-top/text-bottom/middle grow the baseline-relative ascent/descent
+                        // (the max-ascent model, mirroring the atomic AtomicBaselineExtents path); top/bottom
+                        // are line-edge-relative so they contribute a content-box FLOOR instead. The painter
+                        // positions the run via the SAME InlineVerticalAlign.TextLineEdgeBaselineTopPx using
+                        // the grown line metrics, so layout + paint can't disagree. baseline/plain/block-
+                        // direct text → (0,0,0), so those lines stay byte-identical.
+                        var (edgeAbove, edgeBelow, edgeFloor) =
+                            NetPdf.Layout.Inline.InlineVerticalAlign.TextLineEdgeGrowth(
+                                runStyle, blockStyle, runFontSizePx, ascentPx, descentPx, fontSizePx);
+                        if (edgeAbove != 0.0 || edgeBelow != 0.0)
+                        {
+                            lineNeedsMaxAscent = true;
+                            anyMaxAscent = true;
+                            anyTextShift = true;
+                            if (edgeAbove > ascentAbove) ascentAbove = edgeAbove;
+                            if (edgeBelow > descentBelow) descentBelow = edgeBelow;
+                        }
+                        if (edgeFloor > 0.0)
+                        {
+                            // top / bottom — line-edge-relative: the run must FIT the line box (current
+                            // model, centred baseline + the floor grows the line, like a top/bottom atomic).
+                            anyTextShift = true;
+                            if (edgeFloor > maxLineEdgeTextHeight) maxLineEdgeTextHeight = edgeFloor;
+                        }
+                    }
                 }
             }
             if (lineNeedsMaxAscent)
             {
                 // §10.8.1 max-ascent model — the baseline at max-ascent-above so a baseline-aligned
                 // inline-block sits ON the text baseline without overflowing the line top; the line is
-                // at least the sum AND tall enough for any non-baseline (top/bottom) sibling's margin box.
-                perLineHeights[li] = Math.Max(ascentAbove + descentBelow, maxAtomicMarginBoxHeight);
+                // at least the sum AND tall enough for any non-baseline (top/bottom) sibling's margin box
+                // or line-edge text run's content box (text vertical-align line-growth).
+                perLineHeights[li] = Math.Max(ascentAbove + descentBelow,
+                    Math.Max(maxAtomicMarginBoxHeight, maxLineEdgeTextHeight));
                 perLineBaselines[li] = ascentAbove;
             }
             else
             {
                 // Current model (byte-identical when every atomic is baseline/img) — the line grows to the
-                // tallest atomic MARGIN box; the baseline stays centred (NaN → real font metrics).
-                perLineHeights[li] = Math.Max(textLineHeightPx, maxAtomicMarginBoxHeight);
+                // tallest atomic MARGIN box or line-edge (top/bottom) text run; the baseline stays centred
+                // (NaN → real font metrics).
+                perLineHeights[li] = Math.Max(textLineHeightPx,
+                    Math.Max(maxAtomicMarginBoxHeight, maxLineEdgeTextHeight));
                 perLineBaselines[li] = double.NaN;
             }
         }

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -6722,7 +6722,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         double PaddingBlockStart,
         double PaddingBlockEnd,
         double DeclaredWidthPx,    // 0 when `width: auto` (default)
-        double LineHeightOverridePx); // 0 sentinel = use font-size × 1.2
+        double? LineHeightOverridePx); // null = `normal` → font-size × 1.2; an explicit value (incl. 0) is used
 
     private static InlineOnlyBlockMetrics ReadInlineOnlyBlockMetrics(Box block, double containingInlinePx)
     {
@@ -7053,17 +7053,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         }
 
         // Per Finding #5 — line-height honoring. Use the block's
-        // declared line-height when non-zero; fall back to
-        // 1.2 × font-size for `line-height: normal`. CSS Text L3 §3
-        // + CSS Inline L3 §3.5 say the used `line-height` is the
-        // COMPUTED value (`normal` → font's intrinsic line metric);
-        // reading the keyword + the font metric tables remains
-        // sub-cycle 2 work — 1.2 is the de-facto Web default for
+        // declared line-height when present (incl. an explicit 0 — a collapsed line box); fall back to
+        // 1.2 × font-size for `line-height: normal` (null). CSS Text L3 §3 + CSS Inline L3 §3.5 say the
+        // used `line-height` is the COMPUTED value (`normal` → font's intrinsic line metric); reading the
+        // keyword + the font metric tables remains sub-cycle 2 work — 1.2 is the de-facto Web default for
         // `line-height: normal` across major UAs.
         double lineHeight;
-        if (metrics.LineHeightOverridePx > 0)
+        if (metrics.LineHeightOverridePx is { } overridePx)
         {
-            lineHeight = metrics.LineHeightOverridePx;
+            lineHeight = overridePx;
         }
         else
         {
@@ -7222,13 +7220,17 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                         // than the baseline-sized line is CONTAINED (it previously overflowed — the PR #195
                         // deferral). text-top/text-bottom/middle grow the baseline-relative ascent/descent
                         // (the max-ascent model, mirroring the atomic AtomicBaselineExtents path); top/bottom
-                        // are line-edge-relative so they contribute a content-box FLOOR instead. The painter
-                        // positions the run via the SAME InlineVerticalAlign.TextLineEdgeBaselineTopPx using
-                        // the grown line metrics, so layout + paint can't disagree. baseline/plain/block-
-                        // direct text → (0,0,0), so those lines stay byte-identical.
+                        // are line-edge-relative so they contribute an inline-box FLOOR instead. The box
+                        // height is the run's USED line-height (post-PR-#197 review P2 — a tall line-height,
+                        // not only a large font-size, grows the line). The painter positions the run via the
+                        // SAME InlineVerticalAlign.TextLineEdgeBaselineTopPx using the grown line metrics, so
+                        // layout + paint can't disagree. baseline/plain/block-direct text → (0,0,0), so those
+                        // lines stay byte-identical.
+                        var runLineHeightPx =
+                            NetPdf.Layout.Inline.InlineVerticalAlign.OwnLineHeightPx(runStyle, runFontSizePx);
                         var (edgeAbove, edgeBelow, edgeFloor) =
                             NetPdf.Layout.Inline.InlineVerticalAlign.TextLineEdgeGrowth(
-                                runStyle, blockStyle, runFontSizePx, ascentPx, descentPx, fontSizePx);
+                                runStyle, blockStyle, runLineHeightPx, ascentPx, descentPx, fontSizePx);
                         if (edgeAbove != 0.0 || edgeBelow != 0.0)
                         {
                             lineNeedsMaxAscent = true;
@@ -7437,8 +7439,9 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     private static double OwnLineHeightPx(ComputedStyle style)
     {
         var fontSizePx = style.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
-        var declared = style.ReadLineHeightPx(fontSizePx);   // line-height cycle — number/length/% honored
-        return declared > 0 ? declared : fontSizePx * 1.2;
+        // line-height cycle — number/length/% honored; null = `normal` → font-size × 1.2. An explicit
+        // line-height: 0 returns a 0 % base (a 0% vertical-align of a 0 line-height is 0).
+        return style.ReadLineHeightPx(fontSizePx) ?? fontSizePx * 1.2;
     }
 
     /// <summary>vertical-align cycle (CSS 2.2 §10.8.1) — an atomic's extent ABOVE / BELOW the line

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -71,16 +71,20 @@ internal static class ComputedStyleLayoutExtensions
     }
 
     /// <summary>line-height cycle (CSS 2.2 §10.8.1 / CSS Inline 3) — the USED <c>line-height</c> in px,
-    /// or <c>0</c> when it's <c>normal</c> (the SENTINEL meaning "the caller uses its own
-    /// <paramref name="fontSizePx"/> × 1.2 default"). Decodes the full computed grammar that
+    /// or <see langword="null"/> when it's <c>normal</c> / unset (the caller then uses its own
+    /// <paramref name="fontSizePx"/> × 1.2 default). Decodes the full computed grammar that
     /// <c>LineHeightResolver</c> produces: a <c>LengthPx</c> slot (an absolute <c>&lt;length&gt;</c>, or an
     /// <c>em</c>/<c>rem</c> already folded by <c>DeferredLengthResolver</c>) → that px; a <c>Number</c>
     /// slot (a unitless <c>&lt;number&gt;</c> multiplier) → number × <paramref name="fontSizePx"/> (the
     /// element's OWN font-size — a number inherits AS the number); a <c>Percentage</c> slot → % of
-    /// <paramref name="fontSizePx"/>; <c>normal</c> / a keyword / an unset slot → 0. Pre-fix every call
-    /// site read <c>ReadLengthPxOrZero(LineHeight)</c>, which only honored a <c>LengthPx</c> slot AND the
-    /// dispatch never produced one — so a declared length silently became <c>font-size × 1.2</c>.</summary>
-    public static double ReadLineHeightPx(this ComputedStyle style, double fontSizePx)
+    /// <paramref name="fontSizePx"/>; <c>normal</c> / a keyword / an unset slot → <see langword="null"/>.
+    /// <para><b>Explicit zero.</b> A valid <c>line-height: 0</c> / <c>0px</c> / <c>0%</c> returns
+    /// <c>0.0</c> — DISTINCT from <c>normal</c> (null) — so a collapsed line box is honored instead of
+    /// silently falling back to the default (post-PR-#197 review P2; a plain numeric sentinel can't tell
+    /// explicit zero from "use the default"). Pre-fix every call site read
+    /// <c>ReadLengthPxOrZero(LineHeight)</c>, which only honored a <c>LengthPx</c> slot AND the dispatch
+    /// never produced one — so a declared length silently became <c>font-size × 1.2</c>.</para></summary>
+    public static double? ReadLineHeightPx(this ComputedStyle style, double fontSizePx)
     {
         var slot = style.Get(PropertyId.LineHeight);
         return slot.Tag switch
@@ -88,7 +92,7 @@ internal static class ComputedStyleLayoutExtensions
             ComputedSlotTag.LengthPx => slot.AsLengthPx(),
             ComputedSlotTag.Number => slot.AsNumber() * fontSizePx,
             ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * fontSizePx,
-            _ => 0.0,   // normal / Keyword(normal) / Unset → caller's font-size × 1.2 default
+            _ => null,   // normal / Keyword(normal) / Unset → caller's font-size × 1.2 default
         };
     }
 

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -70,6 +70,28 @@ internal static class ComputedStyleLayoutExtensions
         return style.ReadLengthPxOrDefault(id, defaultPx: 0);
     }
 
+    /// <summary>line-height cycle (CSS 2.2 §10.8.1 / CSS Inline 3) — the USED <c>line-height</c> in px,
+    /// or <c>0</c> when it's <c>normal</c> (the SENTINEL meaning "the caller uses its own
+    /// <paramref name="fontSizePx"/> × 1.2 default"). Decodes the full computed grammar that
+    /// <c>LineHeightResolver</c> produces: a <c>LengthPx</c> slot (an absolute <c>&lt;length&gt;</c>, or an
+    /// <c>em</c>/<c>rem</c> already folded by <c>DeferredLengthResolver</c>) → that px; a <c>Number</c>
+    /// slot (a unitless <c>&lt;number&gt;</c> multiplier) → number × <paramref name="fontSizePx"/> (the
+    /// element's OWN font-size — a number inherits AS the number); a <c>Percentage</c> slot → % of
+    /// <paramref name="fontSizePx"/>; <c>normal</c> / a keyword / an unset slot → 0. Pre-fix every call
+    /// site read <c>ReadLengthPxOrZero(LineHeight)</c>, which only honored a <c>LengthPx</c> slot AND the
+    /// dispatch never produced one — so a declared length silently became <c>font-size × 1.2</c>.</summary>
+    public static double ReadLineHeightPx(this ComputedStyle style, double fontSizePx)
+    {
+        var slot = style.Get(PropertyId.LineHeight);
+        return slot.Tag switch
+        {
+            ComputedSlotTag.LengthPx => slot.AsLengthPx(),
+            ComputedSlotTag.Number => slot.AsNumber() * fontSizePx,
+            ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * fontSizePx,
+            _ => 0.0,   // normal / Keyword(normal) / Unset → caller's font-size × 1.2 default
+        };
+    }
+
     /// <summary>Body % lengths (body-percent cycle) — like
     /// <see cref="ReadLengthPxOrZero(ComputedStyle, PropertyId)"/> but a PERCENTAGE slot resolves
     /// against <paramref name="containingInlinePx"/> (the containing block's INLINE size: CSS 2.2

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -567,17 +567,13 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         // natural (= non-reversed) cursor; only the FINAL main-axis
         // offset assigned to each fragment flips for reverse directions.
         //
-        // Per Phase 3 Task 15 L5 post-PR-#65 review F#1 — the axis
-        // mapping below assumes LTR horizontal-tb (the L1 default
-        // writing mode). Per CSS Flexbox §3.1 the spec-correct axis
-        // mapping depends on the cascaded `direction` + `writing-mode`
-        // properties; under RTL or vertical writing modes the physical
-        // mapping differs (e.g., RTL row = right-to-left along the
-        // inline axis = visually equivalent to LTR row-reverse).
-        // Plumbing `direction` / `writing-mode` through the layout
-        // pipeline is L7+ scope (L6 shipped `flex-wrap: wrap` without
-        // expanding the direction pipeline); tracked in
-        // `docs/deferrals.md#flex-layouter-features`.
+        // Per CSS Flexbox §3.1 the physical axis mapping depends on the cascaded
+        // `direction` + `writing-mode`. ROW RTL is now ACTIVE (PR 2 task 6): a `row`
+        // (inline-main-axis) container under `direction: rtl` flips the physical main
+        // axis right-to-left — the XOR into `isReverse` below makes it equivalent to LTR
+        // `row-reverse`. STILL deferred (tracked in `docs/deferrals.md#flex-layouter-features`):
+        // the COLUMN cross-axis under RTL (a column's cross axis is the inline axis), and
+        // all VERTICAL writing modes (`writing-mode` is not yet a registered property).
         var flexDirection = _rootBox.Style.ReadFlexDirection();
         var isColumn = flexDirection.IsFlexColumnDirection();
         var isReverse = flexDirection.IsFlexReverseDirection();

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -581,6 +581,16 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         var flexDirection = _rootBox.Style.ReadFlexDirection();
         var isColumn = flexDirection.IsFlexColumnDirection();
         var isReverse = flexDirection.IsFlexReverseDirection();
+        // Direction pipeline (PR 2 task 6) — for a ROW (inline-main-axis) container, `direction: rtl`
+        // reverses the physical main-axis direction (CSS Flexbox §5.1: row main-start = inline-start =
+        // RIGHT under RTL). So `row` under RTL lays out right-to-left — physically identical to
+        // `row-reverse` under LTR — and `row-reverse` under RTL flips back to left-to-right. RTL therefore
+        // XORs the reverse flag, which (re)routes the main-axis emission AND the flex-start/flex-end
+        // justify-content mapping through the SAME `isReverse` path. Column directions (block main axis)
+        // are unaffected by `direction` on the MAIN axis — the column cross-axis RTL case is a separate,
+        // still-deferred concern (docs/deferrals.md#flex-layouter-features).
+        if (!isColumn && _rootBox.Style.IsRtl())
+            isReverse = !isReverse;
         var (mainSizeProperty, crossSizeProperty) = GetAxisProperties(flexDirection);
 
         // Per Phase 3 Task 15 L6 — read flex-wrap. When the value is

--- a/src/NetPdf/Rendering/PageMarginBoxPainter.cs
+++ b/src/NetPdf/Rendering/PageMarginBoxPainter.cs
@@ -532,6 +532,10 @@ internal static class PageMarginBoxPainter
             // Lay out the content line FIRST — its size drives the §5.3 shrink-to-fit box below. An
             // empty `content: ""` box (CSS Page 3 §6.1: content not none/normal) or one whose font won't
             // resolve has no content size, so it keeps the FULL band.
+            // DEFERRED (deferrals.md#margin-box-line-height) — literal margin-box content uses font-size
+            // × 1.2 regardless of a declared `line-height`: `line-height` is not in MarginBoxStyle's
+            // inherited set, so the slot isn't present here. The body path's ReadLineHeightPx is NOT wired
+            // in until that inheritance lands (the running-element segment path parses line-height separately).
             var lineHeightPx = contentMetricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16) * NormalLineHeightFactor;
             // The box's computed white-space decides whether its content can WRAP: only Normal / PreWrap /
             // PreLine / BreakSpaces wrap, so only they can flex narrower than the single-line width and

--- a/src/NetPdf/Rendering/TextPainter.cs
+++ b/src/NetPdf/Rendering/TextPainter.cs
@@ -295,11 +295,10 @@ internal static class TextPainter
         var metricsFontSizePx = metricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
         // line-height cycle — the full grammar (normal/number/length/%) via ReadLineHeightPx, so a
         // declared `line-height: 24px` (or `1.5`, or `150%`) sets the pitch instead of font-size × 1.2.
-        // The pitch MUST match BlockLayouter's LineHeightOverridePx (same reader + the same metrics font).
-        var lineHeightOverridePx = metricsStyle.ReadLineHeightPx(metricsFontSizePx);
-        var lineHeightPx = lineHeightOverridePx > 0
-            ? lineHeightOverridePx
-            : metricsFontSizePx * NormalLineHeightFactor;
+        // null = `normal` → the × NormalLineHeightFactor fallback; an explicit value (incl. 0, a collapsed
+        // line box) is used. The pitch MUST match BlockLayouter's LineHeightOverridePx (same reader + font).
+        var lineHeightPx = metricsStyle.ReadLineHeightPx(metricsFontSizePx)
+            ?? metricsFontSizePx * NormalLineHeightFactor;
 
         var lines = inline.Lines;
         var shapedRuns = inline.ShapedRuns;

--- a/src/NetPdf/Rendering/TextPainter.cs
+++ b/src/NetPdf/Rendering/TextPainter.cs
@@ -292,10 +292,14 @@ internal static class TextPainter
         // font-size, so the pitch/baseline must match it, not the box's default), falling back
         // to the box style so every other fragment is byte-identical.
         var metricsStyle = fragment.TextMetricsStyle ?? blockStyle;
-        var lineHeightOverridePx = metricsStyle.ReadLengthPxOrZero(PropertyId.LineHeight);
+        var metricsFontSizePx = metricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
+        // line-height cycle — the full grammar (normal/number/length/%) via ReadLineHeightPx, so a
+        // declared `line-height: 24px` (or `1.5`, or `150%`) sets the pitch instead of font-size × 1.2.
+        // The pitch MUST match BlockLayouter's LineHeightOverridePx (same reader + the same metrics font).
+        var lineHeightOverridePx = metricsStyle.ReadLineHeightPx(metricsFontSizePx);
         var lineHeightPx = lineHeightOverridePx > 0
             ? lineHeightOverridePx
-            : metricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16) * NormalLineHeightFactor;
+            : metricsFontSizePx * NormalLineHeightFactor;
 
         var lines = inline.Lines;
         var shapedRuns = inline.ShapedRuns;

--- a/src/NetPdf/Rendering/TextPainter.cs
+++ b/src/NetPdf/Rendering/TextPainter.cs
@@ -451,9 +451,9 @@ internal static class TextPainter
                 // the run to the line box / parent content-area (a non-baseline offset); the others
                 // (baseline / sub / super / a <length> / <percentage>) RAISE off the line baseline. A
                 // sub/super/numeric shift GROWS the line in layout (ComputeInlineAtomicLayout pins the
-                // per-line baseline); a line-edge run positions WITHIN the baseline-sized line — a taller
-                // run may overflow it (line growth for it is deferred, the bounded first cut). baseline /
-                // plain text → byte-identical.
+                // per-line baseline); a line-edge run ALSO grows the line now (PR 3 task 7 —
+                // TextLineEdgeGrowth), so a tall top/bottom/middle/text-* run is positioned WITHIN the
+                // grown line rather than overflowing it. baseline / plain text → byte-identical.
                 var blockFontSizePx = blockStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
                 var baselineTopPx = InlineVerticalAlign.TextLineEdgeBaselineTopPx(
                         runStyle, blockStyle, lineTopPx, thisLineHeightPx, lineBaselineTopPx,

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/HardeningReviewTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/HardeningReviewTests.cs
@@ -40,14 +40,14 @@ public sealed class HardeningReviewTests
     [Fact]
     public void Cycle_2_PropertyType_returns_UnsupportedUnvalidated_not_Deferred()
     {
-        // line-height's PropertyType (LineHeight) is still unwired. Per the
-        // hardening review, it must surface as UnsupportedUnvalidated — distinct
-        // from Deferred which means "validated but needs context". (font-family,
-        // used here pre-cycle-4, now resolves via FontFamilyListResolver.)
-        var result = PropertyResolverDispatch.Resolve(PropertyId.LineHeight, "1.5");
+        // `content`'s PropertyType (Content) is still unwired. Per the hardening
+        // review, it must surface as UnsupportedUnvalidated — distinct from Deferred
+        // which means "validated but needs context". (line-height, used here
+        // pre-line-height-cycle, now resolves via LineHeightResolver.)
+        var result = PropertyResolverDispatch.Resolve(PropertyId.Content, "open-quote");
         Assert.True(result.IsUnsupportedUnvalidated);
         Assert.False(result.IsDeferred);
-        Assert.Equal("1.5", result.RawText);
+        Assert.Equal("open-quote", result.RawText);
         Assert.True(result.HasRawText);
     }
 

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/LineHeightResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/LineHeightResolverTests.cs
@@ -96,4 +96,25 @@ public sealed class LineHeightResolverTests
         var r = Resolve("-10px", new CapturingSink());
         Assert.True(r.IsInvalid);
     }
+
+    [Theory]
+    [InlineData("1e309")]    // overflows double → +Infinity
+    [InlineData("1E400")]
+    [InlineData("9e999")]
+    public void Non_finite_unitless_number_is_invalid_not_a_crash(string value)
+    {
+        // Post-PR-#197 review P2 — a number that overflows to ±Infinity is `>= 0` but would THROW from
+        // ComputedSlot.FromNumber; the double.IsFinite guard turns it into invalid CSS, not a pipeline crash.
+        var r = Resolve(value, new CapturingSink());
+        Assert.True(r.IsInvalid, $"{value} should be invalid (non-finite), not throw");
+    }
+
+    [Theory]
+    [InlineData("3e")]       // malformed exponent → not a number, not a length
+    [InlineData("1.2.3")]
+    public void Malformed_numeric_forms_are_invalid(string value)
+    {
+        var r = Resolve(value, new CapturingSink());
+        Assert.True(r.IsInvalid, $"{value} should be invalid");
+    }
 }

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/LineHeightResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/LineHeightResolverTests.cs
@@ -1,0 +1,99 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.ComputedValues.PropertyResolvers;
+using NetPdf.Css.Diagnostics;
+using NetPdf.Css.Properties;
+using Xunit;
+
+namespace NetPdf.UnitTests.Css.ComputedValues.PropertyResolvers;
+
+/// <summary>
+/// line-height cycle — <see cref="LineHeightResolver"/> resolves the full
+/// <c>normal | &lt;number&gt; | &lt;length&gt; | &lt;percentage&gt;</c> grammar. Pre-fix the dispatch
+/// left <c>line-height</c> unwired, so every value fell through to UnsupportedUnvalidated and a declared
+/// <c>line-height: 24px</c> never reached the computed style.
+/// </summary>
+public sealed class LineHeightResolverTests
+{
+    private sealed class CapturingSink : ICssDiagnosticsSink
+    {
+        public List<CssDiagnostic> Diagnostics { get; } = new();
+        public void Emit(CssDiagnostic d) => Diagnostics.Add(d);
+    }
+
+    private static ResolverResult Resolve(string value, ICssDiagnosticsSink? sink = null)
+        => LineHeightResolver.Resolve(value, PropertyId.LineHeight, "line-height", sink, default);
+
+    [Fact]
+    public void Normal_resolves_to_keyword_zero()
+    {
+        var r = Resolve("normal");
+        Assert.True(r.IsResolved);
+        Assert.Equal(ComputedSlotTag.Keyword, r.Slot.Tag);
+        Assert.Equal(0, r.Slot.AsKeyword());
+    }
+
+    [Theory]
+    [InlineData("1.5", 1.5)]
+    [InlineData("2", 2.0)]
+    [InlineData("0", 0.0)]       // line-height: 0 is valid
+    [InlineData("1.25", 1.25)]
+    public void Unitless_number_resolves_to_number_slot(string value, double expected)
+    {
+        var r = Resolve(value);
+        Assert.True(r.IsResolved);
+        Assert.Equal(ComputedSlotTag.Number, r.Slot.Tag);
+        Assert.Equal(expected, r.Slot.AsNumber(), precision: 4);
+    }
+
+    [Theory]
+    [InlineData("24px", 24.0)]
+    [InlineData("18pt", 24.0)]   // 18pt = 24px (×4/3)
+    public void Absolute_length_resolves_to_lengthpx(string value, double expectedPx)
+    {
+        var r = Resolve(value);
+        Assert.True(r.IsResolved);
+        Assert.Equal(ComputedSlotTag.LengthPx, r.Slot.Tag);
+        Assert.Equal(expectedPx, r.Slot.AsLengthPx(), precision: 2);
+    }
+
+    [Fact]
+    public void Percentage_resolves_to_percentage_slot()
+    {
+        var r = Resolve("150%");
+        Assert.True(r.IsResolved);
+        Assert.Equal(ComputedSlotTag.Percentage, r.Slot.Tag);
+        Assert.Equal(150.0, r.Slot.AsPercentage(), precision: 3);
+    }
+
+    [Fact]
+    public void Em_length_defers_for_the_box_builder()
+    {
+        // A font-relative length can't fold at cascade time (font-size context is the box-builder's) —
+        // it stays Deferred raw for DeferredLengthResolver, which already lists PropertyId.LineHeight.
+        var r = Resolve("2em");
+        Assert.True(r.IsDeferred, $"expected 2em to defer; got {r.State}");
+        Assert.Equal("2em", r.RawText);
+    }
+
+    [Fact]
+    public void Negative_number_is_invalid_with_diagnostic()
+    {
+        var sink = new CapturingSink();
+        var r = Resolve("-1.5", sink);
+        Assert.True(r.IsInvalid);
+        Assert.NotEmpty(sink.Diagnostics);
+        Assert.Equal(CssDiagnosticCodes.CssPropertyValueInvalid001, sink.Diagnostics[0].Code);
+    }
+
+    [Fact]
+    public void Negative_length_is_invalid()
+    {
+        // line-height is a non-negative property (NonNegativeProperties) — LengthResolver rejects it.
+        var r = Resolve("-10px", new CapturingSink());
+        Assert.True(r.IsInvalid);
+    }
+}

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/PropertyDefaultsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/PropertyDefaultsParityTests.cs
@@ -170,6 +170,11 @@ public sealed class PropertyDefaultsParityTests
             // <percentage> → a Percentage slot — there is no "LengthPercentage" slot tag). The default
             // `baseline` resolves to Keyword(0); pre-cycle it returned UnsupportedUnvalidated.
             PropertyType.VerticalAlign,
+            // line-height cycle — LineHeight joined the resolved family via LineHeightResolver
+            // (`normal` → Keyword(0); a unitless <number> → a Number slot; <length>/<percentage> →
+            // LengthPx/Percentage). The default `normal` resolves to Keyword(0); pre-cycle it returned
+            // UnsupportedUnvalidated.
+            PropertyType.LineHeight,
         };
 
         var failures = new List<string>();
@@ -260,6 +265,9 @@ public sealed class PropertyDefaultsParityTests
             // vertical-align cycle — VerticalAlign is now wired (VerticalAlignResolver); its default
             // `baseline` resolves to Keyword(0), so it is NOT UnsupportedUnvalidated — exclude it.
             PropertyType.VerticalAlign,
+            // line-height cycle — LineHeight is now wired (LineHeightResolver); its default `normal`
+            // resolves to Keyword(0), so it is NOT UnsupportedUnvalidated — exclude it.
+            PropertyType.LineHeight,
         };
 
         var failures = new List<string>();

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/PropertyResolverDispatchTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/PropertyResolverDispatchTests.cs
@@ -94,15 +94,15 @@ public sealed class PropertyResolverDispatchTests
     [Fact]
     public void Unsupported_PropertyType_returns_UnsupportedUnvalidated_with_raw_text()
     {
-        // Per the hardening review: still-unwired cycle-2 PropertyTypes (LineHeight
+        // Per the hardening review: still-unwired cycle-2 PropertyTypes (Content
         // here) surface as UnsupportedUnvalidated — distinct from Deferred which
         // means "validated but needs context". The raw text rides along for the
-        // future resolver to pick up. (font-family resolved as of cycle 4.)
+        // future resolver to pick up. (line-height resolves as of the line-height cycle.)
         var sink = new CapturingSink();
-        var result = PropertyResolverDispatch.Resolve(PropertyId.LineHeight, "1.5", sink);
+        var result = PropertyResolverDispatch.Resolve(PropertyId.Content, "open-quote", sink);
         Assert.True(result.IsUnsupportedUnvalidated);
         Assert.False(result.IsDeferred);
-        Assert.Equal("1.5", result.RawText);
+        Assert.Equal("open-quote", result.RawText);
         Assert.Empty(sink.Diagnostics);
     }
 

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -46,6 +46,7 @@ public sealed class DeferralsParityTests
         "rtl-fragment-reversal",
         "text-align-match-parent",
         "line-height-percentage-inheritance",
+        "margin-box-line-height",
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",
         "inline-atomic-boxes",

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -45,6 +45,7 @@ public sealed class DeferralsParityTests
         "uax-24-script-detection",
         "rtl-fragment-reversal",
         "text-align-match-parent",
+        "line-height-percentage-inheritance",
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",
         "inline-atomic-boxes",

--- a/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
@@ -1388,6 +1388,44 @@ public sealed class BlockInlineIntegrationTests
         Assert.Equal(2, BaseDirectionBidiLevel(1));   // rtl base → "A" (L) lifted to level 2 (UAX #9 I2)
     }
 
+    [Theory]
+    [InlineData(0, false)]   // baseline — control: a 48px baseline run does NOT grow the line (mixed-font growth is separate)
+    [InlineData(6, true)]    // top      — grows the line to contain the 48px run
+    [InlineData(7, true)]    // bottom   — grows the line
+    [InlineData(5, true)]    // middle   — grows the line
+    [InlineData(3, true)]    // text-top — grows the line
+    public void Line_edge_vertical_align_grows_line_to_contain_tall_run(int valignKeyword, bool expectGrowth)
+    {
+        // PR 3 task 7 — a line-edge-aligned (top/bottom/middle/text-top/text-bottom) inline TEXT run TALLER
+        // than the baseline-sized line GROWS the line so it is CONTAINED (it previously overflowed — the
+        // PR #195 deferral). A 48px line-edge span on a 16px line (~19.2px) grows the line to ≥ ~40px; a
+        // 48px BASELINE span leaves the line at ~19.2 (the separate mixed-font-size growth is out of scope).
+        var sink = new RecordingFragmentSink();
+        using var resolver = new SyntheticShaperResolver();
+        var blockStyle = MakeStyle();   // default 16px font → ~19.2px line
+        var root = Box.CreateRoot(MakeStyle());
+        var block = Box.ForElement(BoxKind.BlockContainer, blockStyle, MakeElement());
+        block.AppendChild(Box.TextRun("A", MakeStyle()));
+        var spanStyle = MakeStyle();
+        spanStyle.Set(PropertyId.VerticalAlign, ComputedSlot.FromKeyword(valignKeyword));
+        spanStyle.Set(PropertyId.FontSize, ComputedSlot.FromLengthPx(48));
+        block.AppendChild(Box.TextRun("B", spanStyle));
+        root.AppendChild(block);
+        using var layouter = new BlockLayouter(root, sink, null, null, resolver);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var br = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, br, LayoutAttemptStrategy.Strict);
+        var fragment = Assert.Single(sink.Fragments);
+
+        if (expectGrowth)
+            Assert.True(fragment.BlockSize >= 40.0,
+                $"line-edge valign {valignKeyword} should grow the line to contain the 48px run; got {fragment.BlockSize}");
+        else
+            Assert.True(fragment.BlockSize < 25.0,
+                $"a baseline 48px run should leave the line baseline-sized (~19.2); got {fragment.BlockSize}");
+    }
+
     [Fact]
     public void Block_with_margin_border_padding_honors_box_model()
     {

--- a/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/BlockInlineIntegrationTests.cs
@@ -1427,6 +1427,42 @@ public sealed class BlockInlineIntegrationTests
     }
 
     [Fact]
+    public void Line_edge_growth_uses_the_runs_line_height_not_just_font_size()
+    {
+        // Post-PR-#197 review P2 — line-edge growth uses the run's INLINE-BOX height (its USED line-height),
+        // so a tall `line-height` (not only a large font-size) grows the line. A 16px-font `vertical-align:
+        // top` span with line-height:80px grows the line to ~80px; the same span with normal line-height
+        // (~19.2px) leaves a small line. (Pre-fix the growth used font-size only, so both gave ~16-19px.)
+        double LineSize(double spanLineHeightPx)
+        {
+            var sink = new RecordingFragmentSink();
+            using var resolver = new SyntheticShaperResolver();
+            var blockStyle = MakeStyle();
+            var root = Box.CreateRoot(MakeStyle());
+            var block = Box.ForElement(BoxKind.BlockContainer, blockStyle, MakeElement());
+            block.AppendChild(Box.TextRun("A", MakeStyle()));
+            var spanStyle = MakeStyle();
+            spanStyle.Set(PropertyId.VerticalAlign, ComputedSlot.FromKeyword(6));   // top
+            spanStyle.Set(PropertyId.FontSize, ComputedSlot.FromLengthPx(16));
+            if (spanLineHeightPx > 0)
+                spanStyle.Set(PropertyId.LineHeight, ComputedSlot.FromLengthPx(spanLineHeightPx));
+            block.AppendChild(Box.TextRun("B", spanStyle));
+            root.AppendChild(block);
+            using var layouter = new BlockLayouter(root, sink, null, null, resolver);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var layoutCtx = new LayoutContext(ctx);
+            using var br = new BreakResolver();
+            layouter.AttemptLayout(ctx, ref layoutCtx, br, LayoutAttemptStrategy.Strict);
+            return Assert.Single(sink.Fragments).BlockSize;
+        }
+
+        Assert.True(LineSize(80) >= 70.0,
+            $"line-height:80 + vertical-align:top should grow the line to ~80; got {LineSize(80)}");
+        Assert.True(LineSize(0) < 30.0,
+            $"the same 16px-font span at normal line-height should leave a small line; got {LineSize(0)}");
+    }
+
+    [Fact]
     public void Block_with_margin_border_padding_honors_box_model()
     {
         // Per Finding #5 — margin/border/padding/width applied to the

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
@@ -2720,30 +2720,62 @@ public sealed class FlexLayouterTests
 
     // -- F#1 (P2) — direction/writing-mode pipeline known gap -----------
 
-    [Fact(Skip = "PR 2 task 6 — FlexLayouter has not yet ADOPTED the direction pipeline; the shared reader " +
-        "(DirectionStyleExtensions.ReadDirection, added in task 4) exists, but the RTL row → main-axis flip is the " +
-        "remaining work. Tracked in flex-layouter-features deferral.")]
-    public void L5_known_gap_rtl_row_should_flip_main_axis_pending_flex_direction_adoption()
+    [Fact]
+    public void Rtl_row_flips_main_axis_like_row_reverse_ltr()
     {
-        // Per CSS Flexbox §3.1 axis-mapping: `row` in RTL writing mode
-        // means right-to-left (= same physical layout as `row-reverse`
-        // in LTR). With L5's LTR-only main-axis mapping, an RTL
-        // container with `flex-direction: row` would still emit items
-        // left-to-right (= InlineOffsets 0/50/100). When task 6 wires
-        // FlexLayouter to the direction pipeline, this test will pin the
-        // spec-correct behavior: items emitted in physical right-to-left
-        // order so DOM 0 lands at the right edge (= InlineOffset 350 for
-        // 3×50 items in 400px), DOM 1 at 300, DOM 2 at 250 — matching the
-        // current `row-reverse` LTR output for the same fixture.
-        //
-        // When task 6 lands (the pipeline ALREADY exists post-task-4):
-        //   1. Read the cascaded `direction` via DirectionStyleExtensions.
-        //      ReadDirection / IsRtl inside FlexLayouter.
-        //   2. The axis mapping switches from "row → inline left-to-
-        //      right" to "row → inline right-to-left" under RTL.
-        //   3. Drop this test's [Skip] + assert spec-correct offsets.
-        //   4. Remove the corresponding Missing bullet in
-        //      docs/deferrals.md#flex-layouter-features.
+        // PR 2 task 6 — `flex-direction: row` under `direction: rtl` reverses the physical main axis
+        // (CSS Flexbox §5.1: row main-start = inline-start = RIGHT in RTL), so it lays out identically to
+        // `row-reverse` under LTR: items in physical right-to-left order, DOM 0 at the right edge. For
+        // 3×50px items in 400px with default justify (flex-start) the flip transform yields DOM 0 → 350,
+        // DOM 1 → 300, DOM 2 → 250 (the same the row-reverse tests pin). And `row-reverse` under RTL flips
+        // BACK to left-to-right (0/50/100), proving `direction` XORs the reverse flag — not a one-way force.
+        static double[] InlineOffsets(int flexDirectionKeyword)
+        {
+            var sink = new RecordingFragmentSink();
+            using var shaper = new SyntheticShaperResolver();
+            var root = Box.CreateRoot(MakeStyle());
+            var flex = BuildFlexContainer();
+            flex.Style.Set(PropertyId.Direction, ComputedSlot.FromKeyword(1));   // rtl
+            flex.Style.Set(PropertyId.FlexDirection, ComputedSlot.FromKeyword(flexDirectionKeyword));
+            SetLengthPx(flex.Style, PropertyId.Height, 100);
+            var items = new Box[3];
+            for (var i = 0; i < items.Length; i++)
+            {
+                var style = MakeStyle();
+                SetLengthPx(style, PropertyId.Width, 50);
+                SetLengthPx(style, PropertyId.Height, 50);
+                items[i] = Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
+                flex.AppendChild(items[i]);
+            }
+            root.AppendChild(flex);
+            using var layouter = new BlockLayouter(
+                rootBox: root, sink: sink, incomingContinuation: null, diagnostics: null,
+                shaperResolver: shaper);
+            var ctx = new FragmentainerContext(contentInlineSize: 400, blockSize: 800);
+            var layoutCtx = new LayoutContext(ctx);
+            using var resolver = new BreakResolver();
+            layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+            var offsets = new double[items.Length];
+            for (var i = 0; i < items.Length; i++)
+            {
+                offsets[i] = double.NaN;
+                foreach (var f in sink.Fragments)
+                    if (f.Box == items[i]) { offsets[i] = f.InlineOffset; break; }
+            }
+            return offsets;
+        }
+
+        // `row` (keyword 0) under RTL → right-to-left, DOM 0 at the right edge (= row-reverse LTR).
+        var row = InlineOffsets(0);
+        Assert.Equal(350.0, row[0], precision: 3);
+        Assert.Equal(300.0, row[1], precision: 3);
+        Assert.Equal(250.0, row[2], precision: 3);
+
+        // `row-reverse` (keyword 1) under RTL → flips BACK to left-to-right (= plain row in LTR).
+        var rowReverse = InlineOffsets(1);
+        Assert.Equal(0.0, rowReverse[0], precision: 3);
+        Assert.Equal(50.0, rowReverse[1], precision: 3);
+        Assert.Equal(100.0, rowReverse[2], precision: 3);
     }
 
     // -- F#3 (P2) — reverse alignment matrix hardening ------------------

--- a/tests/NetPdf.UnitTests/Phase3/LineHeightReaderTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/LineHeightReaderTests.cs
@@ -12,25 +12,26 @@ namespace NetPdf.UnitTests.Phase3;
 /// line-height cycle — <c>ComputedStyle.ReadLineHeightPx</c> decodes the computed grammar that
 /// <c>LineHeightResolver</c> produces into the USED px the layouters + painter consume: a length →
 /// that px, a number → number × the element's font-size, a percentage → % of font-size, and
-/// <c>normal</c> / unset → 0 (the font-size × 1.2 fallback sentinel).
+/// <c>normal</c> / unset → <see langword="null"/> (the caller's font-size × 1.2 fallback). An EXPLICIT
+/// <c>0</c> / <c>0px</c> / <c>0%</c> returns <c>0.0</c> — distinct from <c>normal</c> — so a collapsed
+/// line box is honored (post-PR-#197 review P2).
 /// </summary>
 public sealed class LineHeightReaderTests
 {
     private static ComputedStyle Style() => ComputedStyle.RentForExclusiveTesting();
 
     [Fact]
-    public void Unset_returns_zero_sentinel()
+    public void Unset_returns_null_for_the_normal_fallback()
     {
-        // 0 = the `normal` sentinel — the caller falls back to font-size × 1.2.
-        Assert.Equal(0.0, Style().ReadLineHeightPx(16), precision: 4);
+        Assert.Null(Style().ReadLineHeightPx(16));
     }
 
     [Fact]
-    public void Normal_keyword_returns_zero_sentinel()
+    public void Normal_keyword_returns_null_for_the_normal_fallback()
     {
         var s = Style();
         s.Set(PropertyId.LineHeight, ComputedSlot.FromKeyword(0));   // normal
-        Assert.Equal(0.0, s.ReadLineHeightPx(16), precision: 4);
+        Assert.Null(s.ReadLineHeightPx(16));
     }
 
     [Fact]
@@ -38,8 +39,8 @@ public sealed class LineHeightReaderTests
     {
         var s = Style();
         s.Set(PropertyId.LineHeight, ComputedSlot.FromLengthPx(24));
-        Assert.Equal(24.0, s.ReadLineHeightPx(16), precision: 4);
-        Assert.Equal(24.0, s.ReadLineHeightPx(40), precision: 4);   // a length doesn't scale with font-size
+        Assert.Equal(24.0, s.ReadLineHeightPx(16)!.Value, precision: 4);
+        Assert.Equal(24.0, s.ReadLineHeightPx(40)!.Value, precision: 4);   // a length doesn't scale with font-size
     }
 
     [Theory]
@@ -50,7 +51,7 @@ public sealed class LineHeightReaderTests
     {
         var s = Style();
         s.Set(PropertyId.LineHeight, ComputedSlot.FromNumber(number));
-        Assert.Equal(expected, s.ReadLineHeightPx(fontSizePx), precision: 4);
+        Assert.Equal(expected, s.ReadLineHeightPx(fontSizePx)!.Value, precision: 4);
     }
 
     [Fact]
@@ -58,6 +59,39 @@ public sealed class LineHeightReaderTests
     {
         var s = Style();
         s.Set(PropertyId.LineHeight, ComputedSlot.FromPercentage(150));
-        Assert.Equal(24.0, s.ReadLineHeightPx(16), precision: 4);   // 150% × 16
+        Assert.Equal(24.0, s.ReadLineHeightPx(16)!.Value, precision: 4);   // 150% × 16
+    }
+
+    [Fact]
+    public void Percentage_recomputes_against_the_reading_font_size_deferral_pin()
+    {
+        // Deferral pin (`line-height-percentage-inheritance`) — a `<percentage>` line-height is resolved at
+        // READ time against the READING element's font-size, NOT inherited as a computed LENGTH from the
+        // declaring element (CSS Inline 3 §4.2). This pins the CURRENT approximation: the SAME 150% slot
+        // yields a DIFFERENT px per font-size, so a child that inherits the slot but has a different
+        // font-size diverges from spec. When the deferral is resolved (% → length at the declaring
+        // element, inherited as that length), the slot would no longer be a Percentage and this updates.
+        var s = Style();
+        s.Set(PropertyId.LineHeight, ComputedSlot.FromPercentage(150));
+        Assert.Equal(24.0, s.ReadLineHeightPx(16)!.Value, precision: 4);   // as if read at a 16px element
+        Assert.Equal(60.0, s.ReadLineHeightPx(40)!.Value, precision: 4);   // re-multiplied at a 40px element — divergent
+    }
+
+    [Fact]
+    public void Explicit_zero_is_distinct_from_normal_returning_0_not_null()
+    {
+        // Post-PR-#197 review P2 — a valid `line-height: 0` / `0px` / `0%` must collapse the line box,
+        // NOT silently fall back to font-size × 1.2. The reader returns 0.0 (non-null) for all three forms.
+        var asLength = Style(); asLength.Set(PropertyId.LineHeight, ComputedSlot.FromLengthPx(0));
+        var asNumber = Style(); asNumber.Set(PropertyId.LineHeight, ComputedSlot.FromNumber(0));
+        var asPercent = Style(); asPercent.Set(PropertyId.LineHeight, ComputedSlot.FromPercentage(0));
+
+        Assert.Equal(0.0, asLength.ReadLineHeightPx(16)!.Value, precision: 4);
+        Assert.Equal(0.0, asNumber.ReadLineHeightPx(16)!.Value, precision: 4);
+        Assert.Equal(0.0, asPercent.ReadLineHeightPx(16)!.Value, precision: 4);
+        // ... and all three are NON-null (a numeric sentinel couldn't tell explicit 0 from the default).
+        Assert.NotNull(asLength.ReadLineHeightPx(16));
+        Assert.NotNull(asNumber.ReadLineHeightPx(16));
+        Assert.NotNull(asPercent.ReadLineHeightPx(16));
     }
 }

--- a/tests/NetPdf.UnitTests/Phase3/LineHeightReaderTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/LineHeightReaderTests.cs
@@ -1,0 +1,63 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.Properties;
+using NetPdf.Layout.Layouters;
+using Xunit;
+
+namespace NetPdf.UnitTests.Phase3;
+
+/// <summary>
+/// line-height cycle — <c>ComputedStyle.ReadLineHeightPx</c> decodes the computed grammar that
+/// <c>LineHeightResolver</c> produces into the USED px the layouters + painter consume: a length →
+/// that px, a number → number × the element's font-size, a percentage → % of font-size, and
+/// <c>normal</c> / unset → 0 (the font-size × 1.2 fallback sentinel).
+/// </summary>
+public sealed class LineHeightReaderTests
+{
+    private static ComputedStyle Style() => ComputedStyle.RentForExclusiveTesting();
+
+    [Fact]
+    public void Unset_returns_zero_sentinel()
+    {
+        // 0 = the `normal` sentinel — the caller falls back to font-size × 1.2.
+        Assert.Equal(0.0, Style().ReadLineHeightPx(16), precision: 4);
+    }
+
+    [Fact]
+    public void Normal_keyword_returns_zero_sentinel()
+    {
+        var s = Style();
+        s.Set(PropertyId.LineHeight, ComputedSlot.FromKeyword(0));   // normal
+        Assert.Equal(0.0, s.ReadLineHeightPx(16), precision: 4);
+    }
+
+    [Fact]
+    public void Length_slot_returns_the_px_independent_of_font_size()
+    {
+        var s = Style();
+        s.Set(PropertyId.LineHeight, ComputedSlot.FromLengthPx(24));
+        Assert.Equal(24.0, s.ReadLineHeightPx(16), precision: 4);
+        Assert.Equal(24.0, s.ReadLineHeightPx(40), precision: 4);   // a length doesn't scale with font-size
+    }
+
+    [Theory]
+    [InlineData(1.5, 16, 24.0)]
+    [InlineData(2.0, 20, 40.0)]
+    [InlineData(1.0, 32, 32.0)]
+    public void Number_slot_multiplies_the_font_size(double number, double fontSizePx, double expected)
+    {
+        var s = Style();
+        s.Set(PropertyId.LineHeight, ComputedSlot.FromNumber(number));
+        Assert.Equal(expected, s.ReadLineHeightPx(fontSizePx), precision: 4);
+    }
+
+    [Fact]
+    public void Percentage_slot_is_a_fraction_of_font_size()
+    {
+        var s = Style();
+        s.Set(PropertyId.LineHeight, ComputedSlot.FromPercentage(150));
+        Assert.Equal(24.0, s.ReadLineHeightPx(16), precision: 4);   // 150% × 16
+    }
+}

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -930,16 +930,18 @@ public sealed class HtmlPdfConvertTests
     public void Inline_block_box_line_height_does_not_shift_its_block_contents_baseline()
     {
         // inline-block last-line baseline real metrics (post-PR-#194 task 2), end-to-end — an inline-block's
-        // OWN line-height doesn't apply to its BLOCK content, so it must NOT move the §10.8.1 baseline. The
-        // surrounding text "A" sits at the SAME y whether or not the inline-block declares line-height.
-        // Pre-fix the descent was read from the inline-block's own style, so line-height:40px wrongly
-        // shifted the line baseline (and "A" with it) though the content line was unchanged.
+        // baseline comes from its CONTENT's last line box, not the inline-block's OWN line-height. The inner
+        // block here pins its line-height EXPLICITLY (14px), so its line is 14px regardless of what the
+        // inline-block declares — and the surrounding "A" sits at the SAME y whether the inline-block's own
+        // line-height is 14px or 40px. (The inner pin matters now that the line-height cycle makes the value
+        // reach the computed style AND inherit — without it, a 40px inline-block line-height would inherit
+        // to the inner block and legitimately grow its line, which is a different effect than the one tested.)
         var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
-        double SurroundingTextY(string ibExtra) => FirstTd(Latin1(HtmlPdf.Convert(
-            "<!DOCTYPE html><html><body><div>A<span style=\"display:inline-block;" + ibExtra + "\">"
-            + "<div>x</div></span></div></body></html>", opts))).Y;
+        double SurroundingTextY(string ibLineHeight) => FirstTd(Latin1(HtmlPdf.Convert(
+            "<!DOCTYPE html><html><body><div>A<span style=\"display:inline-block;line-height:" + ibLineHeight + "\">"
+            + "<div style=\"line-height:14px\">x</div></span></div></body></html>", opts))).Y;
 
-        Assert.Equal(SurroundingTextY(""), SurroundingTextY("line-height:40px"), precision: 2);
+        Assert.Equal(SurroundingTextY("14px"), SurroundingTextY("40px"), precision: 2);
     }
 
     [Fact]
@@ -1062,6 +1064,34 @@ public sealed class HtmlPdfConvertTests
 
         Assert.True(textBottom > middle + 2, $"text-bottom should ride above middle: textBottom={textBottom} middle={middle}");
         Assert.True(middle > textTop + 2, $"middle should ride above text-top: middle={middle} textTop={textTop}");
+    }
+
+    [Fact]
+    public void Line_height_length_and_number_set_the_line_pitch_end_to_end()
+    {
+        // line-height cycle — a declared `line-height` now REACHES the computed style (pre-fix it was
+        // unwired in the dispatch → every value silently fell back to font-size × 1.2). A 2-line block
+        // (split by <br>) has a line PITCH (the Td-y delta between the two lines) equal to the used
+        // line-height. The control `normal` = font-size × 1.2; an absolute `24px` = 24 regardless of font;
+        // a unitless number = number × font-size. The synthetic font-size is derived from the control so
+        // the assertions don't hard-code it. Proves the resolver → ReadLineHeightPx → layouter/painter path.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        double Pitch(string style)
+        {
+            var ys = AllTdY(Latin1(HtmlPdf.Convert(
+                "<!DOCTYPE html><html><body><div style=\"" + style + "\">A<br>A</div></body></html>", opts)));
+            Assert.True(ys.Length >= 2, $"expected two lines (one Td each); got {ys.Length}");
+            return ys[0] - ys[1];   // y-up: the first line sits above the second; their delta is the pitch
+        }
+
+        var normal = Pitch("");   // control → font-size(16px) × 1.2 = 19.2px = 14.4pt (the Td-y is in PDF pt)
+        // A declared absolute length now REACHES the pitch (pre-fix: unwired → ignored). 40px = 30pt,
+        // and it scales linearly — a 20px length is exactly half — proving the length, not a fallback, drives it.
+        Assert.Equal(30.0, Pitch("line-height:40px"), precision: 1);
+        Assert.Equal(0.5 * Pitch("line-height:40px"), Pitch("line-height:20px"), precision: 1);
+        Assert.True(Pitch("line-height:40px") > normal + 5, $"a 40px line-height should exceed the normal pitch {normal}");
+        // A unitless number scales with the element's font-size — line-height:4 is exactly 2× line-height:2.
+        Assert.Equal(2.0 * Pitch("line-height:2"), Pitch("line-height:4"), precision: 1);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -1095,6 +1095,27 @@ public sealed class HtmlPdfConvertTests
     }
 
     [Fact]
+    public void Line_height_zero_collapses_the_line_pitch_end_to_end()
+    {
+        // Post-PR-#197 review P2 — a valid `line-height: 0` (and `0px`/`0%`) COLLAPSES the line box (the
+        // two <br>-split lines overlap, pitch 0) instead of silently falling back to font-size × 1.2. A
+        // plain numeric sentinel couldn't distinguish explicit 0 from `normal`; the nullable reader can.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        double Pitch(string style)
+        {
+            var ys = AllTdY(Latin1(HtmlPdf.Convert(
+                "<!DOCTYPE html><html><body><div style=\"" + style + "\">A<br>A</div></body></html>", opts)));
+            Assert.True(ys.Length >= 2, $"expected two lines; got {ys.Length}");
+            return ys[0] - ys[1];
+        }
+
+        Assert.Equal(0.0, Pitch("line-height:0"), precision: 1);    // explicit zero → collapsed
+        Assert.Equal(0.0, Pitch("line-height:0px"), precision: 1);  // 0px → collapsed
+        Assert.Equal(0.0, Pitch("line-height:0%"), precision: 1);   // 0% → collapsed
+        Assert.True(Pitch("") > 5, "the normal control should keep a positive pitch (≠ collapsed)");
+    }
+
+    [Fact]
     public void Vertical_align_on_a_block_or_cell_does_not_shift_its_own_text()
     {
         // text vertical-align inline-level gate — vertical-align applies to INLINE-LEVEL boxes. A

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -1036,25 +1036,32 @@ public sealed class HtmlPdfConvertTests
     [Fact]
     public void Text_vertical_align_middle_text_top_text_bottom_position_relative_to_the_parent()
     {
-        // text vertical-align line-edge cycle (post-PR-#194 task 3) — `middle` / `text-top` / `text-bottom`
-        // position a run relative to the PARENT's baseline + text content-area (the parent font's x-height
-        // / ascent / descent), so for a run whose font differs from the parent's they give DISTINCT glyph
-        // baselines, ordered (y-up) text-bottom > baseline > middle > text-top. A 40px span in a 16px
-        // block: text-bottom puts its BOTTOM at the parent descent (baseline highest), text-top its TOP at
-        // the parent ascent (baseline lowest), middle its midpoint at the parent baseline + half x-height.
+        // text vertical-align line-edge (post-PR-#194 task 3 + PR 3 task 7 line-growth) — `middle` /
+        // `text-top` / `text-bottom` position a run relative to the PARENT's baseline + text content-area.
+        // Task 7 now GROWS the line to contain a tall such run, which MOVES the shared line baseline — so the
+        // robust check compares the aligned 40px run against a SAME-LINE baseline 40px run (both share the
+        // grown line + its baseline), rather than across separate docs with differing line heights. y-up,
+        // the offset (aligned − same-line baseline) orders text-bottom > middle > text-top: text-bottom puts
+        // the run's BOTTOM at the parent descent (run rides highest), text-top its TOP at the parent ascent
+        // (run rides lowest), middle its midpoint at the parent baseline + half x-height.
         var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
-        double GlyphY(string valign) => FirstTd(Latin1(HtmlPdf.Convert(
-            "<!DOCTYPE html><html><body><div style=\"font-size:16px\">" +
-            "<span style=\"vertical-align:" + valign + ";font-size:40px\">A</span></div></body></html>", opts))).Y;
+        double Offset(string valign)
+        {
+            var ys = AllTdY(Latin1(HtmlPdf.Convert(
+                "<!DOCTYPE html><html><body><div style=\"font-size:16px\">" +
+                "<span style=\"font-size:40px\">A</span>" +                                // reference: 40px baseline
+                "<span style=\"vertical-align:" + valign + ";font-size:40px\">A</span>" +   // the aligned 40px run
+                "</div></body></html>", opts)));
+            Assert.True(ys.Length >= 2, $"expected two Td ops (reference + aligned); got {ys.Length}");
+            return ys[1] - ys[0];   // aligned − same-line baseline reference (content-stream / doc order)
+        }
 
-        var baseline = GlyphY("baseline");
-        var middle = GlyphY("middle");
-        var textTop = GlyphY("text-top");
-        var textBottom = GlyphY("text-bottom");
+        var middle = Offset("middle");
+        var textTop = Offset("text-top");
+        var textBottom = Offset("text-bottom");
 
-        Assert.True(textBottom > baseline + 2, $"text-bottom's baseline should sit above baseline's: textBottom={textBottom} baseline={baseline}");
-        Assert.True(baseline > middle + 2, $"baseline should sit above middle: baseline={baseline} middle={middle}");
-        Assert.True(middle > textTop + 2, $"middle should sit above text-top: middle={middle} textTop={textTop}");
+        Assert.True(textBottom > middle + 2, $"text-bottom should ride above middle: textBottom={textBottom} middle={middle}");
+        Assert.True(middle > textTop + 2, $"middle should ride above text-top: middle={middle} textTop={textTop}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The next three roadmap tasks in order — completing **PR 2 (direction/bidi)** and advancing **PR 3 (inline-text polish)**. Each task ships with unit + integration tests; LTR / default-value output stays byte-identical (no snapshot/golden/real-doc drift).

### Task 6 — RTL flex main-axis flip
`flex-direction: row` under `direction: rtl` reverses the physical main axis (CSS Flexbox §5.1: row main-start = inline-start = RIGHT in RTL). `FlexLayouter` adopts the direction pipeline (PR 2 task 4) and **XORs its existing `isReverse` flag** via `DirectionStyleExtensions.IsRtl` — so `row`+rtl lays out physically identically to `row-reverse`+ltr (right-to-left, DOM 0 at the right edge) and `row-reverse`+rtl flips back. Routing through the same `isReverse` path means flex-start/flex-end justify-content flips correctly too. Column directions (block main axis) are unaffected; LTR is byte-identical (the XOR only fires under RTL). Replaced the skipped stub test; **PR 2 is now complete.**

### Task 7 — line-edge `vertical-align` line growth
A line-edge-aligned text run (`top`/`bottom`/`middle`/`text-top`/`text-bottom`) **taller than the baseline-sized line** previously *overflowed* it (the PR #195 deferral). It now **grows the line**: new `InlineVerticalAlign.TextLineEdgeGrowth` returns `(Above, Below, Floor)` — `text-top`/`text-bottom`/`middle` grow the §10.8.1 max-ascent ascent/descent extents (mirroring the inline-atomic path), while `top`/`bottom` contribute a content-box height floor. The painter is unchanged in mechanism — it already positions line-edge runs via the *shared* `TextLineEdgeBaselineTopPx` using the per-line metrics layout emits, so growing the line makes the painter follow automatically.

### Task 8 — `line-height` cascade wiring
`line-height` was **unwired** in `PropertyResolverDispatch` — every value (`24px`, `1.5`, `150%`) fell through to `UnsupportedUnvalidated`, so a declared line-height *never reached the computed style* and layout/paint silently used font-size × 1.2. New `LineHeightResolver` resolves the full `normal | <number> | <length> | <percentage>` grammar (number → a `Number` multiplier slot inheriting AS the number; em/rem → Deferred raw the box-builder folds; % → a `Percentage` slot; `line-height` registered non-negative). New `ReadLineHeightPx` decodes the slot to used px, adopted by all four readers (BlockLayouter ×2, InlineVerticalAlign, TextPainter) so the reserved line and painted pitch agree.

## Tests
- **Task 6:** `Rtl_row_flips_main_axis_like_row_reverse_ltr` pins the XOR both ways (row+rtl → 350/300/250; row-reverse+rtl → 0/50/100).
- **Task 7:** a theory pinning a 48px line-edge run grows the line (≥40px) while a 48px baseline run doesn't; rewrote the PR#194 middle/text-* relative-positioning test to compare within one shared (now-grown) line.
- **Task 8:** `LineHeightResolver` unit (normal/number/length/%/em-defer/negative-invalid), `ReadLineHeightPx` reader unit, and a facade test proving a declared length/number sets the rendered line pitch vs the normal fallback. Migrated two "still-unwired example" tests onto `content`; fixed the inline-block-baseline test (line-height now inherits, which it couldn't when broken).

## Gates (all green)
0-warning Release · **7103 unit / 4 skip** · 30 LayoutSnapshots · 97 RealDocuments · PaginationGolden · RenderingCorpus · W3cConformance (smoke) · AOT/JIT parity (byte-identical) · determinism.

## Deferrals
Updated `flex-layouter-features` (row RTL shipped; column cross-axis + vertical modes remain), `inline-atomic-boxes` / `rtl-fragment-reversal` (line-edge growth shipped; line-height %-base fixed). Added `line-height-percentage-inheritance` (% should inherit as a computed length — divergent only across a font-size change). PROGRESS rolled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)