### PR TITLE
Phase 3 (tasks 9-11): justify-all <br> + inline-block per-run baseline · running-element nested blocks · string(name, start)/first-except

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,7 +2,7 @@
 
 > **Current state (2026-06-18):** Phase 3's layout + pagination **engine is feature-complete and multi-page rendering is live**. What's left to *finish* Phase 3 is (a) wiring W3C conformance **measurement**, (b) a curated **feature/polish backlog**, (c) **confirming** the perf/memory gates, and (d) the **`0.7.0-beta` release**. The recommended next step is **PR 1 — Conformance measurement** (see the roadmap).
 >
-> Active branch: `phase3-rtl-flex-vertalign-lineheight` — tasks 6–8 (RTL flex main-axis flip · line-edge `vertical-align` line growth · `line-height` length/number/% cascade wiring). PR 2 (direction/bidi, tasks 4–6) is now COMPLETE. PR 1 (conformance) still awaits Roland's approach decision; PR-3 task 9 (inline-block per-run baseline + justify-all on `<br>`) is the next remaining item. `git log --oneline -1` shows the exact commit.
+> Active branch: `phase3-tasks-9-10-11` — tasks 9 (justify-all on internal `<br>` + inline-block last-line per-run baseline) · 10 (running-element nested block layout — confirmed already done via the segment-style/container-bands cycles; deferral corrected) · 11 (`string(name, start)`/`first-except`; compound `@page` was already live). PRs 2–3 + parts of PR 4 now COMPLETE. PR 1 (conformance) still awaits Roland's approach decision. `git log --oneline -1` shows the exact commit.
 >
 > This file was consolidated from a 1.1 MB chronological log on 2026-06-18; the full per-subtask history is archived in [docs/progress-archive.md](docs/progress-archive.md). **Keep this file compact** — roll the roadmap as each PR lands; don't grow a blow-by-blow log here.
 
@@ -17,7 +17,7 @@
 | 4 | Visual parity (gradients, shadows, filters, SVG) | ⏸️ Not started |
 | 5 | Packaging + release | 🔵 Interleaved — layout→PDF wiring done |
 
-**Gates (all green, 2026-06-19):** 7103 unit / 4 skip · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
+**Gates (all green, 2026-06-19):** 7116 unit / 4 skip · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
 
 ## Phase 3 — what's shipped (consolidated)
 
@@ -65,12 +65,12 @@ Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order.
 ### PR 3 — Inline-text polish  [feature]
 7. ✅ Line-edge `vertical-align` line growth — a tall `top/bottom/middle/text-*` run now GROWS its line (`InlineVerticalAlign.TextLineEdgeGrowth`); the painter follows via the shared per-line metrics.
 8. ✅ `line-height` cascade wiring — `LineHeightResolver` + `ReadLineHeightPx` resolve the full `normal | <number> | <length> | <percentage>` grammar (was UNWIRED → silently font-size × 1.2). Residual: `%` inherit-as-length (`line-height-percentage-inheritance` deferral).
-9. inline-block per-run baseline metrics + justify-all on internal `<br>` lines — **remaining** (the next PR-3 task).
+9. ✅ inline-block per-run baseline metrics (`BufferingMeasureSink.DeepestLastLineRunStyle` — deepest last-line run drives the descent) + justify-all on internal `<br>` lines (lifts the §7.3 forced-break exception under justify-all).
 
 ### PR 4 — Paged-media completion  [feature]
-10. Running-element real nested **block** layout (sub-boxes, not flattened text).
-11. `string(name, start)` / `first-except` + compound `@page` selectors (e.g. `chapter:first`).
-12. Page-margin box overflow + container-relative units in margin-box / running content.
+10. ✅ Running-element nested **block** layout — already rendered via the segment-style + container-bands cycles (stacked lines per block child + wrapping + per-block own-style + decorated container bands); confirmed + deferral corrected. Residual: inline-level styling WITHIN a leaf block.
+11. ✅ `string(name, start)` / `first-except` (the page entry value; first-except empty when first == start) + compound `@page` selectors (`chapter:first` etc. — already live in the multi-page path; stale roadmap item). element() start/first-except stays deferred.
+12. Page-margin box overflow + container-relative units in margin-box / running content — **remaining** (next). Plus `margin-box-line-height` (deferral) + flex COLUMN cross-axis RTL.
 
 ### PR 5 — Perf + memory gates  [criteria 7–8]
 13. 3-page invoice ≤ 200 ms p50 benchmark gate (confirm it runs in CI).

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -372,17 +372,19 @@ grepping the ID).
     DescentBelowBaselinePx` — its TextMetricsStyle ?? box font + its real last-line height), so a
     nested-block inline-block with a different font-size / line-height is exact; with NO in-flow line box OR
     a computed `overflow` other than `visible` (the §10.8.1 exception) the baseline is the bottom margin
-    edge (the img-ish placement). Deferred: an inline SPAN overriding the font ON the last line (no per-RUN
-    metrics). The baseline still uses an approximate font ascent/descent (0.8 / −0.2 em — the layout layer
-    has no font-metric access; the painter uses the REAL metrics for glyphs, so an atomic aligns within
-    typical-font tolerance).
+    edge (the img-ish placement). An inline SPAN overriding the font ON the last line IS now honoured (PR-3
+    task 9 — `BufferingMeasureSink.DeepestLastLineRunStyle` scans the last line's slices for the deepest
+    run, a strict deepen-only refinement). The baseline still uses an approximate font ascent/descent
+    (0.8 / −0.2 em — the layout layer has no font-metric access; the painter uses the REAL metrics for
+    glyphs, so an atomic aligns within typical-font tolerance).
   - A `text-align: justify` line carrying an inline ATOMIC now DISTRIBUTES inter-word gaps AND shifts the
     atomic right by the gaps before it (the shared `InlineJustify` helper — the painter + the inline-atomic
-    placement can't disagree); `justify-all` justifies the LAST line too. Deferred: an internal
-    `<br>`-terminated line stays start-aligned even under justify-all. (center / right / end shift the atomic
-    — body text-align cycle; and the direction-relative `start`/`end` shift it to the RIGHT edge in an RTL
-    block — direction pipeline, PR 2 task 5. What remains: the atomic's bidi VISUAL ORDER within a
-    mixed-direction line is still document-order — see `rtl-fragment-reversal`.)
+    placement can't disagree); `justify-all` justifies the LAST line too AND every internal forced-break
+    (`<br>`)-terminated line (PR-3 task 9 — `justify-all` lifts the §7.3 forced-break exception; plain
+    `justify` still leaves a `<br>` line start-aligned). (center / right / end shift the atomic — body
+    text-align cycle; and the direction-relative `start`/`end` shift it to the RIGHT edge in an RTL block —
+    direction pipeline, PR 2 task 5. What remains: the atomic's bidi VISUAL ORDER within a mixed-direction
+    line is still document-order — see `rtl-fragment-reversal`.)
   - An inline-block's `auto` width shrink-to-fit uses the MAX-CONTENT measured at the available width (no
     separate min-content pass); deeply nested inline-blocks recurse through `NestedContentMeasurer` (bounded
     by document depth, not a dedicated cap); LTR horizontal-tb.
@@ -407,9 +409,10 @@ grepping the ID).
 - **Added** — Phase 3 Task 11 sub-cycle 1 review Finding #4; inline `<img>` first cut shipped in the
   inline-atomic-boxes cycle; inline-block first cut shipped in the inline-block cycle.
 - **Removal condition** — RTL bidi VISUAL ORDER honoured for inline atomics (the text-align alignment is
-  already honoured — PR 2 task 5; line-edge text line growth shipped — PR 3 task 7), the inline-block's
-  last-line baseline using true per-RUN content metrics + min-content shrink-to-fit, and inline-flex /
-  -grid / -table atomics laid out (no longer `LAYOUT-INLINE-ATOMIC-NOT-SUPPORTED-001`).
+  already honoured — PR 2 task 5; line-edge text line growth shipped — PR 3 task 7; last-line per-RUN
+  deepest-font metrics + justify-all on internal `<br>` shipped — PR 3 task 9), the inline-block's last-line
+  baseline min-content shrink-to-fit, and inline-flex / -grid / -table atomics laid out (no longer
+  `LAYOUT-INLINE-ATOMIC-NOT-SUPPORTED-001`).
 
 ---
 

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -3489,9 +3489,14 @@ flags the categories):
          granularity — the clip rect guarantees nothing paints outside the padding box, but a sliver of a
          partial line isn't painted), and clip-by-default INVERTS the spec initial (CSS Paged Media §6.2
          applies `overflow` to margin boxes with initial `visible` — page furniture spilling over the body
-         is near-always unwanted, so `visible` must be DECLARED to opt out). STILL deferred for `element()`: the running element's REAL
-         nested BLOCK LAYOUT (sub-boxes with their OWN decoration / margins — still FLATTENED text per direct
-         block child) + deep recursion (each direct block child → one line); the box/element being SEPARATELY-decorated
+         is near-always unwanted, so `visible` must be DECLARED to opt out). The running element's nested
+         BLOCK LAYOUT is now rendered (PR-3 task 10 — the segment-style + container-bands cycles): each
+         direct block child lays out on its OWN stacked line(s) with the block's OWN inherited style, its
+         text WRAPS within the box (post-PR-#154), per-segment margins / padding / line-heights apply, and a
+         decorated intermediate block paints its OWN background / border as a CONTAINER BAND over its
+         descendant lines. STILL deferred for `element()`: INLINE-LEVEL styling WITHIN a leaf block (a
+         `<b>`/`<span>` inside a block child is flattened to that block's own style — the capture records
+         per-block text + style, not per-inline-run); the box/element being SEPARATELY-decorated
          boxes (they COINCIDE — a box property overrides rather than nesting); only RELATIVE UNITS (`%`/`em`/
          `calc()`) in the element's style resolve against the page context (an approximation — exact for
          absolute font-size/color, and CSS-wide `inherit`/`initial` now resolved); the element's own `%`/`em`/`calc()`

--- a/src/NetPdf.Layout/Boxes/CssContentList.cs
+++ b/src/NetPdf.Layout/Boxes/CssContentList.cs
@@ -93,8 +93,10 @@ internal static class CssContentList
     /// FIRST assignment / running element (<c>string(name)</c> default + <c>string(name, first)</c>;
     /// <c>element(name)</c> default + <c>element(name, first)</c>); <see cref="NamedStrings"/> /
     /// <see cref="RunningElements"/> hold the LAST (the exit value — <c>string(name, last)</c> /
-    /// <c>element(name, last)</c>). The <c>start</c> / <c>first-except</c> keywords need cross-page context
-    /// and stay deferred.</para></summary>
+    /// <c>element(name, last)</c>); <see cref="NamedStringsStart"/> / <see cref="RunningElementsStart"/> hold
+    /// the page's ENTRY value (<c>string(name, start)</c>; <c>first-except</c> = first, empty when first ==
+    /// start). For <c>string()</c> all four positions resolve (PR-3 task 11); for <c>element()</c> the rich
+    /// render supports first/last and <c>start</c>/<c>first-except</c> stay deferred (occurrence-keyed).</para></summary>
     public readonly record struct MarginContentContext(
         IReadOnlyDictionary<string, string>? NamedStrings,
         IReadOnlyDictionary<string, string>? RunningElements,
@@ -116,7 +118,13 @@ internal static class CssContentList
         // segment range — PRE-order (outer before inner), so paint order nests correctly. First +
         // last occurrence, lockstep like the segments.
         IReadOnlyDictionary<string, IReadOnlyList<RunningContainer>>? RunningElementContainers = null,
-        IReadOnlyDictionary<string, IReadOnlyList<RunningContainer>>? RunningElementContainersFirst = null);
+        IReadOnlyDictionary<string, IReadOnlyList<RunningContainer>>? RunningElementContainersFirst = null,
+        // string(name, start) / element(name, start) — the page's ENTRY value (the named string carried
+        // IN from the prior page, before this page's own assignments). first-except compares first vs start.
+        // Distinct from First (first-on-page-or-carried) + Last (exit). The cross-page state is the
+        // collector's per-page carried map captured at the start of each page.
+        IReadOnlyDictionary<string, string>? NamedStringsStart = null,
+        IReadOnlyDictionary<string, string>? RunningElementsStart = null);
 
     /// <summary>One nested CONTAINER of a running element's content (container-bands cycle): an
     /// intermediate block-level element (between the running root and the leaf lines) carrying its
@@ -290,20 +298,20 @@ internal static class CssContentList
                 return false;
             }
 
-            // string(name [, first|last]) — Task 22 (+ the position keyword). Pulls the named string set
-            // by `string-set` (collected during the document walk). Only valid with a margin context
-            // (page-margin boxes); a missing/undefined name resolves to the empty string per CSS GCPM L3
-            // (no diagnostic). `first` (AND the no-keyword DEFAULT, per GCPM §7.3) → the FIRST assignment on
-            // the page; `last` → the exit value. The cross-page `start` / `first-except` keywords bail to
-            // unsupported (need the multi-page driver).
+            // string(name [, first|last|start|first-except]) — Task 22 + the position keyword (PR-3 task 11).
+            // Pulls the named string set by `string-set` (collected during the document walk). Only valid
+            // with a margin context (page-margin boxes); a missing/undefined name resolves to the empty
+            // string per CSS GCPM L3 (no diagnostic). `first` (AND the no-keyword DEFAULT, per GCPM §7.3) →
+            // the FIRST assignment on the page; `last` → the exit value; `start` → the page's ENTRY value;
+            // `first-except` → first, but empty when first == start. (start / first-except use the collector's
+            // per-page carried map.)
             if (StartsWithCaseInsensitive(span, i, "string("))
             {
                 var tokenStart = i;
                 i += "string(".Length;
-                if (marginContext is { } mcStr && TryReadPositionedFunction(span, ref i, out var stringName, out var first))
+                if (marginContext is { } mcStr && TryReadPositionedFunction(span, ref i, out var stringName, out var stringPos))
                 {
-                    var dict = first ? mcStr.NamedStringsFirst : mcStr.NamedStrings;
-                    var value = dict is { } ns && ns.TryGetValue(stringName, out var v) ? v : string.Empty;
+                    var value = ResolvePositionedString(stringPos, mcStr, stringName);
                     if (!TryAppendBounded(sb, value, sink, raw, location)) return false;
                     continue;
                 }
@@ -324,13 +332,16 @@ internal static class CssContentList
             {
                 var tokenStart = i;
                 i += "element(".Length;
-                if (marginContext is { } mcEl && TryReadPositionedFunction(span, ref i, out var elementName, out var elFirst))
+                if (marginContext is { } mcEl && TryReadPositionedFunction(span, ref i, out var elementName, out var elementPos)
+                    && elementPos is StringPosition.First or StringPosition.Last)
                 {
-                    var dict = elFirst ? mcEl.RunningElementsFirst : mcEl.RunningElements;
+                    var dict = elementPos == StringPosition.First ? mcEl.RunningElementsFirst : mcEl.RunningElements;
                     var value = dict is { } re && re.TryGetValue(elementName, out var v) ? v : string.Empty;
                     if (!TryAppendBounded(sb, value, sink, raw, location)) return false;
                     continue;
                 }
+                // element(name, start) / first-except stay deferred (the rich running-element rendering is
+                // occurrence-keyed) — bail to unsupported, as before.
                 EmitContentFunctionUnsupported(sink, span, tokenStart, raw, location);
                 return false;
             }
@@ -649,17 +660,18 @@ internal static class CssContentList
         return true;
     }
 
-    /// <summary>Parse a <c>string(…)</c> / <c>element(…)</c> argument list (the opening <c>(</c> already
-    /// consumed): a <c>&lt;custom-ident&gt;</c> + an optional GCPM position keyword. <paramref name="first"/>
-    /// is set <see langword="true"/> for <c>first</c> AND for NO keyword — per CSS GCPM L3 §7.3/§7.4
-    /// <c>first</c> is the DEFAULT (the first occurrence on the page) for both functions — and
-    /// <see langword="false"/> for an explicit <c>last</c> (the exit value). Returns <see langword="false"/>
-    /// (→ the caller bails to unsupported) for an empty/invalid name, the cross-page <c>start</c> /
-    /// <c>first-except</c> keywords (deferred), an unknown keyword, or malformed syntax.</summary>
-    private static bool TryReadPositionedFunction(ReadOnlySpan<char> span, ref int i, out string name, out bool first)
+    /// <summary>The position keyword of a <c>string()</c> / <c>element()</c> function (CSS GCPM §7.3/§7.4):
+    /// <c>first</c> (the default) / <c>last</c> / <c>start</c> (the page's ENTRY value, carried in from the
+    /// prior page before this page's assignments) / <c>first-except</c> (the first value, but the empty
+    /// string when it equals the start value — so a running header doesn't repeat unchanged at a page
+    /// boundary).</summary>
+    internal enum StringPosition { First, Last, Start, FirstExcept }
+
+    private static bool TryReadPositionedFunction(
+        ReadOnlySpan<char> span, ref int i, out string name, out StringPosition position)
     {
         name = string.Empty;
-        first = true; // GCPM default position keyword is `first`.
+        position = StringPosition.First; // GCPM default position keyword is `first`.
         i = SkipWhitespace(span, i);
         var start = i;
         while (i < span.Length)
@@ -687,15 +699,36 @@ internal static class CssContentList
                 i++;
             }
             var kw = span[kwStart..i];
-            if (kw.Equals("first", StringComparison.OrdinalIgnoreCase)) first = true;
-            else if (kw.Equals("last", StringComparison.OrdinalIgnoreCase)) first = false;
-            else return false; // start / first-except (cross-page) or unknown → bail
+            if (kw.Equals("first", StringComparison.OrdinalIgnoreCase)) position = StringPosition.First;
+            else if (kw.Equals("last", StringComparison.OrdinalIgnoreCase)) position = StringPosition.Last;
+            else if (kw.Equals("start", StringComparison.OrdinalIgnoreCase)) position = StringPosition.Start;
+            else if (kw.Equals("first-except", StringComparison.OrdinalIgnoreCase)) position = StringPosition.FirstExcept;
+            else return false; // unknown keyword → bail
             i = SkipWhitespace(span, i);
         }
 
         if (i >= span.Length || span[i] != ')') return false;
         i++; // consume ')'
         return true;
+    }
+
+    /// <summary>Resolve a positioned <c>string()</c> value (PR-3 task 11) against the page's margin context:
+    /// <c>First</c> (the first-on-page-or-carried) / <c>Last</c> (the exit) / <c>Start</c> (the page's ENTRY
+    /// value) / <c>FirstExcept</c> (= First, but the empty string when First equals Start — so a running
+    /// header doesn't repeat unchanged at a page boundary, GCPM §7.3). A missing name → empty.</summary>
+    private static string ResolvePositionedString(StringPosition position, in MarginContentContext mc, string name)
+    {
+        static string Get(IReadOnlyDictionary<string, string>? d, string n)
+            => d is { } dd && dd.TryGetValue(n, out var v) ? v : string.Empty;
+        return position switch
+        {
+            StringPosition.Last => Get(mc.NamedStrings, name),
+            StringPosition.Start => Get(mc.NamedStringsStart, name),
+            StringPosition.FirstExcept =>
+                Get(mc.NamedStringsFirst, name) is var f && f == Get(mc.NamedStringsStart, name)
+                    ? string.Empty : f,
+            _ => Get(mc.NamedStringsFirst, name),   // First / the no-keyword default
+        };
     }
 
     /// <summary>When <paramref name="raw"/> is a STANDALONE <c>element(&lt;name&gt; [, first | last])</c>
@@ -712,7 +745,11 @@ internal static class CssContentList
         var span = raw.AsSpan().Trim();
         if (!StartsWithCaseInsensitive(span, 0, "element(")) return false;
         var i = "element(".Length;
-        if (!TryReadPositionedFunction(span, ref i, out name, out first)) return false;
+        if (!TryReadPositionedFunction(span, ref i, out name, out var position)) return false;
+        // The rich (own-style) running-element render supports first / last only; start / first-except are
+        // occurrence-keyed and stay deferred — treat them as non-standalone so the text path bails (as before).
+        if (position is not (StringPosition.First or StringPosition.Last)) return false;
+        first = position == StringPosition.First;
         // STANDALONE — only whitespace may follow the close-paren (a mixed list keeps the box's style).
         while (i < span.Length)
         {

--- a/src/NetPdf.Layout/Boxes/MarginContentCollector.cs
+++ b/src/NetPdf.Layout/Boxes/MarginContentCollector.cs
@@ -27,9 +27,11 @@ namespace NetPdf.Layout.Boxes;
 /// <see cref="CssContentList.MarginContentContext"/> threaded to the margin-box painter.
 /// </para>
 /// <para>
-/// <b>First-cut scope (single page).</b> The CSS GCPM L3 cross-page "running" semantics (a named string
-/// / running element persists onto later pages until re-set) need the multi-page driver and are
-/// deferred. A <c>string-set</c> pair resolves literal strings + <c>attr()</c> + <c>content()</c> (via
+/// <b>Cross-page semantics are LIVE.</b> The CSS GCPM L3 carry-forward (a named string / running element
+/// persists onto later pages until re-set) is implemented by <see cref="CollectPerPage"/> — one context
+/// PER PAGE with first/last/start-on-page selection and entry-value carry-forward (cycles 5 / 5b);
+/// <see cref="Collect"/> is the single-page / whole-document case it short-circuits to. A
+/// <c>string-set</c> pair resolves literal strings + <c>attr()</c> + <c>content()</c> (via
 /// <see cref="CssContentList.TryParseStringSet(string, IElement, out string)"/>). <c>content()</c> (the element's own text — the common
 /// running-header form <c>h1 { string-set: title content() }</c>) works end-to-end: AngleSharp.Css DROPS a
 /// <c>string-set</c> whose value contains <c>content()</c> (an unknown function in an unknown property),
@@ -42,8 +44,10 @@ namespace NetPdf.Layout.Boxes;
 /// <c>text-align</c> (inherited values walked from ancestors, CSS-wide keywords resolved — post-PR-#151
 /// review P2 + post-PR-#153 review P2), plus the element's OWN (non-inherited) <c>background-color</c> +
 /// <c>border-*</c> + <c>padding-*</c> as the box decoration / box model (cascaded UNDER the box's own
-/// declarations) — all captured here by <see cref="CaptureOwnStyle"/>. The running element's nested BLOCK
-/// children (laid-out sub-boxes) stay deferred (deferrals.md).
+/// declarations) — all captured here by <see cref="CaptureOwnStyle"/>. A running element's nested BLOCK
+/// children render as STACKED segment lines (each its own style) with decorated container bands
+/// (segment-style / container-bands cycles); only real nested-block sub-box LAYOUT (separately laid-out
+/// boxes, per-segment <c>line-height</c>) stays deferred (deferrals.md).
 /// </para>
 /// </remarks>
 internal static class MarginContentCollector
@@ -134,16 +138,42 @@ internal static class MarginContentCollector
         }
 
         // Bucket the string-set assignments by the page their setting element laid out on (or its
-        // nearest rendered ancestor's page), preserving document order within a page.
-        List<(string Name, string Value)>[]? namedByPage = null;
+        // nearest rendered ancestor's page), preserving document order within a page. The setting
+        // ELEMENT is carried alongside so string(name, start) can test whether it begins the page
+        // (review P1) — see SetterBeginsPage below.
+        List<(string Name, string Value, IElement Element)>[]? namedByPage = null;
         if (c.NamedOrdered is not null)
         {
-            namedByPage = new List<(string Name, string Value)>[pageCount];
+            namedByPage = new List<(string Name, string Value, IElement Element)>[pageCount];
             foreach (var (element, name, value) in c.NamedOrdered)
             {
                 var p = ResolvePage(element, elementToPage);
                 if (p < 0 || p >= pageCount) continue;
-                (namedByPage[p] ??= new()).Add((name, value));
+                (namedByPage[p] ??= new()).Add((name, value, element));
+            }
+        }
+
+        // Document index (a single document-order walk) + the rendered elements grouped by page — for
+        // string(name, start)'s GCPM test (review P1): `start` uses a name's first assignment on the page
+        // ONLY when the assigning element BEGINS the page (otherwise it is the carried entry value). A
+        // setter begins the page when every element rendered on that page BEFORE it (in document order)
+        // is an ANCESTOR of it — so wrapping containers (<body>, a section) don't count as preceding
+        // content, but a sibling box above the setter does. A continuation (a container that started on an
+        // earlier page) maps to its FIRST page, so it isn't "on" this page and never blocks a top-of-page
+        // setter. Built only when there are named assignments to resolve start for (running element()
+        // start stays the carried entry — deferred).
+        Dictionary<IElement, int>? docIndex = null;
+        List<IElement>[]? elementsByPage = null;
+        if (namedByPage is not null)
+        {
+            docIndex = new Dictionary<IElement, int>();
+            var docCounter = 0;
+            AssignDocumentIndex(root, docIndex, ref docCounter);
+            elementsByPage = new List<IElement>[pageCount];
+            foreach (var (el, page) in elementToPage)
+            {
+                if (page < 0 || page >= pageCount) continue;
+                (elementsByPage[page] ??= new()).Add(el);
             }
         }
 
@@ -184,10 +214,30 @@ internal static class MarginContentCollector
         var carriedRunning = new Dictionary<string, RunningOccurrence>(StringComparer.Ordinal);
         for (var p = 0; p < pageCount; p++)
         {
-            // string(name, start) / element(name, start) (PR-3 task 11) — the page's ENTRY value: the carried
-            // maps AS THEY ARE before this page's own assignments (re)bind them below. For page 0 these are the
-            // initial empty maps (no entry value). first-except compares the first-on-page value against this.
-            var startNamed = carriedNamed;
+            // string(name, start) (PR-3 task 11 / review P1) — the page's ENTRY value (the carried map AS IT
+            // IS before this page's own assignments rebind it below), OVERRIDDEN per GCPM to a name's FIRST
+            // assignment on the page WHEN the assigning element is the first thing rendered on the page (the
+            // page "starts with" the setter). A mid-page setter changes `first`, not `start`; a page with no
+            // assignment keeps the carried entry value. first-except compares the first-on-page value against
+            // this start value (so a chapter-start page, where first == start, shows empty). element(name,
+            // start) stays the carried entry (deferred — the text path bails on it).
+            Dictionary<string, string> startNamed;
+            if (namedByPage?[p] is { Count: > 0 } startAssignments)
+            {
+                Dictionary<string, string>? startOverride = null;
+                var startSeen = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var (name, value, element) in startAssignments)
+                {
+                    if (!startSeen.Add(name)) continue;       // only each name's FIRST assignment on the page
+                    if (SetterBeginsPage(element, p, elementsByPage, docIndex))   // the page STARTS with the setter
+                        (startOverride ??= new Dictionary<string, string>(carriedNamed, StringComparer.Ordinal))[name] = value;
+                }
+                startNamed = startOverride ?? carriedNamed;   // no page-start setter → the entry value
+            }
+            else
+            {
+                startNamed = carriedNamed;   // no assignment → the entry value
+            }
             var startRun = carriedRunning;
 
             // Named strings (cycle 5). Reuse the carried map when the page sets nothing (Copilot — avoid
@@ -200,7 +250,7 @@ internal static class MarginContentCollector
                 lastNamed = new Dictionary<string, string>(carriedNamed, StringComparer.Ordinal);
                 firstNamed = new Dictionary<string, string>(carriedNamed, StringComparer.Ordinal);
                 var firstSet = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var (name, value) in assignments)
+                foreach (var (name, value, _) in assignments)
                 {
                     lastNamed[name] = value;                            // last-on-page wins
                     if (firstSet.Add(name)) firstNamed[name] = value;  // FIRST on page overrides carried
@@ -295,6 +345,41 @@ internal static class MarginContentCollector
             if (elementToPage.TryGetValue(el, out var p)) return p;
         }
         return -1;
+    }
+
+    /// <summary>Assign each element a monotonic DOCUMENT-ORDER index (depth-first, pre-order) into
+    /// <paramref name="docIndex"/> — used by <see cref="SetterBeginsPage"/> to order a string-set setter
+    /// against the other elements rendered on its page.</summary>
+    private static void AssignDocumentIndex(IElement element, Dictionary<IElement, int> docIndex, ref int counter)
+    {
+        docIndex[element] = counter++;
+        foreach (var child in element.Children)   // IElement children, document order
+            AssignDocumentIndex(child, docIndex, ref counter);
+    }
+
+    /// <summary><see langword="true"/> when <paramref name="setter"/> (a string-set element) BEGINS
+    /// <paramref name="page"/> — i.e. every element rendered on that page in document order BEFORE it is an
+    /// ANCESTOR of it (string(name, start)'s GCPM "the page starts with the setter" test, review P1). A
+    /// wrapping container (<c>&lt;body&gt;</c>, a section) that merely contains the setter does NOT count as
+    /// preceding content; a SIBLING box laid out above the setter does (so a mid-page setter fails this).
+    /// Continuations (a container that started on an earlier page) are mapped to their first page, so they
+    /// aren't in <paramref name="elementsByPage"/>[<paramref name="page"/>] and never block a top-of-page
+    /// setter.</summary>
+    private static bool SetterBeginsPage(
+        IElement setter, int page, List<IElement>[]? elementsByPage, Dictionary<IElement, int>? docIndex)
+    {
+        if (elementsByPage is null || docIndex is null) return false;
+        if (!docIndex.TryGetValue(setter, out var setterIdx)) return false;
+        if (elementsByPage[page] is not { } pageElements) return true;   // setter is the only thing on the page
+        foreach (var x in pageElements)
+        {
+            if (ReferenceEquals(x, setter)) continue;
+            // A non-ancestor element rendered before the setter on this page ⇒ the page does NOT start
+            // with the setter. (IsDescendantOf(setter, x) ⇔ x is an ancestor of the setter.)
+            if (docIndex.TryGetValue(x, out var xi) && xi < setterIdx && !IsDescendantOf(setter, x))
+                return false;
+        }
+        return true;
     }
 
     /// <summary>Walk the document in DOCUMENT ORDER assigning each element a monotonic index, recording the

--- a/src/NetPdf.Layout/Boxes/MarginContentCollector.cs
+++ b/src/NetPdf.Layout/Boxes/MarginContentCollector.cs
@@ -184,6 +184,12 @@ internal static class MarginContentCollector
         var carriedRunning = new Dictionary<string, RunningOccurrence>(StringComparer.Ordinal);
         for (var p = 0; p < pageCount; p++)
         {
+            // string(name, start) / element(name, start) (PR-3 task 11) — the page's ENTRY value: the carried
+            // maps AS THEY ARE before this page's own assignments (re)bind them below. For page 0 these are the
+            // initial empty maps (no entry value). first-except compares the first-on-page value against this.
+            var startNamed = carriedNamed;
+            var startRun = carriedRunning;
+
             // Named strings (cycle 5). Reuse the carried map when the page sets nothing (Copilot — avoid
             // the per-page Dictionary/HashSet allocations on pages with no assignments); copy-on-write only
             // when there are assignments to apply. The carried map is never mutated in place (a page that
@@ -227,6 +233,7 @@ internal static class MarginContentCollector
 
             var (firstText, firstStyles, firstSegs, firstConts) = ProjectRunningOccurrences(firstRun);
             var (lastText, lastStyles, lastSegs, lastConts) = ProjectRunningOccurrences(lastRun);
+            var (startText, _, _, _) = ProjectRunningOccurrences(startRun);   // string/element(name, start)
 
             contexts[p] = new CssContentList.MarginContentContext(
                 NamedStrings: lastNamed.Count > 0 ? lastNamed : null,
@@ -238,7 +245,9 @@ internal static class MarginContentCollector
                 RunningElementSegments: lastSegs,
                 RunningElementSegmentsFirst: firstSegs,
                 RunningElementContainers: lastConts,
-                RunningElementContainersFirst: firstConts);
+                RunningElementContainersFirst: firstConts,
+                NamedStringsStart: startNamed.Count > 0 ? startNamed : null,
+                RunningElementsStart: startText);
         }
         return contexts;
     }

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7321,16 +7321,16 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 ? Math.Max(0.0, (contentInlineSize - lines[li].TotalAdvance) * alignFactor)
                 : 0.0;
             // Per-line justify plan (the SAME gate + math as TextPainter): the LAST line justifies only
-            // under justify-all; a non-last line justifies unless it's forced-break-terminated (an
-            // internal <br> stays start-aligned even under justify-all — a documented approximation).
-            // The last line of a block carries EndsWithMandatoryBreak (content end), so it's gated on
-            // justifyLastLine, NOT the break flag. justify and center/right are mutually exclusive
+            // under justify-all; a non-last line justifies unless it's forced-break-terminated (an internal
+            // <br>) — EXCEPT under justify-all, which justifies EVERY line including forced-break ones
+            // (PR-3 task 9). The last line of a block carries EndsWithMandatoryBreak (content end), so it's
+            // gated on justifyLastLine, NOT the break flag. justify and center/right are mutually exclusive
             // (alignFactor is 0 for justify), so lineAlignOffsetPx is 0 and justifyAccumPx shifts the atomic.
             var isLastLine = li == lines.Length - 1;
             var justifyExtraPerGapPx = 0.0;
             var justifyGapCount = 0;
             if (justifies && justifyConcatText is not null
-                && (isLastLine ? justifyLastLine : !lines[li].EndsWithMandatoryBreak))
+                && (isLastLine ? justifyLastLine : (!lines[li].EndsWithMandatoryBreak || justifyLastLine)))
             {
                 justifyGapCount = NetPdf.Layout.Inline.InlineJustify.InteriorGapCount(
                     lines[li], shapedRuns, justifyConcatText);

--- a/src/NetPdf.Layout/Layouters/BufferingMeasureSink.cs
+++ b/src/NetPdf.Layout/Layouters/BufferingMeasureSink.cs
@@ -157,10 +157,17 @@ internal sealed class BufferingMeasureSink : IBlockFragmentSink
                 // 0.8/0.2-em approximation (ascent+descent)/2 = 0.3·fontSize — NOT the inline-block's OUTER
                 // font, so a nested-block inline-block with a different font-size / line-height stays exact.
                 var metricsStyle = fragment.TextMetricsStyle ?? style;
-                var lastLineFontSizePx = metricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
+                // Per-run last-line metrics (PR-3 task 9) — a SPAN that overrides the font ON the last line
+                // (a larger font-size, ≈ a deeper descender) deepens the inline-block's baseline. Use the
+                // DEEPEST run's style on the last line WHEN it is deeper than the fragment's metrics style
+                // (a strict deepen-only refinement, so the element()-running TextMetricsStyle case and the
+                // uniform-font case stay byte-identical). Was the box / metrics font only — a documented gap.
+                var metricsFontSizePx = metricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
+                var deepestStyle = DeepestLastLineRunStyle(inlineLayout, metricsFontSizePx) ?? metricsStyle;
+                var lastLineFontSizePx = deepestStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
                 var lastLineHeightPx = fragment.PerLineHeightsPx is { Count: > 0 } perLineHeights
                     ? perLineHeights[perLineHeights.Count - 1]
-                    : NetPdf.Layout.Inline.InlineVerticalAlign.OwnLineHeightPx(metricsStyle, lastLineFontSizePx);
+                    : NetPdf.Layout.Inline.InlineVerticalAlign.OwnLineHeightPx(deepestStyle, lastLineFontSizePx);
                 LastLineBoxDescentBelowBaselinePx =
                     fragment.PerLineBaselineTopPx is { Count: > 0 } baselines
                         && double.IsFinite(baselines[baselines.Count - 1])
@@ -187,6 +194,35 @@ internal sealed class BufferingMeasureSink : IBlockFragmentSink
         }
 
         _buffered.Add(fragment);
+    }
+
+    /// <summary>Per-run last-line metrics (PR-3 task 9) — the style of the DEEPEST run on
+    /// <paramref name="inline"/>'s LAST line (the largest font-size, ≈ the deepest descender), or
+    /// <see langword="null"/> when no last-line run is deeper than <paramref name="minFontSizePx"/> (so the
+    /// caller keeps its own metrics style — the deepen-only contract that preserves the uniform-font + the
+    /// element()-running cases). Walks the last line's slices → shaped runs → preprocessed source styles.</summary>
+    private static NetPdf.Css.ComputedValues.ComputedStyle? DeepestLastLineRunStyle(
+        NetPdf.Layout.Inline.InlineLayoutResult inline, double minFontSizePx)
+    {
+        var lines = inline.Lines;
+        if (lines.Length == 0) return null;
+        var lastLine = lines[lines.Length - 1];
+        NetPdf.Css.ComputedValues.ComputedStyle? deepest = null;
+        var deepestFontSizePx = minFontSizePx;
+        foreach (var slice in lastLine.Slices)
+        {
+            if (slice.ShapedRunIndex < 0 || slice.ShapedRunIndex >= inline.ShapedRuns.Count) continue;
+            var sourceIdx = inline.ShapedRuns[slice.ShapedRunIndex].Source.SourceTextRunIndex;
+            if (sourceIdx < 0 || sourceIdx >= inline.PreprocessedRuns.Count) continue;
+            var runStyle = inline.PreprocessedRuns[sourceIdx].Style;
+            var fs = runStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
+            if (fs > deepestFontSizePx)
+            {
+                deepestFontSizePx = fs;
+                deepest = runStyle;
+            }
+        }
+        return deepest;
     }
 
     public void RollbackTo(int cursor)

--- a/src/NetPdf.Layout/Layouters/BufferingMeasureSink.cs
+++ b/src/NetPdf.Layout/Layouters/BufferingMeasureSink.cs
@@ -157,13 +157,16 @@ internal sealed class BufferingMeasureSink : IBlockFragmentSink
                 // 0.8/0.2-em approximation (ascent+descent)/2 = 0.3·fontSize — NOT the inline-block's OUTER
                 // font, so a nested-block inline-block with a different font-size / line-height stays exact.
                 var metricsStyle = fragment.TextMetricsStyle ?? style;
-                // Per-run last-line metrics (PR-3 task 9) — a SPAN that overrides the font ON the last line
-                // (a larger font-size, ≈ a deeper descender) deepens the inline-block's baseline. Use the
-                // DEEPEST run's style on the last line WHEN it is deeper than the fragment's metrics style
-                // (a strict deepen-only refinement, so the element()-running TextMetricsStyle case and the
-                // uniform-font case stay byte-identical). Was the box / metrics font only — a documented gap.
+                // Per-run last-line metrics (PR-3 task 9; PR #198 review P2) — a run on the last line whose
+                // OWN used metrics imply a deeper descent below the baseline deepens the inline-block's
+                // baseline. The candidate is chosen by each run's USED DESCENT (its used line-height AND
+                // font-size: lineHeight/2 − 0.3·fontSize), not font-size alone — so a SAME-font run with a
+                // larger line-height (e.g. `font-size:16px; line-height:80px`) is caught too, not only a
+                // larger-font run. Strict deepen-only (override only when a run is deeper than the fragment's
+                // metrics style), so the element()-running TextMetricsStyle case and the uniform-font case
+                // stay byte-identical; a larger-font run still wins exactly as before (its descent is deeper).
                 var metricsFontSizePx = metricsStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
-                var deepestStyle = DeepestLastLineRunStyle(inlineLayout, metricsFontSizePx) ?? metricsStyle;
+                var deepestStyle = DeepestLastLineRunStyle(inlineLayout, metricsStyle, metricsFontSizePx) ?? metricsStyle;
                 var lastLineFontSizePx = deepestStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
                 var lastLineHeightPx = fragment.PerLineHeightsPx is { Count: > 0 } perLineHeights
                     ? perLineHeights[perLineHeights.Count - 1]
@@ -196,19 +199,23 @@ internal sealed class BufferingMeasureSink : IBlockFragmentSink
         _buffered.Add(fragment);
     }
 
-    /// <summary>Per-run last-line metrics (PR-3 task 9) — the style of the DEEPEST run on
-    /// <paramref name="inline"/>'s LAST line (the largest font-size, ≈ the deepest descender), or
-    /// <see langword="null"/> when no last-line run is deeper than <paramref name="minFontSizePx"/> (so the
-    /// caller keeps its own metrics style — the deepen-only contract that preserves the uniform-font + the
-    /// element()-running cases). Walks the last line's slices → shaped runs → preprocessed source styles.</summary>
+    /// <summary>Per-run last-line metrics (PR-3 task 9; PR #198 review P2) — the style of the run on
+    /// <paramref name="inline"/>'s LAST line with the DEEPEST descent below the baseline (computed from each
+    /// run's OWN used line-height AND font-size, not font-size alone), or <see langword="null"/> when no
+    /// last-line run is deeper than <paramref name="fallbackStyle"/> (so the caller keeps its own metrics
+    /// style — the deepen-only contract that preserves the uniform-font + the element()-running cases).
+    /// Selecting by used descent (rather than font-size) catches a same-font run with a larger line-height,
+    /// while a larger-font run still wins exactly as before (its descent is deeper). Walks the last line's
+    /// slices → shaped runs → preprocessed source styles.</summary>
     private static NetPdf.Css.ComputedValues.ComputedStyle? DeepestLastLineRunStyle(
-        NetPdf.Layout.Inline.InlineLayoutResult inline, double minFontSizePx)
+        NetPdf.Layout.Inline.InlineLayoutResult inline,
+        NetPdf.Css.ComputedValues.ComputedStyle fallbackStyle, double fallbackFontSizePx)
     {
         var lines = inline.Lines;
         if (lines.Length == 0) return null;
         var lastLine = lines[lines.Length - 1];
         NetPdf.Css.ComputedValues.ComputedStyle? deepest = null;
-        var deepestFontSizePx = minFontSizePx;
+        var deepestDescentPx = LastLineRunDescentBelowBaselinePx(fallbackStyle, fallbackFontSizePx);
         foreach (var slice in lastLine.Slices)
         {
             if (slice.ShapedRunIndex < 0 || slice.ShapedRunIndex >= inline.ShapedRuns.Count) continue;
@@ -216,14 +223,24 @@ internal sealed class BufferingMeasureSink : IBlockFragmentSink
             if (sourceIdx < 0 || sourceIdx >= inline.PreprocessedRuns.Count) continue;
             var runStyle = inline.PreprocessedRuns[sourceIdx].Style;
             var fs = runStyle.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16);
-            if (fs > deepestFontSizePx)
+            var descent = LastLineRunDescentBelowBaselinePx(runStyle, fs);
+            if (descent > deepestDescentPx)
             {
-                deepestFontSizePx = fs;
+                deepestDescentPx = descent;
                 deepest = runStyle;
             }
         }
         return deepest;
     }
+
+    /// <summary>A run's approximate descent below its baseline (px) from its USED line metrics —
+    /// <c>OwnLineHeightPx/2 − 0.3·fontSize</c> (the half-leading model: 0.2-em font descent + half the
+    /// leading), clamped ≥ 0. Drives the deepest-last-line-run selection so a larger line-height — not just a
+    /// larger font-size — can deepen the inline-block's §10.8.1 baseline.</summary>
+    private static double LastLineRunDescentBelowBaselinePx(
+        NetPdf.Css.ComputedValues.ComputedStyle style, double fontSizePx)
+        => System.Math.Max(0.0,
+            NetPdf.Layout.Inline.InlineVerticalAlign.OwnLineHeightPx(style, fontSizePx) / 2.0 - 0.3 * fontSizePx);
 
     public void RollbackTo(int cursor)
     {

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -241,8 +241,10 @@ internal static class ComputedStyleLayoutExtensions
     /// <summary>text-align: justify cycle — whether the LAST line justifies too (CSS Text 3 §7.3) —
     /// i.e. <c>text-align: justify-all</c>(7). <c>justify</c>(5) leaves the last line start-aligned (the
     /// §7.3 exception); <c>justify-all</c> justifies every line including the last. Lets <c>TextPainter</c>
-    /// (and the inline-atomic placement) lift the last-line gate. A forced-break-terminated line stays
-    /// start-aligned even under justify-all (a documented first-cut approximation).</summary>
+    /// (and the inline-atomic placement) lift the last-line gate. Under justify-all an INTERNAL
+    /// forced-break (<c>&lt;br&gt;</c>) line justifies too (PR-3 task 9 — the §7.3 forced-break exception is
+    /// lifted); the gate is keyed on the block's genuine LAST line (<c>isLastLine</c>), NOT the
+    /// mandatory-break flag, since a block's final line also carries that flag.</summary>
     public static bool ReadInlineJustifyAll(this ComputedStyle s) =>
         s.ReadKeywordOrDefault(PropertyId.TextAlign, defaultIndex: 0) is 7;
 

--- a/src/NetPdf/Rendering/TextPainter.cs
+++ b/src/NetPdf/Rendering/TextPainter.cs
@@ -374,18 +374,18 @@ internal static class TextPainter
                     : null;
 
             // text-align: justify (CSS Text 3 §7.3) — the LAST line justifies only under justify-all
-            // (JustifyLastLine); a non-last line justifies unless it's forced-break-terminated (an
-            // internal <br> stays start-aligned even under justify-all — a documented approximation). The
-            // LAST line of a block carries EndsWithMandatoryBreak (content end), so it's gated on
-            // JustifyLastLine, NOT the break flag. `gapCount` is the interior word-separator-space count
-            // (trailing spaces sort last → excluded; an inline ATOMIC is advance-only, not an opportunity —
-            // EmitJustifiedLine just advances past it, and the layout shifts the atomic by the same gaps);
-            // an overflowing line (free ≤ 0) isn't squeezed.
+            // (JustifyLastLine); a non-last line justifies unless it's forced-break-terminated (an internal
+            // <br>) — EXCEPT under justify-all, which justifies EVERY line including forced-break ones
+            // (PR-3 task 9; was a documented approximation). The LAST line of a block carries
+            // EndsWithMandatoryBreak (content end), so it's gated on JustifyLastLine, NOT the break flag.
+            // `gapCount` is the interior word-separator-space count (trailing spaces sort last → excluded;
+            // an inline ATOMIC is advance-only, not an opportunity — EmitJustifiedLine just advances past
+            // it, and the layout shifts the atomic by the same gaps); an overflowing line (free ≤ 0) isn't squeezed.
             var isLastLine = li == lines.Length - 1;
             var justifyExtraPerGapPx = 0.0;
             var justifyGapCount = 0;
             if (fragment.JustifyLines && concatText is not null
-                && (isLastLine ? fragment.JustifyLastLine : !line.EndsWithMandatoryBreak)
+                && (isLastLine ? fragment.JustifyLastLine : (!line.EndsWithMandatoryBreak || fragment.JustifyLastLine))
                 && (justifyGapCount = InlineJustify.InteriorGapCount(line, shapedRuns, concatText)) > 0)
             {
                 var freePx = contentInlineSizePx - insetLeftPx - insetRightPx - line.TotalAdvance;

--- a/tests/NetPdf.UnitTests/Layout/Boxes/CssContentListTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/Boxes/CssContentListTests.cs
@@ -219,9 +219,10 @@ public sealed class CssContentListTests
 
     private static CssContentList.MarginContentContext Ctx(
         (string Key, string Value)[]? named = null, (string Key, string Value)[]? running = null,
-        (string Key, string Value)[]? namedFirst = null, (string Key, string Value)[]? runningFirst = null)
+        (string Key, string Value)[]? namedFirst = null, (string Key, string Value)[]? runningFirst = null,
+        (string Key, string Value)[]? namedStart = null)
     {
-        Dictionary<string, string>? n = null, r = null, nf = null, rf = null;
+        Dictionary<string, string>? n = null, r = null, nf = null, rf = null, ns = null;
         if (named is not null) { n = new(); foreach (var (k, v) in named) n[k] = v; }
         if (running is not null) { r = new(); foreach (var (k, v) in running) r[k] = v; }
         // Mirror the collector: a single assignment / element sets BOTH first + last. When a test supplies
@@ -229,7 +230,8 @@ public sealed class CssContentListTests
         // `first` default resolves for string() AND element().
         if (namedFirst is not null) { nf = new(); foreach (var (k, v) in namedFirst) nf[k] = v; } else nf = n;
         if (runningFirst is not null) { rf = new(); foreach (var (k, v) in runningFirst) rf[k] = v; } else rf = r;
-        return new CssContentList.MarginContentContext(n, r, nf, rf);
+        if (namedStart is not null) { ns = new(); foreach (var (k, v) in namedStart) ns[k] = v; }
+        return new CssContentList.MarginContentContext(n, r, nf, rf, NamedStringsStart: ns);
     }
 
     [Fact]
@@ -247,14 +249,39 @@ public sealed class CssContentListTests
     }
 
     [Theory]
-    [InlineData("string(t, start)")]         // cross-page → deferred (needs the multi-page driver)
-    [InlineData("string(t, first-except)")]  // niche GCPM keyword → deferred
-    [InlineData("string(t, bogus)")]         // unknown keyword
-    public async Task String_function_unsupported_position_keyword_bails(string raw)
+    [InlineData("string(t, bogus)")]     // unknown keyword → still unsupported
+    [InlineData("string(t, firstexcept)")]   // missing hyphen → not a known keyword
+    public async Task String_function_unknown_position_keyword_bails(string raw)
     {
         var host = await MakeHost("<p id='h'>x</p>", "h");
         var ctx = Ctx(named: new[] { ("t", "v") }, namedFirst: new[] { ("t", "v") });
         Assert.False(CssContentList.TryParse(raw, host, new CssContentList.PageCounters(1, 1), ctx, out _));
+    }
+
+    [Fact]
+    public async Task String_function_start_keyword_reads_the_page_entry_value()
+    {
+        // string(name, start) (PR-3 task 11) — the value at the START of the page (carried in from the prior
+        // page), DISTINCT from `first` (first-on-page-or-carried) and `last` (the exit value).
+        var host = await MakeHost("<p id='h'>x</p>", "h");
+        var ctx = Ctx(named: new[] { ("t", "last") }, namedFirst: new[] { ("t", "first") },
+            namedStart: new[] { ("t", "start") });
+        Assert.True(CssContentList.TryParse("string(t, start)", host, new CssContentList.PageCounters(1, 1), ctx, out var s));
+        Assert.Equal("start", s);
+    }
+
+    [Fact]
+    public async Task String_function_first_except_is_empty_when_first_equals_start()
+    {
+        // string(name, first-except) (PR-3 task 11) — = `first`, but the EMPTY string when first == start
+        // (so a running header doesn't repeat unchanged at a page boundary, GCPM §7.3).
+        var host = await MakeHost("<p id='h'>x</p>", "h");
+        var same = Ctx(namedFirst: new[] { ("t", "v") }, namedStart: new[] { ("t", "v") });  // first == start
+        Assert.True(CssContentList.TryParse("string(t, first-except)", host, new CssContentList.PageCounters(1, 1), same, out var e));
+        Assert.Equal("", e);
+        var changed = Ctx(namedFirst: new[] { ("t", "new") }, namedStart: new[] { ("t", "old") });  // first != start
+        Assert.True(CssContentList.TryParse("string(t, first-except)", host, new CssContentList.PageCounters(1, 1), changed, out var c));
+        Assert.Equal("new", c);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Layout/Boxes/MarginContentCollectorTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/Boxes/MarginContentCollectorTests.cs
@@ -167,6 +167,71 @@ public sealed class MarginContentCollectorTests
     }
 
     [Fact]
+    public async Task CollectPerPage_start_uses_the_first_assignment_when_the_setter_begins_the_page()
+    {
+        // PR #198 review P1 — string(name, start) uses the page's FIRST assignment WHEN the assigning
+        // element is the FIRST thing rendered on the page (GCPM "the page starts with the setter"). #h sets
+        // title="B" and is the document-order-first rendered element on page 1, so start = "B" — NOT the
+        // (empty) carried entry value the pre-fix code always returned.
+        var (doc, resolved) = await ResolveAsync(
+            "<html><body><p id='p0'>x</p><h1 id='h'>B</h1><p id='p1'>y</p></body></html>",
+            "#h { string-set: title \"B\" }");
+        var map = new System.Collections.Generic.Dictionary<IElement, int>
+        {
+            [doc.QuerySelector("#p0")!] = 0,
+            [doc.QuerySelector("#h")!] = 1,    // the setter is the first rendered element on page 1
+            [doc.QuerySelector("#p1")!] = 1,
+        };
+        var pages = MarginContentCollector.CollectPerPage(doc.DocumentElement!, resolved, map, pageCount: 2);
+
+        Assert.Equal("B", pages[1].NamedStringsStart?["title"]);   // page STARTS with the setter → start = "B"
+        Assert.Equal("B", pages[1].NamedStringsFirst?["title"]);   // first-on-page is also "B"
+    }
+
+    [Fact]
+    public async Task CollectPerPage_start_keeps_the_entry_value_for_a_mid_page_setter()
+    {
+        // PR #198 review P1 — a setter that is NOT the first element on the page changes `first`, not
+        // `start`. #p1a renders first on page 1, THEN #h sets title="B"; so string(title, start) is the page
+        // ENTRY value (here the empty carried value, since page 0 set nothing), while string(title) reads the
+        // mid-page "B".
+        var (doc, resolved) = await ResolveAsync(
+            "<html><body><p id='p0'>x</p><p id='p1a'>y</p><h2 id='h'>B</h2></body></html>",
+            "#h { string-set: title \"B\" }");
+        var map = new System.Collections.Generic.Dictionary<IElement, int>
+        {
+            [doc.QuerySelector("#p0")!] = 0,
+            [doc.QuerySelector("#p1a")!] = 1,   // renders FIRST on page 1 (before the setter)
+            [doc.QuerySelector("#h")!] = 1,
+        };
+        var pages = MarginContentCollector.CollectPerPage(doc.DocumentElement!, resolved, map, pageCount: 2);
+
+        Assert.Null(pages[1].NamedStringsStart);                   // entry value (empty) — the page didn't start with the setter
+        Assert.Equal("B", pages[1].NamedStringsFirst?["title"]);   // but first-on-page IS the mid-page "B"
+    }
+
+    [Fact]
+    public async Task CollectPerPage_start_carries_the_entry_value_onto_a_page_that_sets_nothing()
+    {
+        // PR #198 review P1 — on a page with NO assignment, string(title, start) is the value at the end of
+        // the prior page (the entry value), carried forward. #a sets title="A" and begins page 0; page 1
+        // sets nothing, so its start (and first) is the carried "A".
+        var (doc, resolved) = await ResolveAsync(
+            "<html><body><h1 id='a'>A</h1><p id='p0'>x</p><p id='p1'>y</p></body></html>",
+            "#a { string-set: title \"A\" }");
+        var map = new System.Collections.Generic.Dictionary<IElement, int>
+        {
+            [doc.QuerySelector("#a")!] = 0,
+            [doc.QuerySelector("#p0")!] = 0,
+            [doc.QuerySelector("#p1")!] = 1,
+        };
+        var pages = MarginContentCollector.CollectPerPage(doc.DocumentElement!, resolved, map, pageCount: 2);
+
+        Assert.Equal("A", pages[0].NamedStringsStart?["title"]);   // page 0 begins with the setter #a → "A"
+        Assert.Equal("A", pages[1].NamedStringsStart?["title"]);   // page 1 sets nothing → carried entry "A"
+    }
+
+    [Fact]
     public async Task CollectPerPage_buckets_running_elements_per_page_cycle5b()
     {
         // Cycle 5b — cross-page element() running content. Two `position: running(rh)` headings, each in

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -3599,6 +3599,24 @@ public sealed class HtmlPdfConvertTests
     }
 
     [Fact]
+    public void Running_element_with_block_children_renders_stacked_nested_lines_not_flattened()
+    {
+        // PR-3 task 10 — a `position: running()` element with BLOCK-level children renders its children as
+        // SEPARATE STACKED lines (real nested block layout via the segment-style + container-bands cycles),
+        // NOT one flattened text line. Three block children → three Td lines, each laid out on its own
+        // baseline; long text within a block also wraps (post-PR-#154). A nested container's OWN decoration
+        // (a background band) paints as a rect over its descendant lines — the structure, not flat text.
+        var result = HtmlPdf.ConvertDetailed(
+            "<!DOCTYPE html><html><head><style>.rh { position: running(rh) } " +
+            "@page { @top-center { content: element(rh) } }</style></head>" +
+            "<body><div class=\"rh\"><div style=\"background-color:red\">P</div><div>Q</div><div>R</div></div></body></html>",
+            new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() });
+        var pdf = Latin1(result.Pdf);
+        Assert.Equal(3, TdCount(pdf));               // 3 block children → 3 stacked lines (not 1 flattened)
+        Assert.Contains(" re", pdf);                 // the decorated child paints a background band (nested decoration)
+    }
+
+    [Fact]
     public void Page_margin_box_fitting_content_emits_no_clip_path()
     {
         // A box whose content fits carries no clip rect — its stream must stay clip-free

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -3688,7 +3688,11 @@ public sealed class HtmlPdfConvertTests
             new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() });
         var pdf = Latin1(result.Pdf);
         Assert.Equal(3, TdCount(pdf));               // 3 block children → 3 stacked lines (not 1 flattened)
-        Assert.Contains(" re", pdf);                 // the decorated child paints a background band (nested decoration)
+        // The decorated child paints a FILLED red background band (nested decoration). Assert the red fill
+        // color AND a rectangle FILL (`re f`), not a bare `re` — a clip-path emits `re W n`, so `re` alone
+        // wouldn't prove the band actually painted (Copilot review).
+        Assert.Contains("1 0 0 rg", pdf);            // red fill color (background-color:red)
+        Assert.Contains("re f", pdf);                // a filled rectangle — the band, not a clip-path `re W n`
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -989,6 +989,28 @@ public sealed class HtmlPdfConvertTests
     }
 
     [Fact]
+    public void Inline_block_last_line_baseline_reflects_a_line_height_overriding_span()
+    {
+        // PR #198 review P2 — the last-line deepest-run selection keys on USED DESCENT (line-height AND
+        // font-size), not font-size alone: a SAME-font span with a much larger line-height on the LAST line
+        // deepens the §10.8.1 descent (more half-leading below the baseline), shifting the inline-block's
+        // baseline and the surrounding "A" aligned to it. Moving the same line-height:80px span from line 1
+        // to the LAST line therefore changes the result — font-size-only selection (the pre-fix behavior)
+        // missed a same-font, larger-line-height run.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        double SurroundingY(string ibContent) => FirstTd(Latin1(HtmlPdf.Convert(
+            "<!DOCTYPE html><html><body><div>A<span style=\"display:inline-block\">" + ibContent
+            + "</span></div></body></html>", opts))).Y;
+
+        // Same glyphs + same font-size; only WHICH line carries the line-height:80px span differs.
+        var tallFirst = SurroundingY("<span style=\"line-height:80px\">y</span><br>x");  // tall lh on line 1
+        var tallLast = SurroundingY("x<br><span style=\"line-height:80px\">y</span>");   // tall lh on the LAST line
+
+        Assert.True(System.Math.Abs(tallFirst - tallLast) > 1.0,
+            $"the LAST line's used line-height should drive the inline-block baseline: tallFirst={tallFirst} tallLast={tallLast}");
+    }
+
+    [Fact]
     public void Vertical_align_top_places_an_inline_block_differently_than_baseline()
     {
         // vertical-align cycle (CSS 2.2 §10.8.1) — end-to-end: a `vertical-align` keyword now resolves
@@ -2085,6 +2107,59 @@ public sealed class HtmlPdfConvertTests
         var runs = GlyphRuns(Latin1(result.Pdf));
         Assert.Equal(2, runs.Count);            // one header per page
         Assert.NotEqual(runs[0], runs[1]);       // page 1 "AA" (rh=A) ≠ page 2 "AB" (rh=B)
+    }
+
+    [Fact]
+    public void Multi_page_string_start_uses_the_page_start_setter_and_carries_forward()
+    {
+        // PR #198 review P1/P2 — string(name, start) end-to-end across pages. The .chap div sets title="A"
+        // and is the FIRST element on page 1, so `start` there is "A" (the page STARTS with the setter — not
+        // the empty entry value the pre-fix code returned); page 2 has no setter, so its `start` is the
+        // carried "A". The header content "Z" string(title, start) is therefore "ZA" (2 glyphs) on BOTH
+        // pages. (Pre-fix, page 1's start was the empty entry → "Z", so the two headers differed.)
+        var result = HtmlPdf.ConvertDetailed(
+            "<!DOCTYPE html><html><head><style>" +
+            "@page { @top-center { content: \"Z\" string(title, start) } }" +
+            ".chap { string-set: title \"A\"; height: 50px }" +
+            ".fill { height: 600px }" +
+            "</style></head><body>" +
+            "<div class=\"chap\"></div><div class=\"fill\"></div><div class=\"fill\"></div>" +
+            "</body></html>",
+            new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() });
+
+        Assert.Equal(2, result.PageCount);
+        var runs = GlyphRuns(Latin1(result.Pdf));
+        Assert.Equal(2, runs.Count);              // one header per page
+        Assert.Equal(8, runs[0].Length);          // page 1 "ZA" — start picks up the page-start setter (2 glyphs × 4 hex)
+        Assert.Equal(runs[0], runs[1]);           // page 2 carries the same start value → identical header
+    }
+
+    [Fact]
+    public void Multi_page_first_except_header_is_empty_on_the_chapter_start_page()
+    {
+        // PR #198 review P1/P2 — string(name, first-except) end-to-end. On a page that STARTS with the
+        // assigning element, first == start, so first-except is the EMPTY string (the chapter title isn't
+        // repeated in the header on the page whose top already shows the heading); a pure continuation page
+        // suppresses it too (nothing changed). Plain string(title) DOES show "A" on both pages, proving the
+        // value is resolvable and first-except specifically suppresses it. (Pre-fix `start` was the empty
+        // entry on page 1, so first-except there wrongly showed "A".)
+        const string doc =
+            "<!DOCTYPE html><html><head><style>" +
+            "@page {{ @top-center {{ content: \"Z\" string(title{0}) }} }}" +
+            ".chap {{ string-set: title \"A\"; height: 50px }}" +
+            ".fill {{ height: 600px }}" +
+            "</style></head><body>" +
+            "<div class=\"chap\"></div><div class=\"fill\"></div><div class=\"fill\"></div>" +
+            "</body></html>";
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+
+        var firstExcept = GlyphRuns(Latin1(HtmlPdf.Convert(string.Format(doc, ", first-except"), opts)));
+        var plainFirst = GlyphRuns(Latin1(HtmlPdf.Convert(string.Format(doc, ""), opts)));
+
+        Assert.Equal(2, firstExcept.Count);
+        Assert.All(firstExcept, r => Assert.Equal(4, r.Length));   // each header just "Z" — title suppressed (1 glyph)
+        Assert.Equal(2, plainFirst.Count);
+        Assert.All(plainFirst, r => Assert.Equal(8, r.Length));    // plain string(title) shows "ZA" on both pages
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -885,6 +885,29 @@ public sealed class HtmlPdfConvertTests
     }
 
     [Fact]
+    public void Justify_all_justifies_an_internal_br_terminated_line()
+    {
+        // PR-3 task 9 (CSS Text 3 §7.3) — `justify-all` justifies EVERY line including a forced-break
+        // (<br>)-terminated one; plain `justify` leaves a <br>-terminated line start-aligned (the §7.3
+        // exception, like the last line). Here the first line "A A A" ends in a <br> (an INTERNAL forced
+        // break, NOT the last line — "Z" is), so its words spread to the right edge only under justify-all.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        static string Doc(string align) =>
+            "<!DOCTYPE html><html><body><div style=\"width:600px;text-align:" + align + "\">A A A<br>Z</div></body></html>";
+
+        var justify = Latin1(HtmlPdf.Convert(Doc("justify"), opts));
+        var justifyAll = Latin1(HtmlPdf.Convert(Doc("justify-all"), opts));
+
+        // Under plain justify the <br> line stays start-aligned (§7.3 forced-break exception); under
+        // justify-all it justifies — so its words split into per-word Td segments AND its last word is
+        // pushed toward the right edge.
+        Assert.True(TdCount(justifyAll) > TdCount(justify),
+            $"justify-all should split the internal <br> line into per-word segments: all={TdCount(justifyAll)} justify={TdCount(justify)}");
+        Assert.True(MaxTdX(justifyAll) > MaxTdX(justify) + 5.0,
+            $"justify-all should push the <br> line's last word right: all={MaxTdX(justifyAll)} justify={MaxTdX(justify)}");
+    }
+
+    [Fact]
     public void Justify_keeps_text_on_the_layout_pinned_baseline()
     {
         // text-align: justify pinned-baseline (post-PR-#195 review P1) — when a justified line carries a
@@ -942,6 +965,27 @@ public sealed class HtmlPdfConvertTests
             + "<div style=\"line-height:14px\">x</div></span></div></body></html>", opts))).Y;
 
         Assert.Equal(SurroundingTextY("14px"), SurroundingTextY("40px"), precision: 2);
+    }
+
+    [Fact]
+    public void Inline_block_last_line_baseline_reflects_a_font_overriding_span()
+    {
+        // PR-3 task 9 — an inline-block's baseline comes from its LAST in-flow line box (CSS 2.2 §10.8.1),
+        // so a SPAN that overrides the font (a larger font-size ≈ a deeper descender) ON the LAST line
+        // deepens the descent and shifts the baseline — and the surrounding "A" aligned to it. Moving the
+        // SAME 40px span from an earlier line to the LAST line therefore changes the result:
+        // BufferingMeasureSink now scans the last line's DEEPEST run instead of using the box font only.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        double SurroundingY(string ibContent) => FirstTd(Latin1(HtmlPdf.Convert(
+            "<!DOCTYPE html><html><body><div>A<span style=\"display:inline-block\">" + ibContent
+            + "</span></div></body></html>", opts))).Y;
+
+        // Same glyphs; only WHICH line carries the 40px span differs (line 1 vs the LAST line).
+        var deepFirst = SurroundingY("<span style=\"font-size:40px\">y</span><br>x");   // 40px on line 1, 16px last
+        var deepLast = SurroundingY("x<br><span style=\"font-size:40px\">y</span>");    // 16px line 1, 40px last
+
+        Assert.True(System.Math.Abs(deepFirst - deepLast) > 1.0,
+            $"the LAST line's deepest font should drive the inline-block baseline: deepFirst={deepFirst} deepLast={deepLast}");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The next three roadmap tasks in order. **Two of the three turned out to be largely stale roadmap items** already implemented by earlier cycles — verified, confirmed with tests, and the deferral docs corrected (a pattern this codebase has hit before). Each task ships with tests; LTR / default-value / single-occurrence output stays byte-identical.

### Task 9 — justify-all on internal `<br>` + inline-block last-line per-run baseline  *(new work)*
- **Part A:** `text-align: justify-all` now justifies EVERY line including an internal forced-break (`<br>`)-terminated one (CSS Text 3 §7.3); plain `justify` still leaves a `<br>` line start-aligned. Lifted the forced-break exception under justify-all at the two mirrored gates (`TextPainter` + `BlockLayouter` atomic placement).
- **Part B:** an inline-block's last-line baseline now reflects a SPAN that overrides the font ON the last line — `BufferingMeasureSink.DeepestLastLineRunStyle` scans the last line's slices for the deepest run, used only when deeper than the box font (a strict deepen-only refinement; uniform-font + `element()`-running cases byte-identical).

### Task 10 — running-element nested block layout  *(already done — confirmed)*
The segment-style + container-bands cycles already render a `position: running()` element's block children as **separate stacked lines** with per-block own-style, text wrapping (post-PR-#154), per-segment margins/padding/line-heights, and decorated container bands. The deferral text claiming "still FLATTENED text per direct block child" was **stale**. Added a focused confirmation test (3 block children → 3 stacked Td lines + a child's background band) and corrected the deferral — the residual is inline-level styling *within* a leaf block.

### Task 11 — `string(name, start)` / `first-except` + compound `@page`  *(11a new, 11b already done)*
- **11a (new):** `string()` now resolves all four GCPM position keywords — `first` / `last` / `start` (the page's ENTRY value, carried in from the prior page) / `first-except` (= first, but empty when first == start, so a running header doesn't repeat unchanged). `TryReadPositionedFunction` returns a `StringPosition` enum; the collector captures the carried map at each page's start. `element()` keeps first/last (start/first-except occurrence-keyed → deferred).
- **11b (already done):** compound `@page` selectors (`chapter:first`, `:first:left`, `chapter:first:right`) are fully implemented + tested in the live multi-page path (`AtPageRules.MatchSelector`) — a stale roadmap item, no code change.

## Tests
- Task 9: a facade test that justify-all (not plain justify) justifies an internal `<br>` line; one that moving a 40px span onto the inline-block's last line shifts its baseline.
- Task 10: a confirmation test (block children → stacked lines + decoration band).
- Task 11: `string(t, start)` reads the entry value; `first-except` is empty when first == start and the first value otherwise; unknown/malformed keywords still bail.

## Gates (all green)
0-warning Release · **7116 unit / 4 skip** · 30 LayoutSnapshots · 97 RealDocuments · PaginationGolden · RenderingCorpus · W3cConformance (smoke) · AOT/JIT parity (byte-identical) · determinism.

## Deferrals
Corrected the running-element deferral (nested block layout done; inline-within-leaf-block residual). Rolled the `string()`/`element()` positional deferral note. PROGRESS rolled — PR 3 complete, PR 4 tasks 10–11 done; task 12 (margin-box overflow + container-relative units) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)