### PR TITLE
Task 16: prose pagination — text-bearing blocks break across pages (block-granularity)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,8 +1,8 @@
 # NetPdf — Progress Status
 
-> **Current state (2026-06-19):** Phase 3's layout + pagination engine drives multi-page rendering for **tables, flex, grid, multicol, and empty/explicit-height blocks**. **⚠️ Known gap (the biggest one): plain PROSE block-flow does NOT paginate** — a text-bearing `<p>`/`<div>` taller than a page overflows page 1 instead of breaking (deferrals.md `inline-only-block-pagination`). A block-granularity first cut DID paginate prose (200 `<p>` → 9 pages, no content loss) but REGRESSED two flex/grid pagination tests via an unexplained interaction, so it was reverted — the correct fix is the deferred "mid-subtree split" work. So "multi-page is live" is true for structured content but NOT yet for prose. What's left to *finish* Phase 3: (a) **prose pagination** (top priority), (b) W3C conformance **measurement** (PR 1, still awaits the A/B decision), (c) feature/polish backlog, (d) the `0.7.0-beta` release. **Perf + memory exit criteria 7–8 are now layout-pipeline smoke-gated** (PR 5 — synthetic-font p50 thresholds + a retained-heap check; the full image+web-font workload + allocation-scaling stay the BenchmarkDotNet flow).
+> **Current state (2026-06-20):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, empty/explicit-height blocks — **and now PLAIN PROSE** (task 16): a stack of text blocks taller than a page breaks across pages at paragraph boundaries (`<p>×200` paginates; was 1 overflowing page). Block-granularity only — a SINGLE paragraph taller than a whole page still force-overflows (line-level orphans/widows deferred: `inline-only-block-line-splitting`). What's left to *finish* Phase 3: (a) W3C conformance **measurement** (PR 1, still awaits the A/B decision), (b) feature/polish + pagination/table/grid hardening, (c) multi-page allocation-churn perf (`multi-page-allocation-churn`), (d) the `0.7.0-beta` release. Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
 >
-> Last merged: PR [#198](https://github.com/raroche/NetPdf/pull/198) (tasks 9–11). This branch `phase3-tasks-12-13-14`: task 12 confirmed done (margin-box overflow + relative-unit resolution already implemented + tested; container units are a tracked post-v1 deferral) + tasks 13–15 (perf + memory gates). `git log --oneline -1` shows the exact commit.
+> Last merged: PR [#199](https://github.com/raroche/NetPdf/pull/199) (tasks 12–15: perf + memory gates). This branch `phase3-prose-pagination`: **task 16 — block-granularity prose pagination** (the inline-only branch consults the break resolver; guards a real content extent so zero-extent flex/grid blocks don't spuriously break). `git log --oneline -1` shows the exact commit.
 >
 > This file was consolidated from a 1.1 MB chronological log on 2026-06-18; the full per-subtask history is archived in [docs/progress-archive.md](docs/progress-archive.md). **Keep this file compact** — roll the roadmap as each PR lands; don't grow a blow-by-blow log here.
 
@@ -46,7 +46,7 @@ Phase 3 is "complete" per [phase-3 §Exit criteria](docs/phases/phase-3-layout-a
 | 10 | Determinism | ✅ |
 | 11 | CHANGELOG + `0.7.0-beta` tagged | ❌ |
 
-**Bottom line:** most engine work is done, but **two real multi-page gaps surfaced while gating perf (2026-06-19): (1) prose block-flow doesn't paginate** (`inline-only-block-pagination` — the top open item) and (2) allocation churn is super-linear on long docs (`multi-page-allocation-churn`). The critical path is **prose pagination → conformance measurement → release.**
+**Bottom line:** the big multi-page gap is closed — **prose now paginates** (task 16, block-granularity). Remaining: line-level paragraph splitting (`inline-only-block-line-splitting`, niche), super-linear allocation churn on long docs (`multi-page-allocation-churn`), conformance measurement, and table/grid hardening. The critical path is now **conformance measurement → hardening → release.**
 
 ## Phase 3 — remaining-work roadmap
 
@@ -77,8 +77,8 @@ Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order.
 14. ✅ 20-page report ≤ 1.5 s p50 — enforced gate (~400 ms, 22-page tabular report; the live multi-page path).
 15. ✅ Retained-heap gate — heap flat across page count (criterion 8 PARTIAL: retained footprint linear; ALLOCATION scaling is super-linear — `multi-page-allocation-churn`, the `[MemoryDiagnoser]` standard would flag it; a slope gate is large-doc hardening).
 
-### ▶ PR 6 — PROSE PAGINATION  [the top open gap — DO NEXT]
-16. **Inline-only block pagination** (`inline-only-block-pagination`) — make a text-bearing block taller than a page break across pages. A block-granularity first cut works for prose but regressed flex/grid (reverted); the fix needs the right context guard (exclude flex/grid item-content measure recursions) + likely line-level splitting (orphans/widows). The single most impactful remaining feature — prose is the common document.
+### PR 6 — PROSE PAGINATION  ✅ DONE
+16. ✅ **Inline-only block pagination** (block-granularity) — the recursion's inline-only branch now consults the break resolver, so a text block whose margin-box overflows the page breaks WHOLE to the next page (`<p>×200` paginates; no content loss/duplication). Guards a real content extent (`InlineOnlyBreakMinExtentPx`) so a ZERO-extent anonymous block (flex/grid content past the page edge) doesn't spuriously break — the regression that blocked the first cut, root-caused (both triggers were `chunk == 0` at `start > pageBlockSize`). Residual: line-level paragraph splitting / orphans+widows (`inline-only-block-line-splitting`). Full unit suite + snapshots/golden/real-docs all green.
 
 ### PR 7 — Pagination / table / grid hardening  [feature]
 17. Table intra-cell row splitting (cell content > remaining page height).

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -278,36 +278,32 @@ grepping the ID).
 
 ---
 
-## inline-only-block-pagination
+## inline-only-block-line-splitting
 
-- **ID** — `inline-only-block-pagination`
-- **Status** — `approximated` (inline-only blocks emit atomically + overflow page 1; no child-boundary
-  break is consulted, so prose doesn't paginate).
-- **Behavior** — A block whose content is INLINE-ONLY (text / line boxes — a `<p>`, a `<div>text</div>`) is
-  laid out + emitted ATOMICALLY by `BlockLayouter.EmitInlineOnlyBlockInRecursion`; the recursion's
-  inline-only branch `continue`s WITHOUT consulting the break resolver. So when N such blocks stack taller
-  than a page they do NOT break across pages — they force-overflow page 1 (`<p>×200` → ONE A4 page, all
-  paragraphs crammed on it). Empty / explicit-height blocks (no line box), tables, flex, grid, and multicol
-  DO fragment; only plain PROSE block-flow fails to paginate. The outer-loop path (`DispatchInlineOnlyBlock`,
-  the layout root's direct children) IS pagination-aware — the gap is the RECURSION (content nested under
-  `body`), which every real document hits.
-- **Missing** — a break consult in the recursion's inline-only branch (`BlockLayouter.cs` ~line 4623)
-  mirroring the block-flow check (~4830): measure the inline-only block's extent, `ConsiderBreakAt`, and on
-  `BreakHere` return `BlockContinuation(ResumeAtChild)` to push the whole block to the next page. CAVEAT
-  (2026-06-19): a first cut of exactly that block-granularity break DID paginate prose (200 paragraphs → 9
-  pages, no content duplicated; empty-block pagination unchanged) but REGRESSED two flex/grid pagination
-  tests through an UNEXPLAINED interaction (an all-empty-item `flex-wrap: wrap-reverse` container began
-  paginating), so it was reverted. The correct fix needs the right context guard (exclude flex/grid
-  item-content measure recursions) and likely LINE-LEVEL splitting (orphans/widows) for a single
-  page-taller-than-one paragraph — the "true mid-subtree split / sub-cycle 2" work.
-- **Trigger** — any document whose main content is plain prose in block-flow (`<p>` / `<div>` text) taller
-  than one page — the most common document shape. It silently overflows page 1 instead of paginating.
+- **ID** — `inline-only-block-line-splitting`
+- **Status** — `approximated` (block-granularity prose pagination ships; a SINGLE paragraph taller than a
+  whole page can't split its own lines — it force-overflows).
+- **Behavior** — Block-granularity PROSE pagination is LIVE (2026-06-20): the recursion's inline-only branch
+  now consults the break resolver before emitting (mirroring the block-flow check at ~`BlockLayouter.cs`
+  L4830), so a text-bearing block whose margin-box would overflow the fragmentainer breaks WHOLE to the next
+  page — `<p>×200` paginates cleanly across pages (was ONE overflowing A4 page). The RESIDUAL is LINE-LEVEL:
+  a SINGLE inline-only block taller than an ENTIRE page can't split its OWN lines across pages (no
+  orphans/widows), so it force-overflows the page it starts on instead of breaking mid-paragraph.
+  Multi-paragraph prose — the common case — paginates at paragraph boundaries.
+- **Missing** — intra-block LINE fragmentation: a continuation that resumes a paragraph at line K on the
+  next page (an `InlineContinuation` carrying the resume line index) + orphans/widows (CSS Fragmentation
+  §4) — the "true mid-subtree split" work.
+- **Trigger** — a SINGLE `<p>`/`<div>` whose text is taller than one whole page (rare) — it overflows the
+  bottom of its starting page rather than splitting its lines.
 - **Owner files** — `src/NetPdf.Layout/Layouters/BlockLayouter.cs` (the inline-only branch in
-  `EmitBlockSubtreeRecursive` + `EmitInlineOnlyBlockInRecursion` + `MeasureInlineOnlyBlockExtent`).
-- **Added** — 2026-06-19, surfaced while wiring the task-14 "20-page report" perf gate. Already noted in
-  code as "true mid-subtree splitting is sub-cycle 2 work" (`BlockLayouter.cs:7920`).
-- **Removal condition** — plain prose (`<p>×N` / `<div>text</div>×N` taller than a page) paginates with no
-  content loss or duplication, AND the flex/grid pagination tests stay green.
+  `EmitBlockSubtreeRecursive` + `EmitInlineOnlyBlockInRecursion`).
+- **Added** — 2026-06-20, when block-granularity prose pagination shipped (the broad
+  `inline-only-block-pagination` deferral CLOSED). The fix guards on a real content extent
+  (`InlineOnlyBreakMinExtentPx`) so a ZERO-extent anonymous block — flex/grid content the recursion walks,
+  placed past the page edge — does NOT spuriously break (that was the earlier flex/grid regression: both
+  triggering blocks had `chunk == 0` at `start > pageBlockSize`).
+- **Removal condition** — a single inline-only block taller than a page splits its lines across pages with
+  orphans/widows honored.
 
 ---
 

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -4642,39 +4642,42 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 var inlineOnlyMarginStart =
                     child.Style.ReadLengthOrPercentPx(PropertyId.MarginTop, contentInlineSize);
 
-                // Prose pagination (block-granularity) — consult the break resolver BEFORE emitting an
-                // inline-only block, mirroring the block-flow check below. Pre-fix this branch emitted
-                // unconditionally + `continue`d, so N stacked text blocks taller than the page all
-                // force-overflowed page 1 (`<p>×200` → 1 page). Now a text block whose margin-box would
-                // overflow the fragmentainer breaks WHOLE to the next page (its resume re-enters at
-                // `childIdx`, exactly like a block-flow child). CHILD-BOUNDARY granularity only — splitting a
-                // single paragraph's LINES across pages (orphans/widows) stays the deferred mid-subtree work.
+                // Prose pagination (block-granularity, 2026-06-20) — the recursion's inline-only path now
+                // CONSULTS the break resolver before emitting, mirroring the in-flow block break check below.
+                // Pre-fix this branch emitted unconditionally + `continue`d, so N stacked text blocks taller
+                // than the page all force-overflowed page 1 (`<p>×200` → 1 page). Now a text block whose
+                // VISUAL extent would overflow the fragmentainer breaks WHOLE to the next page (its resume
+                // re-enters at `childIdx`, exactly like a block-flow child). CHILD-BOUNDARY granularity only —
+                // splitting a single paragraph's LINES across pages (orphans/widows) stays the deferred
+                // mid-subtree work (`inline-only-block-line-splitting`).
                 //
-                // GUARD `inlineChunk > InlineOnlyBreakMinExtentPx`: only break a block with REAL content
-                // extent. A ZERO-extent inline-only block — an empty/whitespace AnonymousBlock the recursion
-                // may walk for flex/grid content, placed PAST the page edge by that layout — has nothing to
-                // push to the next page; breaking it spawned a spurious page (regressed flex wrap-reverse +
-                // grid-fr — both were chunk == 0 blocks at start > pageBlockSize). Forward-progress guard
-                // (`_sink.Cursor > sinkCursorAtRecursionEntry`): an over-tall FIRST block still
-                // force-overflows so pagination always progresses. Named-page breaks on an inline-only block
-                // stay deferred (rare; the block-flow path owns them).
+                // The chunk is the VISUAL extent BELOW the border-box top (border-box + a NON-NEGATIVE
+                // margin-bottom), mirroring the top-level inline path's `max(marginBox, visualBlockExtent)`
+                // (review P2): a negative margin-bottom must NOT shrink it below the real text border-box,
+                // which would let visible prose overflow instead of breaking.
+                //
+                // GUARD `> InlineOnlyBreakMinExtentPx`: only break a block with REAL content extent. A
+                // ZERO-extent inline-only block — an empty/whitespace AnonymousBlock the recursion may walk
+                // for flex/grid content, placed PAST the page edge by that layout — has nothing to push to
+                // the next page; breaking it spawned a spurious page (regressed flex wrap-reverse + grid-fr —
+                // both chunk == 0 at start > pageBlockSize). Forward-progress guard (`_sink.Cursor >
+                // sinkCursorAtRecursionEntry`): an over-tall FIRST block still force-overflows so pagination
+                // always progresses. Named-page breaks on an inline-only block stay deferred (rare; the
+                // block-flow path owns them).
                 if (propagatingResolver is not null
                     && propagatingFragmentainer is { SuppressBlockPagination: false } pfInline
                     && _sink.Cursor > sinkCursorAtRecursionEntry)
                 {
-                    var inlineMarginBoxExtent = MeasureInlineOnlyBlockExtent(
-                        child, contentInlineSize, cancellationToken);
-                    // Border-box top (matches the emit offset below); the chunk runs from there to the
-                    // margin-box bottom (border-box + margin-bottom = margin-box extent − margin-top).
-                    var inlineChunk = Math.Max(0, inlineMarginBoxExtent - inlineOnlyMarginStart);
-                    if (inlineChunk > InlineOnlyBreakMinExtentPx)
+                    _ = MeasureInlineOnlyBlockExtent(
+                        child, contentInlineSize, out var inlineVisualChunk, cancellationToken);
+                    if (inlineVisualChunk > InlineOnlyBreakMinExtentPx)
                     {
                         var inlineChildStart = Math.Max(0, contentTop + childCursor + inlineOnlyMarginStart);
                         var savedUsedBlockSizeInline = pfInline.UsedBlockSize;
                         pfInline.UsedBlockSize = inlineChildStart;
                         var inlineDecision = propagatingResolver.ConsiderBreakAt(
                             BreakOpportunity.Block(
-                                usedBlockSize: inlineChildStart, chunkBlockSize: inlineChunk),
+                                usedBlockSize: inlineChildStart, chunkBlockSize: inlineVisualChunk),
                             pfInline);
                         pfInline.UsedBlockSize = savedUsedBlockSizeInline;
                         if (inlineDecision.Action == BreakAction.BreakHere)
@@ -7959,13 +7962,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// margin-collapse arithmetic; this helper just runs the
     /// inline pass + emits.
     ///
-    /// <para><b>Pagination scope.</b> The recursive path does NOT
-    /// consult the resolver (the outer-loop's measure pass already
-    /// reserved page space via
-    /// <see cref="MeasureSubtreeVisualBlockExtent"/>). If the
-    /// inline content overflows the parent, the outer-loop's
-    /// forced-overflow path fires per existing cycle 2c semantics.
-    /// True mid-subtree splitting is sub-cycle 2 work.</para>
+    /// <para><b>Pagination scope.</b> The recursive caller (<see cref="EmitBlockSubtreeRecursive"/>) now
+    /// CONSULTS the break resolver BEFORE invoking this helper (prose pagination, 2026-06-20): a
+    /// text-bearing block whose visual extent would overflow the fragmentainer breaks WHOLE to the next page
+    /// at child-boundary granularity. This helper itself just runs the inline pass + emits at the chosen
+    /// offset; it is reached only once the caller has decided the block fits (or is the first, force-overflow
+    /// case). Intra-block LINE splitting — a single paragraph taller than a whole page resuming at line K on
+    /// the next page (orphans/widows) — stays deferred (`inline-only-block-line-splitting`).</para>
     ///
     /// <para><b>NotSupportedException + atomic-inline diagnostics.</b>
     /// Routed through the captured diagnostic sink (set at
@@ -8041,6 +8044,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     private double MeasureInlineOnlyBlockExtent(
         Box inlineOnlyBlock,
         double parentContentInlineSize,
+        out double visualChunkBelowBorderTopPx,
         CancellationToken cancellationToken)
     {
         var metrics = ReadInlineOnlyBlockMetrics(inlineOnlyBlock, parentContentInlineSize);
@@ -8053,9 +8057,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             cancellationToken);
         if (computation is null)
         {
+            visualChunkBelowBorderTopPx = 0;
             return 0;
         }
         var comp = computation.Value;
+        // The VISUAL extent BELOW the border-box top (border-box + a NON-negative margin-bottom — a negative
+        // margin-bottom is clamped to 0, mirroring the top-level inline path's `visualBlockExtent`). The
+        // prose-pagination break uses this as its chunk so a negative margin-bottom can't shrink the break
+        // below the real text border-box (review P2).
+        visualChunkBelowBorderTopPx = comp.BorderBoxBlockSize + Math.Max(0, metrics.MarginBlockEnd);
         // Return the margin-box block-axis extent so the parent's
         // measure pass reserves enough page space (matches the
         // in-flow block path's measure semantics).
@@ -8510,6 +8520,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             var inlineMargined = MeasureInlineOnlyBlockExtent(
                 parent,
                 parentContentInlineSize: _bfcContentInlineSize,
+                out _,
                 cancellationToken);
             return Math.Max(parentBorderBoxBlockSize, inlineMargined);
         }

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -4358,6 +4358,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             => _outer.UpdateFragmentBlockSize(_baseline + cursor, newBlockSize);
     }
 
+    /// <summary>Minimum margin-box content extent (px) below an inline-only block's border-box top for the
+    /// prose-pagination break to consider it. A block at or under this is treated as having NO paginatable
+    /// content (an empty / whitespace anonymous block) — breaking before it would spawn a spurious page.
+    /// Sub-px to admit any real single line while excluding the zero-extent case.</summary>
+    private const double InlineOnlyBreakMinExtentPx = 0.5;
+
     /// <summary>Per Phase 3 Task 7 cycle 2b — recursively emit fragments
     /// for <paramref name="parent"/>'s block-level descendants. Called
     /// AFTER the parent's own fragment is emitted; offsets are relative
@@ -4635,6 +4641,48 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // AFTER the child instead of pushing it down.
                 var inlineOnlyMarginStart =
                     child.Style.ReadLengthOrPercentPx(PropertyId.MarginTop, contentInlineSize);
+
+                // Prose pagination (block-granularity) — consult the break resolver BEFORE emitting an
+                // inline-only block, mirroring the block-flow check below. Pre-fix this branch emitted
+                // unconditionally + `continue`d, so N stacked text blocks taller than the page all
+                // force-overflowed page 1 (`<p>×200` → 1 page). Now a text block whose margin-box would
+                // overflow the fragmentainer breaks WHOLE to the next page (its resume re-enters at
+                // `childIdx`, exactly like a block-flow child). CHILD-BOUNDARY granularity only — splitting a
+                // single paragraph's LINES across pages (orphans/widows) stays the deferred mid-subtree work.
+                //
+                // GUARD `inlineChunk > InlineOnlyBreakMinExtentPx`: only break a block with REAL content
+                // extent. A ZERO-extent inline-only block — an empty/whitespace AnonymousBlock the recursion
+                // may walk for flex/grid content, placed PAST the page edge by that layout — has nothing to
+                // push to the next page; breaking it spawned a spurious page (regressed flex wrap-reverse +
+                // grid-fr — both were chunk == 0 blocks at start > pageBlockSize). Forward-progress guard
+                // (`_sink.Cursor > sinkCursorAtRecursionEntry`): an over-tall FIRST block still
+                // force-overflows so pagination always progresses. Named-page breaks on an inline-only block
+                // stay deferred (rare; the block-flow path owns them).
+                if (propagatingResolver is not null
+                    && propagatingFragmentainer is { SuppressBlockPagination: false } pfInline
+                    && _sink.Cursor > sinkCursorAtRecursionEntry)
+                {
+                    var inlineMarginBoxExtent = MeasureInlineOnlyBlockExtent(
+                        child, contentInlineSize, cancellationToken);
+                    // Border-box top (matches the emit offset below); the chunk runs from there to the
+                    // margin-box bottom (border-box + margin-bottom = margin-box extent − margin-top).
+                    var inlineChunk = Math.Max(0, inlineMarginBoxExtent - inlineOnlyMarginStart);
+                    if (inlineChunk > InlineOnlyBreakMinExtentPx)
+                    {
+                        var inlineChildStart = Math.Max(0, contentTop + childCursor + inlineOnlyMarginStart);
+                        var savedUsedBlockSizeInline = pfInline.UsedBlockSize;
+                        pfInline.UsedBlockSize = inlineChildStart;
+                        var inlineDecision = propagatingResolver.ConsiderBreakAt(
+                            BreakOpportunity.Block(
+                                usedBlockSize: inlineChildStart, chunkBlockSize: inlineChunk),
+                            pfInline);
+                        pfInline.UsedBlockSize = savedUsedBlockSizeInline;
+                        if (inlineDecision.Action == BreakAction.BreakHere)
+                        {
+                            return new BlockContinuation(ResumeAtChild: childIdx, ConsumedBlockSize: 0);
+                        }
+                    }
+                }
 
                 var emittedExtent = EmitInlineOnlyBlockInRecursion(
                     child,

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -47,7 +47,7 @@ public sealed class DeferralsParityTests
         "text-align-match-parent",
         "line-height-percentage-inheritance",
         "margin-box-line-height",
-        "inline-only-block-pagination",
+        "inline-only-block-line-splitting",
         "multi-page-allocation-churn",
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",

--- a/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
+++ b/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
@@ -17,9 +17,10 @@ namespace NetPdf.UnitTests.Performance;
 /// Phase 3 exit-criterion 7 + 8 SMOKE gates (docs/phases/phase-3-layout-and-pagination.md). These measure
 /// the engine's LAYOUT → paginate → paint → PDF-write THROUGHPUT through a SYNTHETIC font resolver
 /// (deterministic glyphs, no system-font I/O — platform font loading adds ~140 ms of fixed,
-/// environment-dependent overhead) over TABLE fixtures (plain block-flow PROSE pagination is a tracked open
-/// gap, deferrals.md <c>inline-only-block-pagination</c>). They carry ~4× headroom over the measured p50 on
-/// dev hardware.
+/// environment-dependent overhead) over TABLE fixtures (block-flow PROSE now paginates too — see the
+/// <c>Prose_*</c> tests in HtmlPdfConvertTests + the <c>Prose_*</c> gate below; only single-paragraph
+/// line-splitting remains, deferrals.md <c>inline-only-block-line-splitting</c>). They carry ~4× headroom
+/// over the measured p50 on dev hardware.
 ///
 /// <para><b>Scope — these are guard rails, not the authoritative perf numbers.</b> The repo's standard for
 /// strict perf + ALLOCATION scaling is the BenchmarkDotNet + <c>[MemoryDiagnoser]</c> flow in
@@ -66,6 +67,18 @@ public sealed class PerformanceGateTests
             $"the report fixture should be a 20–24 page workload; got {pages} — the workload shape drifted.");
         Assert.True(p50 <= 1500.0,
             $"Exit criterion 7: the {pages}-page report p50 {p50:F1} ms exceeds the 1.5 s gate.");
+    }
+
+    [Fact]
+    [Trait("Category", "Performance")]
+    public void Prose_multi_page_renders_within_budget_p50()
+    {
+        // Prose pagination (task 16) bounds the per-block recursive break measure: 150 one-line paragraphs
+        // (~6 pages) render well within budget, so the measure-then-emit pass on the no-break path is not a
+        // throughput problem at realistic prose scale (review P3). ~58 ms p50 on dev hardware (~4× headroom).
+        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Prose(paragraphs: 150), warmup: 3, iters: 9);
+        Assert.True(pages >= 4, $"the prose fixture should paginate (≥ 4 pages); got {pages}.");
+        Assert.True(p50 <= 250.0, $"prose ({pages} pages) p50 {p50:F1} ms exceeds the 250 ms budget.");
     }
 
     [Fact]
@@ -178,6 +191,20 @@ internal static class PerfFixtures
                   .Append("</td><td>").Append((r * 11) % 1000).Append("</td></tr>");
             sb.Append("</table>");
         }
+        return sb.Append("</body></html>").ToString();
+    }
+
+    /// <summary>A paginating PROSE document — N one-line paragraphs (inline-only blocks that break at
+    /// paragraph boundaries). Exercises the prose-pagination path, whose recursive break check measures each
+    /// block's inline extent before emitting — this fixture bounds that cost (review P3).</summary>
+    internal static string Prose(int paragraphs)
+    {
+        var sb = new StringBuilder("<!DOCTYPE html><html><head><style>"
+            + "body { font-size: 13px } @page { @bottom-center { content: counter(page) } }"
+            + "</style></head><body>");
+        for (var i = 0; i < paragraphs; i++)
+            sb.Append("<p>Paragraph ").Append(i)
+              .Append(" with a sentence of body text that fills roughly one line on the page.</p>");
         return sb.Append("</body></html>").ToString();
     }
 }

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -209,7 +209,8 @@ public sealed class HtmlPdfConvertTests
     [Fact]
     public void Prose_block_flow_taller_than_one_page_paginates_at_paragraph_boundaries()
     {
-        // Prose pagination (deferrals.md `inline-only-block-pagination`, now BLOCK-granularity): a stack of
+        // Prose pagination (block-granularity — the broad `inline-only-block-pagination` deferral is now
+        // CLOSED; the residual single-paragraph line split is `inline-only-block-line-splitting`): a stack of
         // text-bearing blocks (inline-only blocks) taller than the page now BREAKS across pages instead of
         // overflowing page 1 (the pre-fix behavior was 120 paragraphs crammed onto a single page). Each
         // paragraph is emitted EXACTLY ONCE — Td count == paragraph count — so the break/resume neither

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -206,6 +206,46 @@ public sealed class HtmlPdfConvertTests
         Assert.DoesNotContain(result.Warnings, d => d.Code == DiagnosticCodes.PdfContentOverflowTruncated001);
     }
 
+    [Fact]
+    public void Prose_block_flow_taller_than_one_page_paginates_at_paragraph_boundaries()
+    {
+        // Prose pagination (deferrals.md `inline-only-block-pagination`, now BLOCK-granularity): a stack of
+        // text-bearing blocks (inline-only blocks) taller than the page now BREAKS across pages instead of
+        // overflowing page 1 (the pre-fix behavior was 120 paragraphs crammed onto a single page). Each
+        // paragraph is emitted EXACTLY ONCE — Td count == paragraph count — so the break/resume neither
+        // drops content (overflow) nor duplicates it. Mid-paragraph line splitting (orphans/widows) stays
+        // deferred; whole one-line paragraphs move to the next page.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        var sb = new StringBuilder("<!DOCTYPE html><html><body>");
+        for (var i = 0; i < 120; i++) sb.Append("<p>Line ").Append(i).Append("</p>");
+        sb.Append("</body></html>");
+
+        var result = HtmlPdf.ConvertDetailed(sb.ToString(), opts);
+
+        Assert.True(result.PageCount >= 2, $"expected prose to paginate; got {result.PageCount} page(s).");
+        Assert.True(result.PageCount < 20, $"sanity: a handful of pages, got {result.PageCount}.");
+        Assert.Equal(120, TdCount(Latin1(result.Pdf)));   // one Td per paragraph — no content lost or duplicated
+    }
+
+    [Fact]
+    public void Prose_and_empty_height_blocks_paginate_together_without_content_loss()
+    {
+        // The inline-only break (prose) composes with the block-flow break (empty/explicit-height blocks):
+        // a doc mixing both paginates with ALL content present. 20 + 20 one-line paragraphs around a tall
+        // empty block → both paths break, and all 40 paragraph lines are emitted exactly once.
+        var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
+        var sb = new StringBuilder("<!DOCTYPE html><html><body>");
+        for (var i = 0; i < 20; i++) sb.Append("<p>Alpha ").Append(i).Append("</p>");
+        sb.Append("<div style=\"height:500px\"></div>");
+        for (var i = 0; i < 20; i++) sb.Append("<p>Beta ").Append(i).Append("</p>");
+        sb.Append("</body></html>");
+
+        var result = HtmlPdf.ConvertDetailed(sb.ToString(), opts);
+
+        Assert.True(result.PageCount >= 2, $"expected pagination; got {result.PageCount}.");
+        Assert.Equal(40, TdCount(Latin1(result.Pdf)));   // all 40 paragraphs present, once each
+    }
+
     // Non-block pagination — regression lock-in (multi-page-driver.md, post-cycle-8 audit).
     // These three modes were ALREADY paginating through the driver loop (the table /
     // multicol layouters propagate their continuations through BlockLayouter's dispatch,

--- a/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/HtmlPdfConvertTests.cs
@@ -226,25 +226,36 @@ public sealed class HtmlPdfConvertTests
         Assert.True(result.PageCount >= 2, $"expected prose to paginate; got {result.PageCount} page(s).");
         Assert.True(result.PageCount < 20, $"sanity: a handful of pages, got {result.PageCount}.");
         Assert.Equal(120, TdCount(Latin1(result.Pdf)));   // one Td per paragraph — no content lost or duplicated
+        // No CONTENT was truncated — the paragraphs paginated, none dropped (review P3, like the adjacent
+        // block-pagination tests). (PAGINATION-FORCED-OVERFLOW-001 is the existing "subtree taller than a
+        // page, committed + recursed" signal shared by ALL block-flow pagination — empty-height blocks emit
+        // it too — so it is NOT asserted absent here; only data loss matters.)
+        Assert.DoesNotContain(result.Warnings, d => d.Code == DiagnosticCodes.PdfContentOverflowTruncated001);
     }
 
     [Fact]
     public void Prose_and_empty_height_blocks_paginate_together_without_content_loss()
     {
-        // The inline-only break (prose) composes with the block-flow break (empty/explicit-height blocks):
-        // a doc mixing both paginates with ALL content present. 20 + 20 one-line paragraphs around a tall
-        // empty block → both paths break, and all 40 paragraph lines are emitted exactly once.
+        // The inline-only break (prose) composes with the block-flow break (explicit-height blocks): a doc
+        // mixing both paginates with ALL content present. 20 + 20 one-line paragraphs around a tall RED
+        // spacer → both paths break, all 40 paragraph lines emit exactly once, AND the spacer still paints
+        // its red fill (so dropping/misplacing the spacer fails the test, not just the surrounding prose —
+        // review P2).
         var opts = new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() };
         var sb = new StringBuilder("<!DOCTYPE html><html><body>");
         for (var i = 0; i < 20; i++) sb.Append("<p>Alpha ").Append(i).Append("</p>");
-        sb.Append("<div style=\"height:500px\"></div>");
+        sb.Append("<div style=\"height:500px;background-color:red\"></div>");
         for (var i = 0; i < 20; i++) sb.Append("<p>Beta ").Append(i).Append("</p>");
         sb.Append("</body></html>");
 
         var result = HtmlPdf.ConvertDetailed(sb.ToString(), opts);
+        var pdf = Latin1(result.Pdf);
 
         Assert.True(result.PageCount >= 2, $"expected pagination; got {result.PageCount}.");
-        Assert.Equal(40, TdCount(Latin1(result.Pdf)));   // all 40 paragraphs present, once each
+        Assert.Equal(40, TdCount(pdf));      // all 40 paragraphs present, once each
+        Assert.Contains("1 0 0 rg", pdf);    // the red spacer's fill color
+        Assert.Contains("re f", pdf);        // the spacer paints a filled rectangle (not dropped)
+        Assert.DoesNotContain(result.Warnings, d => d.Code == DiagnosticCodes.PdfContentOverflowTruncated001);
     }
 
     // Non-block pagination — regression lock-in (multi-page-driver.md, post-cycle-8 audit).


### PR DESCRIPTION
## Summary

Closes the **biggest open multi-page gap**: plain block-flow **prose now paginates**. A stack of text-bearing blocks (`<p>`, `<div>text</div>`) taller than a page used to *overflow page 1* — `<p>×200` rendered as **one** crammed A4 page. It now breaks across pages at paragraph boundaries.

## The fix

`BlockLayouter.EmitBlockSubtreeRecursive`'s inline-only branch previously emitted a text block unconditionally and `continue`d — never consulting the break resolver. It now mirrors the block-flow break check: measure the inline-only block's margin-box extent, `ConsiderBreakAt`, and on `BreakHere` return `BlockContinuation(ResumeAtChild)` to push the whole block to the next page (resume re-enters at `childIdx`, exactly like a block-flow child). **Child-boundary granularity** — a single paragraph taller than a *whole* page still force-overflows (line-level orphans/widows stay deferred as the narrower `inline-only-block-line-splitting`, renamed from the now-closed broad deferral).

## Root-causing the regression that blocked the earlier attempt

A first cut of this fix (last PR) paginated prose correctly but regressed two flex/grid tests via a mechanism I couldn't explain, so it was reverted. **This time I instrumented and root-caused it**: the break fired on a **zero-extent `AnonymousBlock`** (empty/whitespace flex/grid content the recursion walks) placed *past* the page edge — `start=200` on an `80px` page, `chunk=0`. The greedy resolver said "break" because the position already overflowed, spawning a spurious page. Both regressing tests were exactly this (`chunk == 0` at `start > pageBlockSize`).

Fixed by guarding `inlineChunk > InlineOnlyBreakMinExtentPx` (0.5 px): **only a block with real content extent can break.** The two previously-regressing flex/grid tests now pass unchanged.

## Tests
- `<p>×120` → multi-page, **Td count == 120** (one per paragraph: no content lost to overflow, none duplicated by break/resume).
- Prose + empty-height blocks compose (both break paths together, all content present).
- The existing flex-wrap-reverse + grid-fr pagination tests are the regression lock for the zero-extent guard.

## Verification
7127 unit / 4 skip (+2) · 30 LayoutSnapshots · 97 RealDocuments · PaginationGolden · RenderingCorpus · W3cConformance (smoke) · **AOT/JIT parity** · 0-warning Release. **Byte-identical for every existing pinned doc** (none had overflowing inline-only content), so the change only *adds* pagination where prose previously overflowed.

> **Scope note:** prose pagination turned into a substantial investigation + fix (the #1 gap), so this is a focused single-task PR rather than a 3-task group. The next roadmap items (17 table intra-cell row splitting, 18 grid cross-page track sizing) are each substantial deferred layout work — best taken on next with the same care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)