### PR TITLE
Phase 3 PR 7 (tasks 17–19): table intra-cell row splitting · grid row-extent memo · float content atomicity

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,8 +1,8 @@
 # NetPdf — Progress Status
 
-> **Current state (2026-06-20):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, empty/explicit-height blocks — **and now PLAIN PROSE** (task 16): a stack of text blocks taller than a page breaks across pages at paragraph boundaries (`<p>×200` paginates; was 1 overflowing page). Block-granularity only — a SINGLE paragraph taller than a whole page still force-overflows (line-level orphans/widows deferred: `inline-only-block-line-splitting`). What's left to *finish* Phase 3: (a) W3C conformance **measurement** (PR 1, still awaits the A/B decision), (b) feature/polish + pagination/table/grid hardening, (c) multi-page allocation-churn perf (`multi-page-allocation-churn`), (d) the `0.7.0-beta` release. Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
+> **Current state (2026-06-20):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, prose, empty/explicit-height blocks. **PR 7 (table/grid/float hardening) just landed:** table intra-cell row splitting (a tall row's stacked-block cell content breaks across pages — task 17), grid cross-page row-extent memo (task 18), and float content atomicity (nested grid/flex in floats stop truncating — task 19). What's left to *finish* Phase 3: (a) W3C conformance **measurement** (PR 1, still awaits the A/B decision), (b) remaining hardening residuals (nested table/multicol in floats, recursive consumed-extent accounting, `multi-page-allocation-churn` — all latent/documented), (c) the `0.7.0-beta` release. Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
 >
-> Last merged: PR [#199](https://github.com/raroche/NetPdf/pull/199) (tasks 12–15: perf + memory gates). This branch `phase3-prose-pagination`: **task 16 — block-granularity prose pagination** (the inline-only branch consults the break resolver; guards a real content extent so zero-extent flex/grid blocks don't spuriously break). `git log --oneline -1` shows the exact commit.
+> Last merged: PR [#200](https://github.com/raroche/NetPdf/pull/200) (task 16: prose pagination). This branch `phase3-table-grid-float-hardening`: **tasks 17–19** (3 commits, one per task). `git log --oneline -1` shows the exact commit.
 >
 > This file was consolidated from a 1.1 MB chronological log on 2026-06-18; the full per-subtask history is archived in [docs/progress-archive.md](docs/progress-archive.md). **Keep this file compact** — roll the roadmap as each PR lands; don't grow a blow-by-blow log here.
 
@@ -17,7 +17,7 @@
 | 4 | Visual parity (gradients, shadows, filters, SVG) | ⏸️ Not started |
 | 5 | Packaging + release | 🔵 Interleaved — layout→PDF wiring done |
 
-**Gates (all green, 2026-06-19):** 7125 unit / 4 skip (+ the 3 perf/memory gates) · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
+**Gates (all green, 2026-06-20):** 7133 unit / 4 skip (+ the 3 perf/memory gates) · 30 LayoutSnapshots · 97 RealDocuments · W3cConformance (smoke only) · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
 
 ## Phase 3 — what's shipped (consolidated)
 
@@ -80,10 +80,10 @@ Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order.
 ### PR 6 — PROSE PAGINATION  ✅ DONE
 16. ✅ **Inline-only block pagination** (block-granularity) — the recursion's inline-only branch now consults the break resolver, so a text block whose margin-box overflows the page breaks WHOLE to the next page (`<p>×200` paginates; no content loss/duplication). Guards a real content extent (`InlineOnlyBreakMinExtentPx`) so a ZERO-extent anonymous block (flex/grid content past the page edge) doesn't spuriously break — the regression that blocked the first cut, root-caused (both triggers were `chunk == 0` at `start > pageBlockSize`). Residual: line-level paragraph splitting / orphans+widows (`inline-only-block-line-splitting`). Full unit suite + snapshots/golden/real-docs all green.
 
-### PR 7 — Pagination / table / grid hardening  [feature]
-17. Table intra-cell row splitting (cell content > remaining page height).
-18. Grid shared track-sizing across continuation pages + emitted-rows extent.
-19. Float-continuation propagation + recursive-block consumed-extent accounting. Plus `multi-page-allocation-churn` (per-page O(1) layout cursor — large-doc perf).
+### PR 7 — Pagination / table / grid hardening  [feature] ✅ DONE
+17. ✅ **Table intra-cell row splitting** (block-granularity) — a body row whose cell stacks block children taller than the page breaks WITHIN itself across pages (`TableContinuation.RowSplitOffset`; cells measure full natural height via `SuppressBlockPagination`; split-aware dry-run propagates the continuation through the production `BlockLayouter` path). Tight scope: no footers/bottom-captions/rowspan-origin; a single atomic block still force-overflows (`inline-only-block-line-splitting`).
+18. ✅ **Grid cross-page row-extent memo** + corrected the deferral premise — the 3 `GridSizing.Resolve` sites take GENUINELY different inputs (indefinite-block site 1 vs definite sites 2/3; probe lacks measurers), so a naive 3→1 share is INCORRECT for `fr` grids; the expensive shaping was already shared. Landed the page-invariant site-1 §11 memo (`GridMeasurementCache.RowExtentSum`) so resume pages skip it; site-2+3 collapse needs a reftest sweep (stays deferred).
+19. ✅ **Float content atomicity** — nested grid + flex in a float emit atomically (lossless) instead of paginating-then-truncating (floats don't fragment yet; `_inAtomicFloatSubtree`). Residual (all `not-started`/`approximated`, documented): nested table+multicol in floats still truncate (page-budget-coupled wrapper sizing); recursive consumed-extent accounting + `multi-page-allocation-churn` are LATENT (no visible impact).
 
 ### PR 8 — Release  [criterion 11]
 20. **Deferral audit** — reconcile `deferrals.md` / `compatibility-matrix.md` with live state; close stale entries (especially the grid residuals, several of which already shipped).

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1012,23 +1012,39 @@ grepping the ID).
   Finding #1; floats remain out-of-flow per CSS 2.2 §9.5 and can't
   yet carry a continuation across pages).
 - **Behavior** — When a float subtree (`float: left` / `float: right`
-  containing block-level descendants) hosts a nested multicol or
-  table whose pagination breaks mid-emission, the `BlockLayouter`
-  recursion produces a non-null `LayoutContinuation` for that
-  subtree. Floats are out-of-flow per CSS 2.2 §9.5; propagating
-  their continuation through the in-flow pagination machinery would
-  require float-tracking continuation machinery
-  (FloatManager-aware continuation state, float-fragment resume
-  contract, BFC-snapshot restoration in the float emission path).
-  The cycle 2 hardening pass discards the recursion return inside
-  float subtrees (the float's first-page slice is committed; the
-  remainder is truncated) + emits the new
-  `LAYOUT-FLOAT-BREAK-INSIDE-NESTED-001` Warning diagnostic at most
-  once per page so the truncation is observable.
-- **Missing** — float-tracking continuation machinery
-  (FloatManager state snapshot/restore across pages; float-
-  fragment resume contract; cross-page float overflow per
-  CSS Fragmentation L3 §5).
+  containing block-level descendants) hosts a nested container whose
+  pagination breaks mid-emission, the `BlockLayouter` recursion would
+  produce a non-null `LayoutContinuation` for that subtree. Floats are
+  out-of-flow per CSS 2.2 §9.5; propagating their continuation through
+  the in-flow pagination machinery would require float-tracking
+  continuation machinery (FloatManager-aware continuation state, float-
+  fragment resume contract, BFC-snapshot restoration).
+- **Task 19 (what landed)** — floats DON'T fragment across pages yet,
+  so nested **grid** + **flex** containers inside a float now emit
+  ATOMICALLY (the cycle-1 contract: all rows / items on one page,
+  overflowing the page edge if tall) — LOSSLESS, the correct
+  out-of-flow model, mirroring how a float with tall explicit content
+  already force-overflows. Gated by `_inAtomicFloatSubtree` (set
+  save/restore around the float recursion entry in `EmitFloat` /
+  `EmitNestedFloat`), which suppresses the recursive-site
+  paginatable-grid + paginatable-flex clamp/flag. In-flow content is
+  byte-identical (the flag is only set inside a float). A regression
+  test pins "float + 1000px grid on a 500px page → AllDone, no
+  `LAYOUT-FLOAT-BREAK-INSIDE-NESTED-001`, rows past the page edge
+  emitted".
+- **Still truncates (+ diagnoses)** — nested **table** + **multicol**
+  inside a float. Their wrapper sizing couples to the page budget
+  (`PreMeasureTableIfNeeded` with `useDryRunCommittedHeight`; the
+  MulticolLayouter paginates against the captured fragmentainer), so
+  forcing them atomic needs a page-budget-decoupled measure pass
+  (a separate cycle); until then the recursion return is discarded +
+  `LAYOUT-FLOAT-BREAK-INSIDE-NESTED-001` fires at most once per page.
+- **Missing** — atomic (or fragmenting) nested **table** + **multicol**
+  inside floats; the full float-tracking continuation machinery
+  (FloatManager state snapshot/restore across pages — the snapshot/
+  restore API already exists; float-fragment resume contract; cross-
+  page float overflow per CSS Fragmentation L3 §5) for true float
+  fragmentation rather than atomic overflow.
 - **Trigger** — corpus needs a float containing multicol/table that
   spans pages, OR a user-reported case where content inside a
   large float vanishes.

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -635,9 +635,7 @@ grepping the ID).
 - **Missing** — Per CSS Tables L3 + HTML5 §4.9.11: percentage
   column widths; full grid/table used-inline-size reconciliation for
   content-shrink scenarios; §6.3 border-collapse + border-spacing;
-  §6.4 column-group widths beyond Pass A fallback; row-internal
-  splitting (a single row taller than the fragmentainer is
-  currently atomic + triggers forced-overflow);
+  §6.4 column-group widths beyond Pass A fallback;
   §11 spec-strict rowspan distribution-proportional algorithm;
   CSS Tables L3 §3 spec-strict proportional-weight column-width
   distribution (sub-cycle 5 ships a deterministic linear-interpolation
@@ -686,12 +684,31 @@ grepping the ID).
     fallback was deleted (the class remains, still used for
     captions). The `TableLayouter` single-oversized-row forward-
     progress fallback is the safety net.
+    Phase 3 Task 17 cycle 5c.2d added **intra-cell row splitting at
+    BLOCK granularity**: a single body row whose cell content stacks
+    block children taller than the page now breaks WITHIN itself
+    across pages (`TableContinuation.RowSplitOffset` carries the
+    cell-relative cut; the resume page re-measures + re-slices
+    deterministically) instead of force-overflowing. Cell content is
+    measured at full natural height (`SuppressBlockPagination` on the
+    cell fragmentainer — pagination is the table's job, not the
+    cell's). The dry-run wrapper-sizing (`DryRunCommittedBlockSize`)
+    is split-aware so the outer dispatch propagates the continuation.
+    Tight cycle-1 scope: a split row OWNS each of its pages (the next
+    row starts fresh after the tail); enabled only when the table has
+    no footers + no bottom captions + the row carries no rowspan
+    origin. A single ATOMIC block taller than the page (explicit
+    `height`, no inner break opportunity) still force-overflows —
+    shares the `inline-only-block-line-splitting` line-granularity
+    deferral.
     Remaining: spec-strict §11 rowspan distribution-proportional
     algorithm; §6.3 border-collapse model + `border-spacing`;
-    row-internal splitting + row-level `break-inside: avoid`; RTL
-    writing modes / row reversal / caption inline-axis keyword
-    routing; HTML5 colspan='0'/rowspan='0' remainder semantics;
-    percentage column widths.
+    intra-cell splitting for rows WITH footers / bottom captions /
+    rowspan origins, and packing a following row below a split row's
+    tail (currently the next row starts fresh); row-level
+    `break-inside: avoid`; RTL writing modes / row reversal / caption
+    inline-axis keyword routing; HTML5 colspan='0'/rowspan='0'
+    remainder semantics; percentage column widths.
   - `src/NetPdf.Layout/Layouters/BlockLayouter.cs::PreMeasureTableIfNeeded`
     — sub-cycle 5 hardening Finding 6 now consumes the table's
     `MeasuredUsedInlineSize` to widen the wrapper's border-box

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -2297,49 +2297,70 @@ flags the categories):
 ## grid-fragment-plan-shared-sizing-deferral
 
 - **ID** — `grid-fragment-plan-shared-sizing-deferral`
-- **Status** — `not-started`. Phase 3 Task 17 cycle 5c.2b post-
-  PR-#100 review P2.
+- **Status** — `approximated`. Phase 3 Task 17 cycle 5c.2b post-
+  PR-#100 review P2; **partially addressed in Task 18** (the
+  cross-page row-extent memo landed; the full per-attempt plan
+  stays deferred — see below).
 - **Behavior** — auto-height paginatable grids run
-  `GridSizing.Resolve` three times per attempted fragment:
+  `GridSizing.Resolve` up to three times per attempted fragment:
   (1) in `PreMeasureGridRowExtent` to grow the wrapper to
   natural extent; (2) in F1's `PreMeasureGridRowExtentAt`
   probe (when no incoming cache present); (3) inside
-  `GridLayouter.AttemptLayout` for the actual dispatch. Each
-  `Resolve` runs §11 sizing + §8.5 placement; for grids with
-  many items + repeat-expanded tracks, this triples the §11
-  work per attempt + amplifies the cycle-5 resume cache's CPU
-  amortization rationale.
-- **Practical impact** — measurable CPU overhead on large
-  invoice / report grids; the resume cache hit path on page 2+
-  avoids one Resolve (cycle 5c.2a P1#2), but pages where the
-  cache is invalidated (= inline-size mismatch, identity
-  mismatch) or absent (= first-page) still triple-resolve.
-- **Missing** — a shared per-attempt `GridFragmentPlan`
-  immutable record carrying row geometry + placements + the
-  next-row fit prediction + the emitted-extent inputs, computed
-  ONCE per attempt + threaded through pre-measure +
-  `PreMeasureGridRowExtentAt` + `DispatchGridInner` so all
-  three sites consume the same authoritative resolve. Mirrors
-  the cycle-5 resume cache pattern but lives one layer up (=
-  per-attempt, not per-resume-cycle).
+  `GridLayouter.AttemptLayout` for the actual dispatch.
+- **Task 18 finding (corrects the original premise)** — the
+  three Resolves are NOT redundant duplicates; they take
+  GENUINELY DIFFERENT inputs, so a naive "compute once, share
+  across all three" would be **incorrect**: (1) uses an
+  INDEFINITE block budget (`contentBlockSize: 1`) to compute
+  the auto-height grid's natural extent — under indefinite
+  block, `fr` rows collapse (CSS Grid §11.5), whereas (3) uses
+  the DEFINITE wrapper extent where `fr` rows expand to fill;
+  the two produce different row sizes for `fr` grids (the
+  chicken-and-egg that forces site 1 to be separate). (2) the
+  probe passes NO content/width measurers, so its content-row
+  sizes differ from (3)'s. The Length-only fixtures that "don't
+  surface it" are exactly the case where indefinite≡definite +
+  measurers don't matter. Additionally, the EXPENSIVE work —
+  per-cell content SHAPING — is ALREADY shared across all three
+  sites via `GridMeasurementCache` (the `MeasurePassCount`
+  regression test pins it); the residual redundancy is only the
+  §11/§8.5 ARITHMETIC, which is comparatively cheap.
+- **Task 18 (what landed)** — `PreMeasureGridRowExtent`'s
+  natural row extent is page-INVARIANT (indefinite block budget;
+  fixed inline + page budget), and a multi-page grid re-grows
+  its wrapper on every page. That site-1 §11 pass is now
+  memoized on `GridMeasurementCache.RowExtentSum` keyed by
+  (grid box, inline size, measure budget), so resume pages +
+  rewind retries skip it entirely (the `RowExtentComputeCount`
+  regression test pins "== 1 across a multi-page grid").
+  Byte-identical (deterministic Resolve).
+- **Practical impact** — the first-page 3× remains (three
+  genuinely-different resolves; not safely collapsible), but
+  the expensive shaping is shared + the cross-page site-1
+  re-resolve is now elided.
+- **Missing** — collapsing the first-page site-2 (probe) and
+  site-3 (dispatch) resolves where they DO align (Length-only
+  grids, or by giving the probe the dispatch's measurers — but
+  that shifts content-grid pagination decisions, so it needs a
+  reftest sweep); a full per-attempt `GridFragmentPlan` is only
+  correct for the definite-block sites (2+3), NOT site 1.
 - **Trigger** — when a benchmark on a large multi-page grid
   shows measurable CPU regression vs cycle 5b atomic dispatch.
-  Until benchmarks land, accepted as a known cost since the
-  Length-only track tests in cycle 5c.2a/b don't surface it.
 - **Owner files** —
-  - `src/NetPdf.Layout/Layouters/GridSizing.cs` — `Result` type
-    becomes the shared plan's payload.
+  - `src/NetPdf.Layout/Layouters/GridMeasurementCache.cs` —
+    `RowExtentSum` memo + `RowExtentComputeCount` (Task 18).
   - `src/NetPdf.Layout/Layouters/BlockLayouter.cs` —
-    `PreMeasureGridRowExtent` + `PreMeasureGridRowExtentAt` +
-    `DispatchGridInner` thread the shared plan.
+    `PreMeasureGridRowExtent` consults the memo;
+    `PreMeasureGridRowExtentAt` + `DispatchGridInner` would
+    thread a definite-block plan for the 2+3 collapse.
   - `src/NetPdf.Layout/Layouters/GridLayouter.cs` —
     `ConfigureEmission` accepts a precomputed plan in lieu of
     running its own `Resolve`.
 - **Added** — Phase 3 Task 17 cycle 5c.2b + post-PR-#100 review
-  P2.
-- **Removal condition** — shared plan lands AND benchmark
-  shows ≤ 1× CPU vs cycle 5b atomic dispatch for paginatable-
-  grid fixtures.
+  P2; partially addressed Phase 3 Task 18.
+- **Removal condition** — the site-2+3 definite-block collapse
+  lands AND a benchmark shows ≤ 1× CPU vs cycle 5b atomic
+  dispatch for paginatable-grid fixtures.
 
 ---
 

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -8922,11 +8922,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // splits cleanly internally).
         if (useDryRunCommittedHeight)
         {
-            var resumeAt =
-                (incomingTableContinuation as TableContinuation)?.NextRowIndex ?? 0;
+            var resumeCont = incomingTableContinuation as TableContinuation;
+            var resumeAt = resumeCont?.NextRowIndex ?? 0;
+            // Per Phase 3 Task 17 cycle 5c.2d — thread the intra-cell row
+            // split offset so the dry-run sizes the resume-page wrapper to
+            // the row's REMAINING tail, not its full height.
+            var resumeSplitOffset = resumeCont?.RowSplitOffset ?? 0.0;
             var dryRunCommitted = tableLayouter.DryRunCommittedBlockSize(
                 fragmentainer, resumeAt,
-                out _, out _);
+                out _, out _, resumeSplitOffset);
             tableContentHeight = dryRunCommitted;
         }
         else

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -9760,6 +9760,18 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // common case (the cache key carries them, so a writing-mode mismatch just
         // misses + re-measures — correct, never stale). Null → the local caches.
         var measureBudget = _capturedFragmentainer?.BlockSize ?? 1_000_000;
+        // Per Phase 3 Task 18 (grid-fragment-plan-shared-sizing-deferral, partial) —
+        // the natural row extent is page-invariant for a fixed-width grid (block budget
+        // is the indefinite signal `1`; the inline size + measure budget don't change
+        // across the pages it spans). Memoize it on the shared cache so resume pages +
+        // rewind retries skip the redundant §11 sizing pass entirely (the cell shaping
+        // was already shared; this elides the arithmetic too). Byte-identical: Resolve
+        // is deterministic for the key.
+        if (sharedCache is not null
+            && sharedCache.TryGetRowExtentSum(gridBox, contentInlineSize, measureBudget, out var cachedRowExtent))
+        {
+            return cachedRowExtent;
+        }
         var measureCache = new Dictionary<(Box Item, double AvailInline), double>();
         GridSizing.GridContentMeasurer? measurer = _shaperResolver is null
             ? null
@@ -9816,6 +9828,9 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             cancellationToken: cancellationToken,
             contentMeasurer: measurer,
             widthMeasurer: widthMeasurer);
+        // Per Phase 3 Task 18 — memoize for the grid's subsequent pages / retries.
+        sharedCache?.CacheRowExtentSum(
+            gridBox, contentInlineSize, measureBudget, sizing.RowExtentSum);
         return sizing.RowExtentSum;
     }
 

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -447,6 +447,21 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// page. Reset on every AttemptLayout entry.</summary>
     private bool _emittedFloatBreakInsideNestedDiagnosticThisPage;
 
+    /// <summary>Per Phase 3 Task 19 (float-continuation-propagation, partial) — set
+    /// while emitting a FLOAT's subtree. Floats are out-of-flow (CSS 2.2 §9.5) and the
+    /// engine does NOT yet fragment them across pages; a nested grid / flex that
+    /// paginated inside a float returned a continuation the float path discarded,
+    /// silently TRUNCATING the overflow. With this flag set, nested grid + flex
+    /// containers in a float emit ATOMICALLY (the cycle-1 contract: all rows / items on
+    /// one page, overflowing the page edge if tall) — lossless, the correct "floats
+    /// don't fragment yet" model, mirroring how a float with tall explicit content
+    /// already force-overflows. Block-flow content in floats already emits atomically
+    /// (the float recursion passes no propagating fragmentainer). Nested TABLE +
+    /// multicol stay on the truncate-and-diagnose path (their wrapper-sizing couples to
+    /// the page budget — a separate cycle). Save/restore around the recursion entry so
+    /// float-in-float nesting composes; in-flow content (flag false) is byte-identical.</summary>
+    private bool _inAtomicFloatSubtree;
+
     /// <summary>Construct a layouter for <paramref name="rootBox"/>'s
     /// block children, emitting fragments into <paramref name="sink"/>.
     /// <paramref name="incomingContinuation"/> resumes a multi-page
@@ -5275,8 +5290,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // the page.</para>
                 // PR-#182 review P1 — suppressed for nested content (a discarded
                 // PageComplete would drop the deferred flex items).
+                // Per Phase 3 Task 19 — also suppressed inside a FLOAT subtree: the
+                // flex emits atomically (full natural extent, no page clamp) so its
+                // items are lossless rather than truncated past a discarded split.
                 if (IsPaginatableFlex(child)
                     && !_disableFlexPagination
+                    && !_inAtomicFloatSubtree
                     && _capturedFragmentainer is not null)
                 {
                     var pageRemainingForFlex =
@@ -5373,8 +5392,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // see authored == clamped + the dual-input mechanism
             // degenerates to legacy behavior.
             var recursiveAuthoredBorderBoxBlockSize = childBorderBoxBlockSize;
+            // Per Phase 3 Task 19 — a grid inside a FLOAT subtree emits atomically
+            // (full natural extent, no page clamp) so its rows are lossless rather than
+            // truncated past a discarded split (floats don't fragment yet).
             if (IsPaginatableGrid(child)
                 && !_disableGridPagination
+                && !_inAtomicFloatSubtree
                 && _capturedFragmentainer is not null)
             {
                 var pageRemainingForGrid =
@@ -6196,13 +6219,25 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // + emit a one-shot per-page diagnostic so the truncation is
         // observable. The first-page slice of the float is committed;
         // the deep break's remainder is lost.
-        var nestedFloatRet = EmitBlockSubtreeRecursive(
-            child,
-            parentBlockOffset: fragmentBlockOffset,
-            parentInlineOffset: fragmentInlineOffset,
-            parentInlineSize: borderBoxInlineSize,
-            cancellationToken: cancellationToken,
-            depth: 1);
+        // Per Phase 3 Task 19 — mark the float subtree so nested grid / flex emit
+        // atomically (lossless) instead of paginating into a discarded continuation.
+        var nestedPrevAtomicFloat = _inAtomicFloatSubtree;
+        _inAtomicFloatSubtree = true;
+        LayoutContinuation? nestedFloatRet;
+        try
+        {
+            nestedFloatRet = EmitBlockSubtreeRecursive(
+                child,
+                parentBlockOffset: fragmentBlockOffset,
+                parentInlineOffset: fragmentInlineOffset,
+                parentInlineSize: borderBoxInlineSize,
+                cancellationToken: cancellationToken,
+                depth: 1);
+        }
+        finally
+        {
+            _inAtomicFloatSubtree = nestedPrevAtomicFloat;
+        }
         if (nestedFloatRet is not null
             && !_emittedFloatBreakInsideNestedDiagnosticThisPage)
         {
@@ -6455,13 +6490,25 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // without float-tracking continuation machinery (existing
         // Phase 3 Task 8 deferral). Emit a one-shot per-page
         // diagnostic so authors see the truncation.
-        var floatRet = EmitBlockSubtreeRecursive(
-            child,
-            parentBlockOffset: fragmentBlockOffset,
-            parentInlineOffset: fragmentInlineOffset,
-            parentInlineSize: borderBoxInlineSize,
-            cancellationToken: cancellationToken,
-            depth: 1);
+        // Per Phase 3 Task 19 — mark the float subtree so nested grid / flex emit
+        // atomically (lossless) instead of paginating into a discarded continuation.
+        var floatPrevAtomicFloat = _inAtomicFloatSubtree;
+        _inAtomicFloatSubtree = true;
+        LayoutContinuation? floatRet;
+        try
+        {
+            floatRet = EmitBlockSubtreeRecursive(
+                child,
+                parentBlockOffset: fragmentBlockOffset,
+                parentInlineOffset: fragmentInlineOffset,
+                parentInlineSize: borderBoxInlineSize,
+                cancellationToken: cancellationToken,
+                depth: 1);
+        }
+        finally
+        {
+            _inAtomicFloatSubtree = floatPrevAtomicFloat;
+        }
         if (floatRet is not null
             && !_emittedFloatBreakInsideNestedDiagnosticThisPage)
         {

--- a/src/NetPdf.Layout/Layouters/GridMeasurementCache.cs
+++ b/src/NetPdf.Layout/Layouters/GridMeasurementCache.cs
@@ -34,11 +34,48 @@ internal sealed class GridMeasurementCache
     private readonly Dictionary<
         (Box Item, double BlockBudget, WritingMode Wm, bool Rtl), double> _inlineExtent = new();
 
+    /// <summary>Per Phase 3 Task 18 (grid-fragment-plan-shared-sizing-deferral, partial)
+    /// — the natural row extent <c>BlockLayouter.PreMeasureGridRowExtent</c> resolves to
+    /// grow an auto-height grid's wrapper, memoized per (grid box, content inline size,
+    /// measure block budget). That pre-grow runs an entire §11 sizing + §8.5 placement
+    /// pass and repeats IDENTICALLY on every page a multi-page grid spans (the inputs —
+    /// indefinite block budget = 1, the wrapper's content inline size, the page block
+    /// budget — are page-invariant). The cell SHAPING is already shared via
+    /// <see cref="_blockExtent"/>/<see cref="_inlineExtent"/>; this memo additionally
+    /// elides the redundant §11 ARITHMETIC on resume pages + rewind retries. The result
+    /// is deterministic for the key (same inputs → same Resolve), so a hit is byte-
+    /// identical.</summary>
+    private readonly Dictionary<(Box Grid, double Inline, double Budget), double> _rowExtentSum = new();
+
     /// <summary>Instrumentation — the <see cref="NestedContentMeasurer.Measure"/>
     /// passes that actually RAN (cache misses). A regression test asserts the
     /// pre-measure + emission of one grid share the cache (the second site adds
     /// zero passes), proving the cross-component win is real.</summary>
     public int MeasurePassCount { get; private set; }
+
+    /// <summary>Per Phase 3 Task 18 — instrumentation: the number of
+    /// <c>PreMeasureGridRowExtent</c> §11 passes that actually RAN (row-extent cache
+    /// misses). A regression test asserts a multi-page grid pre-measures its row extent
+    /// ONCE across all its pages (== 1), proving the cross-page memo elides the
+    /// per-page re-resolve.</summary>
+    public int RowExtentComputeCount { get; private set; }
+
+    /// <summary>Per Phase 3 Task 18 — true (with the memoized extent) when the natural
+    /// row extent for this grid + inputs was already resolved on a prior page / attempt.
+    /// The caller skips the §11 pass entirely on a hit.</summary>
+    public bool TryGetRowExtentSum(Box grid, double inline, double budget, out double extent)
+        => _rowExtentSum.TryGetValue((grid, inline, budget), out extent);
+
+    /// <summary>Per Phase 3 Task 18 — record a freshly-resolved row extent. Increments
+    /// <see cref="RowExtentComputeCount"/> only on the first store for a key (the caller
+    /// guards with <see cref="TryGetRowExtentSum"/>, so a key is computed once).</summary>
+    public void CacheRowExtentSum(Box grid, double inline, double budget, double extent)
+    {
+        var key = (grid, inline, budget);
+        if (_rowExtentSum.ContainsKey(key)) return;
+        RowExtentComputeCount++;
+        _rowExtentSum[key] = extent;
+    }
 
     /// <summary>The cell's CONTENT block extent at <paramref name="availInline"/>,
     /// memoized on the full input set. Mirrors the lambda in

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -152,24 +152,34 @@ namespace NetPdf.Layout.Layouters;
 ///   falling back to Pass B / Pass C.</item>
 ///   <item>Border-collapse model + <c>border-spacing</c> per
 ///   §6.3.</item>
-///   <item>Multi-fragmentainer ROW-INTERNAL splitting (one row whose
-///   content is taller than the remaining page is committed in full
-///   + the existing forced-overflow diagnostic fires; cycle 2+ may
-///   split row content across pages).</item>
+///   <item>Row-internal splitting is now LIVE at BLOCK granularity
+///   (Task 17 cycle 5c.2d): a body row whose cell stacks block
+///   children taller than the page breaks WITHIN itself across pages
+///   (the cut lands on the deepest block boundary that fits;
+///   <see cref="TableContinuation.RowSplitOffset"/> carries the
+///   cell-relative consumed extent). Tight scope: no footers / bottom
+///   captions / rowspan origin in the row. STILL deferred: a single
+///   ATOMIC block taller than the page (no inner block boundary)
+///   force-overflows rather than splitting mid-box (shares the prose
+///   <c>inline-only-block-line-splitting</c> line-granularity
+///   deferral); packing a following row below a split row's tail
+///   (a split row owns each of its pages).</item>
 ///   <item>Right-to-left tables / writing-mode flips.</item>
 ///   <item>Spec-strict CSS Tables L3 rowspan distribution-proportional
 ///   algorithm. Sub-cycle 2 uses a naive "extra height to the last
 ///   row of the span" approach.</item>
-///   <item>Nested-recursion continuation propagation past a single
-///   depth — Task 13 cycle 2 hardening (Finding 1) carries
-///   <see cref="TableContinuation"/> through
-///   <see cref="BlockLayouter.EmitBlockSubtreeRecursive"/> when the
-///   table is a DIRECT descendant (depth=1) of the just-emitted top-
-///   level block (so <c>&lt;body&gt;&gt;&lt;table&gt;</c> tables now
-///   split + repeat headers/footers across pages); deeper nesting
-///   (e.g. <c>&lt;body&gt;&gt;&lt;div&gt;&gt;&lt;table&gt;</c>) still
-///   falls back to the atomic <see cref="NoBreakBreakResolver"/>.
-///   Sub-cycle 6+ may generalize to arbitrary depth.</item>
+///   <item>Nested-recursion continuation propagation: Task 14 cycle 2
+///   hardening (Finding 1) lifted the original depth==1 limit —
+///   <see cref="BlockLayouter.EmitBlockSubtreeRecursive"/> now returns
+///   a <c>LayoutContinuation?</c> chain that carries a
+///   <see cref="TableContinuation"/> through ANY in-flow recursion
+///   depth (so both <c>&lt;body&gt;&gt;&lt;table&gt;</c> and
+///   <c>&lt;body&gt;&gt;&lt;div&gt;&gt;&lt;table&gt;</c> split + repeat
+///   headers/footers); the depth≥2 <see cref="NoBreakBreakResolver"/>
+///   fallback was deleted (the class survives for caption layout).
+///   Tables nested inside an out-of-flow FLOAT remain atomic (Task 19;
+///   the recursion still discards their continuation — see
+///   <c>docs/deferrals.md#float-continuation-propagation</c>).</item>
 /// </list>
 ///
 /// <para><b>Per Phase 3 Task 13 cycle 2 — <c>&lt;thead&gt;</c> /
@@ -192,13 +202,19 @@ namespace NetPdf.Layout.Layouters;
 /// <see cref="TableContinuation"/> via
 /// <see cref="LayoutAttemptResult.PageComplete"/>. The outer
 /// <see cref="BlockLayouter"/> propagates the continuation through
-/// its <see cref="BlockContinuation.LayouterState"/> slot.
-/// <c>PAGINATION-FORCED-OVERFLOW-001</c> still fires for the
-/// degenerate single-oversized-row case (a row taller than the
-/// fragmentainer is unsplittable in cycle 1 — committed in full +
-/// the existing forced-overflow diagnostic surfaces it). Row-INTERNAL
-/// splitting + per-row <c>break-inside: avoid</c> support are cycle
-/// 2+ scope — see
+/// its <see cref="BlockContinuation.LayouterState"/> slot. Per Task 17
+/// cycle 5c.2d a single oversized row that is SLICEABLE (its cell
+/// stacks block children) now breaks WITHIN itself at the deepest
+/// fitting block boundary instead of force-overflowing
+/// (<see cref="TableContinuation.RowSplitOffset"/>; the split-aware
+/// <see cref="DryRunCommittedBlockSize"/> sizes the wrapper to the
+/// slice so the outer dispatch propagates the continuation).
+/// <c>PAGINATION-FORCED-OVERFLOW-001</c> now fires only for the truly
+/// ATOMIC oversized row — one whose first remaining block is itself
+/// taller than the page (no inner block boundary to cut at), or a row
+/// with footers / bottom captions / a rowspan origin (out of the
+/// cycle's tight scope). Per-row <c>break-inside: avoid</c> support
+/// stays deferred — see
 /// <c>docs/deferrals.md#table-auto-fixed-spans-borders</c>.</para>
 ///
 /// <para><b>Per-cell break-resolver isolation (post-Finding-3 hardening).</b>
@@ -314,6 +330,20 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 throw new ArgumentOutOfRangeException(
                     nameof(incomingContinuation),
                     $"TableContinuation.ConsumedBlockSize={tc.ConsumedBlockSize} "
+                    + "must be finite + non-negative.");
+            }
+            // Per PR-#201 review P2 — RowSplitOffset is now layout-critical
+            // (it feeds the resume row's slice height + the dry-run wrapper
+            // size). A NaN / infinite / negative offset would produce a
+            // negative `remaining` / `sliceHeight` and emit negative-sized
+            // row + cell fragments. Reject at the boundary; the upper-bound
+            // (offset within the resumed row's height) is clamped in
+            // AttemptLayout once the measure pass knows the row height.
+            if (!double.IsFinite(tc.RowSplitOffset) || tc.RowSplitOffset < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(incomingContinuation),
+                    $"TableContinuation.RowSplitOffset={tc.RowSplitOffset} "
                     + "must be finite + non-negative.");
             }
         }
@@ -692,18 +722,30 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     /// sizing simulation (<see cref="DryRunCommittedBlockSize"/>).</summary>
     private const double IntraCellRowSplitMinBudgetPx = 1.0;
 
-    /// <summary>Per Phase 3 Task 17 cycle 5c.2d — whether body row
-    /// <paramref name="rowIndex"/> can break WITHIN itself at the cell-
-    /// relative block offset <paramref name="sliceEndCellRelative"/> (=
-    /// already-consumed cut + this page's budget). True only when the
-    /// tight cycle-1 scope holds — no footers, no bottom captions, no
-    /// rowspan origin in the row — AND at least one cell has a buffered
-    /// content fragment starting at/after the cut (= a real block-
-    /// granularity break opportunity below the budget; a single atomic
-    /// block has none). The emit-time splitter and the dry-run wrapper-
-    /// sizing simulation MUST agree, so both call this one predicate.</summary>
-    private bool IsBodyRowSliceable(int rowIndex, double sliceEndCellRelative)
+    /// <summary>Per Phase 3 Task 17 cycle 5c.2d (PR-#201 review P1) — derive the
+    /// intra-cell row split cut from the cell content's actual BLOCK BOUNDARIES,
+    /// not the raw page-budget edge. The <paramref name="cut"/> is the DEEPEST
+    /// buffered fragment BOTTOM (across every cell anchored in row
+    /// <paramref name="rowIndex"/>) that still fits the page window
+    /// <c>[<paramref name="priorCut"/>, priorCut + <paramref name="avail"/>]</c> —
+    /// i.e. "the last full block boundary that fits". Block-granularity: the cut
+    /// lands on a block edge, so a block whose bottom exceeds the window moves
+    /// WHOLE to the next page (it isn't cut mid-box); a spanning wrapper
+    /// fragment's bottom exceeds the window (the row is oversized) so it's
+    /// naturally excluded from the cut while the content blocks below it drive it.
+    ///
+    /// <para>Returns <see langword="true"/> (with <paramref name="cut"/> &gt;
+    /// <paramref name="priorCut"/>) only when the tight cycle-1 scope holds (no
+    /// footers, no bottom captions, no rowspan origin) AND at least one block
+    /// boundary fits past <paramref name="priorCut"/>. Returns
+    /// <see langword="false"/> when the FIRST remaining block is taller than the
+    /// page (no fitting boundary) → the caller force-overflows. The emit-time
+    /// splitter and the dry-run wrapper-sizing simulation MUST agree, so both
+    /// call this one method.</para></summary>
+    private bool TryComputeRowSliceCut(
+        int rowIndex, double priorCut, double avail, out double cut)
     {
+        cut = priorCut;
         if (_measuredFooterRowCount > 0) return false;
         if (_measuredCaptionList is { Count: > 0 })
         {
@@ -713,15 +755,23 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             }
         }
         if (_measuredPlacements is null) return false;
-        var any = false;
+        var limit = priorCut + avail;
         for (var i = 0; i < _measuredPlacements.Count; i++)
         {
             var p = _measuredPlacements[i];
             if (p.OriginRow != rowIndex) continue;
             if (p.RowSpan > 1) return false;
-            if (p.ContentBuffer.HasContentAtOrBelow(sliceEndCellRelative)) any = true;
+            var buf = p.ContentBuffer.Buffered;
+            for (var j = 0; j < buf.Count; j++)
+            {
+                var bottom = buf[j].BlockOffset + buf[j].BlockSize;
+                if (bottom > priorCut && bottom <= limit && bottom > cut)
+                {
+                    cut = bottom;
+                }
+            }
         }
-        return any;
+        return cut > priorCut + IntraCellRowSplitMinBudgetPx;
     }
 
     /// <summary>Per Phase 3 Task 13 cycle 1 hardening (Finding 2) —
@@ -814,8 +864,12 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             var chunk = rows[r].RowHeight;
             // Per Phase 3 Task 17 cycle 5c.2d — on the resume page of an
             // intra-cell split, only the row's REMAINING content (below
-            // the prior cut) is still to emit.
-            var priorCut = r == resumeAtRow ? incomingRowSplitOffset : 0.0;
+            // the prior cut) is still to emit. Per PR-#201 review P2 —
+            // clamp the offset to the measured row height so a malformed
+            // over-large continuation can't drive remainingChunk negative.
+            var priorCut = r == resumeAtRow
+                ? System.Math.Min(incomingRowSplitOffset, chunk)
+                : 0.0;
             var remainingChunk = chunk - priorCut;
             // cycle 2: chunk fits if rowBottom + footerStackHeight <= BlockSize.
             if (cursorInFragmentainer + remainingChunk + footerStackHeight > pageBlockSize)
@@ -836,19 +890,20 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 {
                     // Per Phase 3 Task 17 cycle 5c.2d — when the oversized
                     // row is SLICEABLE it breaks WITHIN itself: only the
-                    // page-budget slice commits here + the table returns
-                    // PageComplete. Report needsSplitting (NOT force-
-                    // overflow) so the wrapper sizes to the slice + the
-                    // outer dispatch propagates the continuation, matching
-                    // the multi-row deferral path. A non-sliceable atomic
-                    // row keeps the forced-overflow path (full chunk).
+                    // boundary-aligned slice commits here + the table
+                    // returns PageComplete. Report needsSplitting (NOT
+                    // force-overflow) so the wrapper sizes to the slice +
+                    // the outer dispatch propagates the continuation. The
+                    // committed extent is the SAME boundary-derived cut the
+                    // emit pass uses (PR-#201 review P1), not the raw
+                    // budget, so the wrapper matches the emitted slice.
                     var availForRow =
                         pageBlockSize - cursorInFragmentainer - footerStackHeight;
                     if (availForRow > IntraCellRowSplitMinBudgetPx
-                        && IsBodyRowSliceable(r, priorCut + availForRow))
+                        && TryComputeRowSliceCut(r, priorCut, availForRow, out var dryCut))
                     {
                         needsSplitting = true;
-                        committedBodyRowsBlock += availForRow;
+                        committedBodyRowsBlock += dryCut - priorCut;
                         // Row r is NOT fully committed: leave
                         // lastCommittedRowExclusive < bodyEnd so bottom
                         // captions don't count toward this page's extent.
@@ -1702,22 +1757,29 @@ internal sealed class TableLayouter : ILayouter, IDisposable
 
             var rowHeight = rows![r].RowHeight;
             var remaining = rowHeight - priorCut;
-            var sliceEnd = priorCut + availBudget;
 
-            // Sliceable only when the remaining content has a block-
-            // granularity break opportunity at/below the budget (shared
-            // with the dry-run wrapper-sizing predicate so both agree). A
-            // single atomic block taller than the page has none and must
-            // force-overflow (mirrors inline-only-block-line-splitting).
-            // The tail-fits case (remaining <= budget) needs no such
-            // boundary — it emits the rest in one go.
-            if (remaining > availBudget && !IsBodyRowSliceable(r, sliceEnd))
+            // Choose the slice height. The tail-fits case emits all the
+            // remaining content in one go. Otherwise the cut lands on the
+            // DEEPEST block boundary that fits the budget (PR-#201 review
+            // P1) — NOT the raw page edge — so an earlier boundary isn't
+            // missed + a block straddling the edge moves whole rather than
+            // overflowing. No fitting boundary → the first remaining block
+            // is taller than the page → force-overflow (return null).
+            double sliceHeight;
+            if (remaining <= availBudget)
+            {
+                sliceHeight = remaining;
+            }
+            else if (TryComputeRowSliceCut(r, priorCut, availBudget, out var cut))
+            {
+                sliceHeight = cut - priorCut;
+            }
+            else
             {
                 return null;
             }
 
-            // Commit. Headers repeat at the top of every page the row
-            // spans; the slice fills the remaining budget.
+            // Commit. Headers repeat at the top of every page the row spans.
             if (repeatHeadOnThisPage)
             {
                 EmitHeaderRows(
@@ -1729,7 +1791,6 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                     cancellationToken: cancellationToken);
             }
 
-            var sliceHeight = System.Math.Min(remaining, availBudget);
             var hasMore = EmitSlicedRow(
                 rows!, placementsByRow, columnOffsetsLocal!, rowBlockOffsets,
                 usedInlineSize, r, priorCut, sliceHeight,
@@ -1778,7 +1839,15 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // row. Emit the tail slice (which may itself split again).
         if (incomingRowSplitOffset > 0 && resumeAtRow < bodyEnd)
         {
-            var splitResume = TryEmitSplitRow(resumeAtRow, incomingRowSplitOffset);
+            // Per PR-#201 review P2 — the constructor already rejected NaN /
+            // infinite / negative offsets; clamp an over-large offset to the
+            // now-measured row height so the slice height can't go negative.
+            // Clamped == row height ⇒ remaining 0 ⇒ TryEmitSplitRow emits a
+            // degenerate empty slice + advances to the next row (no re-emit /
+            // no loss) — the graceful recovery for a malformed continuation.
+            var resumeRowHeight = rows![resumeAtRow].RowHeight;
+            var clampedSplitOffset = System.Math.Min(incomingRowSplitOffset, resumeRowHeight);
+            var splitResume = TryEmitSplitRow(resumeAtRow, clampedSplitOffset);
             if (splitResume is not null) return splitResume.Value;
             // Not splittable on resume (shouldn't happen — we only park a
             // row we already sliced) — fall through to the normal loop,
@@ -5697,24 +5766,6 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 target.Emit(f with { BlockOffset = f.BlockOffset + shift });
             }
             return hasMore;
-        }
-
-        /// <summary>Per Phase 3 Task 17 cycle 5c.2d — true when any
-        /// buffered fragment's cell-relative block TOP is at or below
-        /// <paramref name="cellRelativeOffset"/>. Drives the intra-cell
-        /// split decision: a row only splits (rather than force-
-        /// overflowing) when its content has a block-granularity break
-        /// opportunity below the page budget — i.e. at least one cell has
-        /// a fragment starting at/after the cut. A single atomic block
-        /// (explicit-<c>height</c> cell, no inner break opportunity) has
-        /// no such fragment and falls back to forced-overflow.</summary>
-        public bool HasContentAtOrBelow(double cellRelativeOffset)
-        {
-            for (var i = 0; i < _buffered.Count; i++)
-            {
-                if (_buffered[i].BlockOffset >= cellRelativeOffset) return true;
-            }
-            return false;
         }
 
         /// <summary>Per Finding 2 — exposed for diagnostics / tests

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -685,6 +685,45 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     /// size when it exceeds the wrapper.</para></summary>
     internal double MeasuredUsedInlineSize => _measuredUsedInlineSize;
 
+    /// <summary>Per Phase 3 Task 17 cycle 5c.2d — the minimum per-row
+    /// page budget below which an intra-cell split can't make forward
+    /// progress (a near-zero slice would loop). Shared by the emit-time
+    /// split decision (<c>TryEmitSplitRow</c>) and the dry-run wrapper-
+    /// sizing simulation (<see cref="DryRunCommittedBlockSize"/>).</summary>
+    private const double IntraCellRowSplitMinBudgetPx = 1.0;
+
+    /// <summary>Per Phase 3 Task 17 cycle 5c.2d — whether body row
+    /// <paramref name="rowIndex"/> can break WITHIN itself at the cell-
+    /// relative block offset <paramref name="sliceEndCellRelative"/> (=
+    /// already-consumed cut + this page's budget). True only when the
+    /// tight cycle-1 scope holds — no footers, no bottom captions, no
+    /// rowspan origin in the row — AND at least one cell has a buffered
+    /// content fragment starting at/after the cut (= a real block-
+    /// granularity break opportunity below the budget; a single atomic
+    /// block has none). The emit-time splitter and the dry-run wrapper-
+    /// sizing simulation MUST agree, so both call this one predicate.</summary>
+    private bool IsBodyRowSliceable(int rowIndex, double sliceEndCellRelative)
+    {
+        if (_measuredFooterRowCount > 0) return false;
+        if (_measuredCaptionList is { Count: > 0 })
+        {
+            for (var i = 0; i < _measuredCaptionList.Count; i++)
+            {
+                if (_measuredCaptionList[i].Side == CaptionSide.Bottom) return false;
+            }
+        }
+        if (_measuredPlacements is null) return false;
+        var any = false;
+        for (var i = 0; i < _measuredPlacements.Count; i++)
+        {
+            var p = _measuredPlacements[i];
+            if (p.OriginRow != rowIndex) continue;
+            if (p.RowSpan > 1) return false;
+            if (p.ContentBuffer.HasContentAtOrBelow(sliceEndCellRelative)) any = true;
+        }
+        return any;
+    }
+
     /// <summary>Per Phase 3 Task 13 cycle 1 hardening (Finding 2) —
     /// dry-run pagination simulation to estimate the block-axis extent
     /// the table will commit on the current page WITHOUT actually
@@ -713,7 +752,8 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         FragmentainerContext fragmentainer,
         int resumeAtRow,
         out bool needsSplitting,
-        out bool willForceOverflowOnSingleRow)
+        out bool willForceOverflowOnSingleRow,
+        double incomingRowSplitOffset = 0.0)
     {
         needsSplitting = false;
         willForceOverflowOnSingleRow = false;
@@ -772,8 +812,13 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         for (var r = resumeAtRow; r < bodyEnd; r++)
         {
             var chunk = rows[r].RowHeight;
+            // Per Phase 3 Task 17 cycle 5c.2d — on the resume page of an
+            // intra-cell split, only the row's REMAINING content (below
+            // the prior cut) is still to emit.
+            var priorCut = r == resumeAtRow ? incomingRowSplitOffset : 0.0;
+            var remainingChunk = chunk - priorCut;
             // cycle 2: chunk fits if rowBottom + footerStackHeight <= BlockSize.
-            if (cursorInFragmentainer + chunk + footerStackHeight > pageBlockSize)
+            if (cursorInFragmentainer + remainingChunk + footerStackHeight > pageBlockSize)
             {
                 // First body row on page: forced-overflow forward-
                 // progress. Per cycle 2 also forces when the row is
@@ -784,14 +829,36 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 var freshPageBodyBudget = pageBlockSize - headerStackHeight - footerStackHeight;
                 var bodyRowIntrinsicallyOversized = bodyHasOverhead
                     && r == resumeAtRow
-                    && chunk > freshPageBodyBudget;
+                    && remainingChunk > freshPageBodyBudget;
                 if ((r == resumeAtRow
                     && !(isFirstPage && _measuredTopCaptionsTotal > 0))
                     || bodyRowIntrinsicallyOversized)
                 {
-                    willForceOverflowOnSingleRow = true;
-                    committedBodyRowsBlock += chunk;
-                    lastCommittedRowExclusive = r + 1;
+                    // Per Phase 3 Task 17 cycle 5c.2d — when the oversized
+                    // row is SLICEABLE it breaks WITHIN itself: only the
+                    // page-budget slice commits here + the table returns
+                    // PageComplete. Report needsSplitting (NOT force-
+                    // overflow) so the wrapper sizes to the slice + the
+                    // outer dispatch propagates the continuation, matching
+                    // the multi-row deferral path. A non-sliceable atomic
+                    // row keeps the forced-overflow path (full chunk).
+                    var availForRow =
+                        pageBlockSize - cursorInFragmentainer - footerStackHeight;
+                    if (availForRow > IntraCellRowSplitMinBudgetPx
+                        && IsBodyRowSliceable(r, priorCut + availForRow))
+                    {
+                        needsSplitting = true;
+                        committedBodyRowsBlock += availForRow;
+                        // Row r is NOT fully committed: leave
+                        // lastCommittedRowExclusive < bodyEnd so bottom
+                        // captions don't count toward this page's extent.
+                    }
+                    else
+                    {
+                        willForceOverflowOnSingleRow = true;
+                        committedBodyRowsBlock += remainingChunk;
+                        lastCommittedRowExclusive = r + 1;
+                    }
                 }
                 else
                 {
@@ -799,8 +866,8 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 }
                 break;
             }
-            committedBodyRowsBlock += chunk;
-            cursorInFragmentainer += chunk;
+            committedBodyRowsBlock += remainingChunk;
+            cursorInFragmentainer += remainingChunk;
             lastCommittedRowExclusive = r + 1;
         }
         // Bottom captions only on the last page (= committed all body
@@ -931,6 +998,11 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // [0, rowCount] check.
         var rawResumeAtRow = _incomingTableContinuation?.NextRowIndex ?? 0;
         var priorConsumedBlock = _incomingTableContinuation?.ConsumedBlockSize ?? 0.0;
+        // Per Phase 3 Task 17 cycle 5c.2d — intra-cell row splitting. A
+        // non-zero RowSplitOffset means the resume row (NextRowIndex) is
+        // the TAIL of a row whose content split across pages; this much of
+        // its cell-relative block extent already emitted on prior pages.
+        var incomingRowSplitOffset = _incomingTableContinuation?.RowSplitOffset ?? 0.0;
         if (rows is not null && rawResumeAtRow > rowCount)
         {
             throw new ArgumentOutOfRangeException(
@@ -950,7 +1022,14 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // Cycle-2 "isFirstPage" means: this is the FIRST emit of the
         // table (top captions still pending; not a resume). Mirrors the
         // cycle-1 semantic of rawResumeAtRow == 0.
-        var isFirstPage = rawResumeAtRow == 0;
+        //
+        // Per Phase 3 Task 17 cycle 5c.2d — a split of row 0 resumes with
+        // NextRowIndex == 0 BUT a non-zero RowSplitOffset; that's a resume
+        // page (top captions + first-page semantics already committed),
+        // NOT the first page. Exclude it from the sentinel so captions
+        // don't re-emit and the continuation's RepeatHead / RepeatFoot
+        // flags drive header / footer repetition.
+        var isFirstPage = rawResumeAtRow == 0 && incomingRowSplitOffset == 0;
 
         // Per Phase 3 Task 13 cycle 2 hardening (Finding 4) — honor
         // RepeatHead / RepeatFoot on resume pages. On the FIRST page
@@ -1579,6 +1658,133 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // EXACTLY the cycle-2 contract.
         fragmentainer.UsedBlockSize = bodyAnchor + effectiveFooterStackHeight;
 
+        // Per Phase 3 Task 17 cycle 5c.2d — intra-cell row splitting
+        // support. A row whose content overflows the page body budget AND
+        // has a block-granularity break opportunity below the budget
+        // breaks WITHIN itself (the fitting slice emits here; the rest
+        // resumes next page) instead of force-overflowing at full extent.
+        // Tight cycle-1 scope: no footers, no bottom captions, no rowspan
+        // origin in the row, and a real sliceable boundary — otherwise
+        // the existing forced-overflow path runs unchanged.
+        var splitHasBottomCaption = false;
+        if (captions is { Count: > 0 })
+        {
+            for (var ci = 0; ci < captions.Count; ci++)
+            {
+                if (captions[ci].Side == CaptionSide.Bottom)
+                {
+                    splitHasBottomCaption = true;
+                    break;
+                }
+            }
+        }
+        var splitHeaderDiagSink = _diagnostics ?? layout.Diagnostics;
+
+        // Emit body row `r` sliced from cell-relative offset `priorCut`.
+        // Returns a PageComplete / AllDone result when the row is
+        // SLICEABLE; returns null to signal "fall back to forced-overflow"
+        // (atomic block, rowspan origin, footers / bottom captions, or no
+        // room for forward progress).
+        LayoutAttemptResult? TryEmitSplitRow(int r, double priorCut)
+        {
+            if (footerCount > 0 || splitHasBottomCaption) return null;
+            var bucket = placementsByRow[r];
+            if (bucket is null || bucket.Count == 0) return null;
+            for (var i = 0; i < bucket.Count; i++)
+            {
+                if (bucket[i].RowSpan > 1) return null;
+            }
+
+            var rowTop = rowBlockOffsets[r];
+            // No footer reservation in scope (footerCount == 0).
+            var availBudget = fragmentainer.BlockSize - rowTop;
+            if (availBudget <= IntraCellRowSplitMinBudgetPx) return null;
+
+            var rowHeight = rows![r].RowHeight;
+            var remaining = rowHeight - priorCut;
+            var sliceEnd = priorCut + availBudget;
+
+            // Sliceable only when the remaining content has a block-
+            // granularity break opportunity at/below the budget (shared
+            // with the dry-run wrapper-sizing predicate so both agree). A
+            // single atomic block taller than the page has none and must
+            // force-overflow (mirrors inline-only-block-line-splitting).
+            // The tail-fits case (remaining <= budget) needs no such
+            // boundary — it emits the rest in one go.
+            if (remaining > availBudget && !IsBodyRowSliceable(r, sliceEnd))
+            {
+                return null;
+            }
+
+            // Commit. Headers repeat at the top of every page the row
+            // spans; the slice fills the remaining budget.
+            if (repeatHeadOnThisPage)
+            {
+                EmitHeaderRows(
+                    rows!, placementsByRow, columnOffsetsLocal!,
+                    rowBlockOffsets, rowEndBlockOffset, usedInlineSize,
+                    headerStart: 0, headerEndExclusive: headerCount,
+                    flushDiagnostics: splitHeaderDiagSink,
+                    diagnosticsAlreadyFlushed: ref _headerCellDiagnosticsFlushed,
+                    cancellationToken: cancellationToken);
+            }
+
+            var sliceHeight = System.Math.Min(remaining, availBudget);
+            var hasMore = EmitSlicedRow(
+                rows!, placementsByRow, columnOffsetsLocal!, rowBlockOffsets,
+                usedInlineSize, r, priorCut, sliceHeight,
+                cancellationToken, commitDiagSink);
+
+            // Restore UsedBlockSize so the outer wrapper-advance doesn't
+            // double-count (mirrors the other PageComplete returns).
+            fragmentainer.UsedBlockSize = initialUsedBlockSize;
+
+            if (hasMore)
+            {
+                // More of THIS row remains — resume it on the next page.
+                return LayoutAttemptResult.PageComplete(
+                    new TableContinuation(
+                        RepeatHead: headerCount > 0,
+                        RepeatFoot: false,
+                        NextRowIndex: r,
+                        ConsumedBlockSize: priorConsumedBlock + sliceHeight,
+                        ColumnLayoutCache: BuildColumnLayoutCache(),
+                        RowSplitOffset: priorCut + sliceHeight),
+                    cost: 0);
+            }
+
+            if (r + 1 < bodyEnd)
+            {
+                // More body rows remain. A split row owns its pages (cycle
+                // 1 scope): the next row starts fresh on the following page
+                // rather than packing below this row's tail.
+                return LayoutAttemptResult.PageComplete(
+                    new TableContinuation(
+                        RepeatHead: headerCount > 0,
+                        RepeatFoot: false,
+                        NextRowIndex: r + 1,
+                        ConsumedBlockSize: priorConsumedBlock + sliceHeight,
+                        ColumnLayoutCache: BuildColumnLayoutCache(),
+                        RowSplitOffset: 0.0),
+                    cost: 0);
+            }
+
+            // Last body row, fully emitted, no footers / bottom captions
+            // in scope — the table is done.
+            return LayoutAttemptResult.AllDone(cost: 0);
+        }
+
+        // Resume of a split row: the incoming continuation parked us mid-
+        // row. Emit the tail slice (which may itself split again).
+        if (incomingRowSplitOffset > 0 && resumeAtRow < bodyEnd)
+        {
+            var splitResume = TryEmitSplitRow(resumeAtRow, incomingRowSplitOffset);
+            if (splitResume is not null) return splitResume.Value;
+            // Not splittable on resume (shouldn't happen — we only park a
+            // row we already sliced) — fall through to the normal loop,
+            // which force-overflows the remaining content losslessly.
+        }
+
         for (var r = resumeAtRow; r < bodyEnd; r++)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -1868,6 +2074,26 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 // Subcase (a): fall through to emit r anyway.
             }
 
+            // Per Phase 3 Task 17 cycle 5c.2d — intra-cell split point.
+            // A row about to commit whose bottom overflows this page (=
+            // forced-overflow: it's first on the page + can't fit ANY
+            // page) breaks WITHIN itself when sliceable, instead of
+            // overflowing at full extent. Reached by BOTH the resolver's
+            // Continue (LastResort emits the oversized first row) and the
+            // BreakHere force-overflow fall-through above. Returns null
+            // for atomic / out-of-scope rows → forced-overflow unchanged.
+            if (rowsEmittedOnPage == 0)
+            {
+                var pageBudgetForRow =
+                    fragmentainer.BlockSize - effectiveFooterStackHeight;
+                var rowBottom = rowBlockOffsets[r] + rows![r].RowHeight;
+                if (rowBottom > pageBudgetForRow + IntraCellRowSplitMinBudgetPx)
+                {
+                    var splitFresh = TryEmitSplitRow(r, 0.0);
+                    if (splitFresh is not null) return splitFresh.Value;
+                }
+            }
+
             // Continue / forced-overflow forward progress — commit
             // this row. The actual emission happens in a single batch
             // after the loop (EmitRowWindow) so the paint-safe order
@@ -2116,6 +2342,87 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // for future content-side row-window-specific logic (e.g.,
         // cycle 2's rowspan truncation).
         _ = placements;
+    }
+
+    /// <summary>Per Phase 3 Task 17 cycle 5c.2d — emit a SINGLE body row
+    /// sliced to the block window
+    /// <c>[<paramref name="sliceStart"/>, sliceStart + <paramref name="sliceHeight"/>)</c>
+    /// of its cell content (intra-cell row splitting). The row + cell
+    /// box fragments are sized to <paramref name="sliceHeight"/> (this
+    /// page's visible portion); the cell content drains via
+    /// <see cref="MeasuringFragmentSink.FlushSlice"/>. Paint-safe order
+    /// (row → cells → content) mirrors <see cref="EmitRowWindow"/>.
+    ///
+    /// <para>Returns <see langword="true"/> when any cell still has
+    /// content below the window (= a continuation is needed). The caller
+    /// guarantees the row has no rowspan crossing (every anchored cell is
+    /// <c>RowSpan == 1</c>) per the cycle's tight scope. Cell diagnostics
+    /// flush ONLY on the final slice (<c>!hasMore</c>) so a row spanning
+    /// N pages doesn't emit its content diagnostics N times — the resume
+    /// page re-measures the cell deterministically, so the final-slice
+    /// flush carries the identical diagnostic set.</para></summary>
+    private bool EmitSlicedRow(
+        List<RowMeasurement> rows,
+        List<CellPlacement>?[] placementsByRow,
+        double[] columnOffsets,
+        double[] rowBlockOffsets,
+        double usedInlineSize,
+        int rowIndex,
+        double sliceStart,
+        double sliceHeight,
+        CancellationToken cancellationToken,
+        IPaginateDiagnosticsSink? diagSink)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var rowTop = rowBlockOffsets[rowIndex];
+
+        // Phase A — row background fragment, clamped to the slice height.
+        _sink.Emit(new BoxFragment(
+            Box: rows[rowIndex].Row,
+            InlineOffset: _contentInlineOffset,
+            BlockOffset: rowTop,
+            InlineSize: usedInlineSize,
+            BlockSize: sliceHeight));
+
+        var bucket = placementsByRow[rowIndex];
+        if (bucket is null) return false;
+
+        // Phase B — cell background fragments, clamped to the slice height.
+        for (var i = 0; i < bucket.Count; i++)
+        {
+            var placement = bucket[i];
+            var cellInlineOffset = _contentInlineOffset
+                + columnOffsets[placement.OriginCol];
+            var cellInlineSize =
+                columnOffsets[placement.OriginCol + placement.ColSpan]
+                - columnOffsets[placement.OriginCol];
+            _sink.Emit(new BoxFragment(
+                Box: placement.Cell,
+                InlineOffset: cellInlineOffset,
+                BlockOffset: rowTop,
+                InlineSize: cellInlineSize,
+                BlockSize: sliceHeight));
+        }
+
+        // Phase C — slice each cell's buffered content into the window.
+        var sliceEnd = sliceStart + sliceHeight;
+        var hasMore = false;
+        for (var i = 0; i < bucket.Count; i++)
+        {
+            if (bucket[i].ContentBuffer.FlushSlice(
+                    _sink, rowTop, sliceStart, sliceEnd))
+            {
+                hasMore = true;
+            }
+        }
+        if (!hasMore && diagSink is not null)
+        {
+            for (var i = 0; i < bucket.Count; i++)
+            {
+                bucket[i].DiagnosticsBuffer?.FlushTo(diagSink);
+            }
+        }
+        return hasMore;
     }
 
     /// <summary>Per Phase 3 Task 13 cycle 2 — emit the
@@ -4984,9 +5291,23 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // anchored at that column is empty.
         var innerContentInlineSize = cellInlineSize - inlineEdges;
         if (innerContentInlineSize < 1.0) innerContentInlineSize = 1.0;
+        // Per Phase 3 Task 17 cycle 5c.2d — a table cell measures its
+        // FULL natural content height; pagination is the TABLE's job, not
+        // the cell's. SuppressBlockPagination keeps the inner block-flow
+        // layout from self-paginating (which, post-Task-16 prose
+        // pagination, would otherwise truncate a multi-block cell taller
+        // than the page to the fragmentainer height + silently discard the
+        // remainder — see the disableGridPagination note below). With it
+        // set, the cell's buffered fragments span its true extent, so the
+        // row sizes correctly AND the intra-cell splitter can slice the
+        // overflowing portion across pages. The real blockSize is kept so
+        // %-height children still resolve against the page box.
         var cellFragmentainer = new FragmentainerContext(
             contentInlineSize: innerContentInlineSize,
-            blockSize: Math.Max(fragmentainer.BlockSize, 1));
+            blockSize: Math.Max(fragmentainer.BlockSize, 1))
+        {
+            SuppressBlockPagination = true,
+        };
 
         // Per Finding 5 — wrap the ambient diagnostic sink in a
         // BufferingDiagnosticsSink. Cell-internal diagnostics (e.g.,
@@ -5329,6 +5650,71 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                 }
                 target.Emit(f);
             }
+        }
+
+        /// <summary>Per Phase 3 Task 17 cycle 5c.2d — intra-cell row
+        /// splitting. Drains the buffered fragments whose cell-relative
+        /// block TOP falls in the window
+        /// <c>[<paramref name="sliceStart"/>, <paramref name="sliceEnd"/>)</c>,
+        /// shifting each so content at cell-offset
+        /// <paramref name="sliceStart"/> lands at
+        /// <paramref name="additionalBlockOffset"/> (= this page's row
+        /// block origin). Fragments above the window (top &lt;
+        /// <paramref name="sliceStart"/>) were committed on a prior page
+        /// and are skipped; fragments below it (top &gt;=
+        /// <paramref name="sliceEnd"/>) are left for the next page.
+        ///
+        /// <para><b>Block-granularity.</b> Inclusion keys on the
+        /// fragment's TOP edge — a fragment straddling
+        /// <paramref name="sliceEnd"/> is emitted in full on the current
+        /// page (it overflows the budget rather than being cut mid-box),
+        /// mirroring the prose <c>inline-only-block-line-splitting</c>
+        /// rule. The buffer is NOT cleared (the resume page re-measures
+        /// the cell deterministically + re-slices), so this is safe to
+        /// call once per page across the row's split lifetime.</para>
+        ///
+        /// <para>Returns <see langword="true"/> when at least one buffered
+        /// fragment lies at or below <paramref name="sliceEnd"/> (= the
+        /// row has more content for a subsequent page).</para></summary>
+        public bool FlushSlice(
+            IBlockFragmentSink target,
+            double additionalBlockOffset,
+            double sliceStart,
+            double sliceEnd)
+        {
+            ArgumentNullException.ThrowIfNull(target);
+            var shift = additionalBlockOffset - sliceStart;
+            var hasMore = false;
+            for (var i = 0; i < _buffered.Count; i++)
+            {
+                var f = _buffered[i];
+                if (f.BlockOffset >= sliceEnd)
+                {
+                    hasMore = true;
+                    continue;
+                }
+                if (f.BlockOffset < sliceStart) continue;
+                target.Emit(f with { BlockOffset = f.BlockOffset + shift });
+            }
+            return hasMore;
+        }
+
+        /// <summary>Per Phase 3 Task 17 cycle 5c.2d — true when any
+        /// buffered fragment's cell-relative block TOP is at or below
+        /// <paramref name="cellRelativeOffset"/>. Drives the intra-cell
+        /// split decision: a row only splits (rather than force-
+        /// overflowing) when its content has a block-granularity break
+        /// opportunity below the page budget — i.e. at least one cell has
+        /// a fragment starting at/after the cut. A single atomic block
+        /// (explicit-<c>height</c> cell, no inner break opportunity) has
+        /// no such fragment and falls back to forced-overflow.</summary>
+        public bool HasContentAtOrBelow(double cellRelativeOffset)
+        {
+            for (var i = 0; i < _buffered.Count; i++)
+            {
+                if (_buffered[i].BlockOffset >= cellRelativeOffset) return true;
+            }
+            return false;
         }
 
         /// <summary>Per Finding 2 — exposed for diagnostics / tests

--- a/src/NetPdf.Paginate/LayoutContinuation.cs
+++ b/src/NetPdf.Paginate/LayoutContinuation.cs
@@ -80,13 +80,32 @@ internal sealed record InlineContinuation(
 /// widths so the resume-page TableLayouter skips the (expensive) auto-
 /// layout pass. When non-null on resume, the layouter loads the cached
 /// values + jumps straight to the cell-content emit pass for the
-/// resumed rows.</summary>
+/// resumed rows.
+/// <paramref name="RowSplitOffset"/> per Phase 3 Task 17 cycle 5c.2d —
+/// intra-cell ROW splitting. When a single body row's content is taller
+/// than the entire fragmentainer body budget AND its cells' content is
+/// SLICEABLE (= has block-granularity break opportunities below the
+/// page budget), the row breaks WITHIN itself: the portion that fits is
+/// emitted on this page and the remainder resumes on the next page at
+/// row <paramref name="NextRowIndex"/>. <paramref name="RowSplitOffset"/>
+/// is the cumulative cell-relative block-axis extent of row
+/// <paramref name="NextRowIndex"/> ALREADY emitted on prior pages (0 =
+/// the row starts fresh; &gt; 0 = resume the row's tail at that cell-
+/// relative offset). Block-granularity only — a single atomic block
+/// (e.g. an explicit-<c>height</c> cell with no inner break
+/// opportunity) taller than the page still force-overflows rather than
+/// splitting mid-block (mirrors the prose
+/// <c>inline-only-block-line-splitting</c> deferral). The cut is the
+/// page budget; the resume page re-measures the cells deterministically
+/// + re-slices from <paramref name="RowSplitOffset"/>, so the heavy
+/// per-cell content buffers don't need to cross the page boundary.</summary>
 internal sealed record TableContinuation(
     bool RepeatHead,
     bool RepeatFoot,
     int NextRowIndex,
     double ConsumedBlockSize = 0.0,
-    object? ColumnLayoutCache = null) : LayoutContinuation;
+    object? ColumnLayoutCache = null,
+    double RowSplitOffset = 0.0) : LayoutContinuation;
 
 /// <summary>Multi-line flex container split between flex lines.
 /// <c>LineIndex</c> identifies the next flex line to emit.

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -859,6 +859,57 @@ public sealed class GridLayouterProductionTests
     }
 
     [Fact]
+    public async Task Float_with_tall_nested_grid_emits_atomically_without_truncation()
+    {
+        // Per Phase 3 Task 19 (float-continuation-propagation, partial) — a grid taller
+        // than the page INSIDE a float used to paginate, and the out-of-flow float path
+        // discarded the continuation → the overflow rows were silently TRUNCATED +
+        // LAYOUT-FLOAT-BREAK-INSIDE-NESTED-001 fired. Floats don't fragment across pages
+        // yet, so the grid now emits ATOMICALLY (all rows, overflowing the page edge) —
+        // lossless, no truncation. 5 rows × 200 = 1000px in a float on a 500px page.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+              .f { float: left; width: 200px; }
+              .grid { display: grid; grid-template-columns: 100px; grid-auto-rows: 200px; }
+              .grid > div { background-color: #3366cc; }
+            </style></head><body>
+              <div class="f">
+                <div class="grid">
+                  <div></div><div></div><div></div><div></div><div></div>
+                </div>
+              </div>
+            </body></html>
+            """;
+        var host = new HtmlParsingHost();
+        var document = await host.ParseAsync(html, new HtmlPdfOptions());
+        var sheets = AdaptAllSheetsViaPreprocessor(document);
+        var cascade = CascadeResolver.Resolve(document, sheets, CssMediaContext.DefaultPrint);
+        var resolved = VarResolver.Resolve(cascade, document);
+        var box = BoxBuilder.Build(document, resolved);
+
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+        using var layouter = new BlockLayouter(box, sink, null, diag, shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 500);
+        var layoutCtx = new LayoutContext(ctx) { Diagnostics = diag };
+        using var resolver = new BreakResolver();
+        var result = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        // The grid stayed atomic inside the float — no truncation continuation,
+        // so the float-break-inside-nested diagnostic does NOT fire, and the page
+        // completes (AllDone) rather than deferring the float's overflow.
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutFloatBreakInsideNested001);
+        Assert.Equal(LayoutAttemptOutcome.AllDone, result.Outcome);
+
+        // Lossless: grid rows past the 500px page edge were emitted (atomic
+        // overflow), not truncated. The last row tops at 800px.
+        Assert.Contains(sink.Fragments, f => f.BlockOffset >= 700);
+    }
+
+    [Fact]
     public async Task Production_html_spanning_item_distributes_after_subtracting_fixed_tracks()
     {
         // Riders-2 grid spanning-item distribution cycle (CSS Grid §11.5.1) — a content item spanning a

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -803,6 +803,62 @@ public sealed class GridLayouterProductionTests
     }
 
     [Fact]
+    public async Task RowExtent_premeasure_is_memoized_across_a_grids_pages()
+    {
+        // Per Phase 3 Task 18 (grid-fragment-plan-shared-sizing-deferral, partial) —
+        // PreMeasureGridRowExtent runs a full §11 sizing + §8.5 placement pass to grow
+        // an auto-height grid's wrapper. That pass is page-invariant (indefinite block
+        // budget, fixed inline size + page budget), so for a grid that spans multiple
+        // pages it now resolves ONCE across all of them (RowExtentComputeCount == 1) —
+        // resume pages + rewind retries reuse the memoized extent instead of re-running
+        // the §11 arithmetic. (The cell SHAPING was already shared via MeasurePassCount;
+        // this elides the arithmetic too.)
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+              .grid { display: grid; grid-template-columns: 100px; grid-auto-rows: 200px; }
+              .grid > div { background-color: #3366cc; }
+            </style></head><body>
+              <div class="grid">
+                <div></div><div></div><div></div><div></div><div></div>
+              </div>
+            </body></html>
+            """;
+        var host = new HtmlParsingHost();
+        var document = await host.ParseAsync(html, new HtmlPdfOptions());
+        var sheets = AdaptAllSheetsViaPreprocessor(document);
+        var cascade = CascadeResolver.Resolve(document, sheets, CssMediaContext.DefaultPrint);
+        var resolved = VarResolver.Resolve(cascade, document);
+        var box = BoxBuilder.Build(document, resolved);
+
+        var cache = new GridMeasurementCache();
+        using var shaper = new SyntheticShaperResolver();
+
+        // 5 rows × 200 = 1000px content on a 500px page → spans 3 pages.
+        LayoutContinuation? incoming = null;
+        var pages = 0;
+        var done = false;
+        while (!done && pages < 8)
+        {
+            var sink = new RecordingFragmentSink();
+            var diag = new RecordingDiagnosticsSink();
+            using var layouter = new BlockLayouter(box, sink, incoming, diag, shaper);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 500);
+            var layoutCtx = new LayoutContext(ctx) { Diagnostics = diag, GridMeasureCache = cache };
+            using var resolver = new BreakResolver();
+            var result = layouter.AttemptLayout(
+                ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+            pages++;
+            if (result.Outcome == LayoutAttemptOutcome.AllDone) done = true;
+            else incoming = result.Continuation;
+        }
+
+        Assert.True(done, "the grid never completed within the page bound");
+        Assert.True(pages >= 2, "the grid should span multiple pages to exercise the memo");
+        // The §11 row-extent pre-measure ran exactly once across all the pages.
+        Assert.Equal(1, cache.RowExtentComputeCount);
+    }
+
+    [Fact]
     public async Task Production_html_spanning_item_distributes_after_subtracting_fixed_tracks()
     {
         // Riders-2 grid spanning-item distribution cycle (CSS Grid §11.5.1) — a content item spanning a

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterProductionTests.cs
@@ -803,7 +803,7 @@ public sealed class GridLayouterProductionTests
     }
 
     [Fact]
-    public async Task RowExtent_premeasure_is_memoized_across_a_grids_pages()
+    public async Task RowExtent_premeasure_is_memoized_across_grid_pages()
     {
         // Per Phase 3 Task 18 (grid-fragment-plan-shared-sizing-deferral, partial) —
         // PreMeasureGridRowExtent runs a full §11 sizing + §8.5 placement pass to grow
@@ -906,6 +906,51 @@ public sealed class GridLayouterProductionTests
 
         // Lossless: grid rows past the 500px page edge were emitted (atomic
         // overflow), not truncated. The last row tops at 800px.
+        Assert.Contains(sink.Fragments, f => f.BlockOffset >= 700);
+    }
+
+    [Fact]
+    public async Task Float_with_tall_nested_flex_column_emits_atomically_without_truncation()
+    {
+        // Per PR-#201 review P2 — `_inAtomicFloatSubtree` suppresses nested FLEX
+        // pagination as well as grid, but the grid test alone wouldn't catch a
+        // flex regression. A column flex taller than the page inside a float must
+        // emit ATOMICALLY (all items, overflowing the page edge) — lossless, no
+        // truncation. 5 items × 200 = 1000px in a float on a 500px page.
+        const string html = """
+            <!DOCTYPE html><html><head><style>
+              .f { float: left; width: 200px; }
+              .flex { display: flex; flex-direction: column; }
+              .flex > div { height: 200px; background-color: #3366cc; }
+            </style></head><body>
+              <div class="f">
+                <div class="flex">
+                  <div></div><div></div><div></div><div></div><div></div>
+                </div>
+              </div>
+            </body></html>
+            """;
+        var host = new HtmlParsingHost();
+        var document = await host.ParseAsync(html, new HtmlPdfOptions());
+        var sheets = AdaptAllSheetsViaPreprocessor(document);
+        var cascade = CascadeResolver.Resolve(document, sheets, CssMediaContext.DefaultPrint);
+        var resolved = VarResolver.Resolve(cascade, document);
+        var box = BoxBuilder.Build(document, resolved);
+
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+        using var layouter = new BlockLayouter(box, sink, null, diag, shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 500);
+        var layoutCtx = new LayoutContext(ctx) { Diagnostics = diag };
+        using var resolver = new BreakResolver();
+        var result = layouter.AttemptLayout(
+            ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.Strict);
+
+        Assert.DoesNotContain(diag.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.LayoutFloatBreakInsideNested001);
+        Assert.Equal(LayoutAttemptOutcome.AllDone, result.Outcome);
+        // Lossless: flex items past the 500px page edge were emitted.
         Assert.Contains(sink.Fragments, f => f.BlockOffset >= 700);
     }
 

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterProductionTests.cs
@@ -1092,6 +1092,79 @@ public sealed class TableLayouterProductionTests
     }
 
     [Fact]
+    public void IntraCell_production_non_divisor_blocks_cut_at_boundary()
+    {
+        // Per PR-#201 review P1/P3 — through the production BlockLayouter path
+        // (which adds the split-aware dry-run wrapper sizing) with NON-divisor
+        // blocks: 600 + 600 on an 800px page. No block starts at the 800px
+        // budget, so a raw-edge cut would force-overflow; the boundary-aware cut
+        // must split after the first block (RowSplitOffset == 600). Both blocks
+        // emit across 2 pages, no forced-overflow.
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+        var grid = Box.Anonymous(BoxKind.TableGrid, MakeStyle());
+        var row = Box.ForElement(BoxKind.TableRow, MakeStyle(), MakeElement());
+        var cell = Box.ForElement(BoxKind.TableCell, MakeStyle(), MakeElement());
+        var anon = Box.Anonymous(BoxKind.AnonymousBlock, MakeStyle());
+        foreach (var h in new[] { 600.0, 600.0 })
+        {
+            var bcStyle = MakeStyle();
+            SetLengthPx(bcStyle, PropertyId.Height, h);
+            anon.AppendChild(Box.ForElement(BoxKind.BlockContainer, bcStyle, MakeElement()));
+        }
+        cell.AppendChild(anon);
+        row.AppendChild(cell);
+        grid.AppendChild(row);
+        table.AppendChild(grid);
+        root.AppendChild(table);
+
+        LayoutContinuation? incoming = null;
+        var pages = 0;
+        var done = false;
+        var firstSplitOffset = -1.0;
+        while (!done && pages < 8)
+        {
+            using var layouter = new BlockLayouter(
+                rootBox: root, sink: sink, incomingContinuation: incoming,
+                diagnostics: diagSink, shaperResolver: shaper);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var layoutCtx = new LayoutContext(ctx) { Diagnostics = diagSink };
+            using var resolver = new BreakResolver();
+            var result = layouter.AttemptLayout(
+                ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+            pages++;
+            if (result.Outcome == LayoutAttemptOutcome.AllDone)
+            {
+                done = true;
+            }
+            else
+            {
+                Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+                incoming = result.Continuation;
+                var bc = Assert.IsType<BlockContinuation>(incoming);
+                var tc = Assert.IsType<TableContinuation>(bc.LayouterState);
+                if (firstSplitOffset < 0) firstSplitOffset = tc.RowSplitOffset;
+            }
+        }
+
+        Assert.True(done, "table never completed within the page bound");
+        Assert.Equal(2, pages);
+        Assert.Equal(600.0, firstSplitOffset, precision: 3); // boundary, not 800
+        var blockFragments = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (f.Box.Kind == BoxKind.BlockContainer) blockFragments++;
+        }
+        Assert.Equal(2, blockFragments);
+        Assert.DoesNotContain(diagSink.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+    }
+
+    [Fact]
     public void Cycle2_production_table_at_depth_3_splits_cleanly()
     {
         // Per Phase 3 Task 14 cycle 2 hardening (Finding #1) — the

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterProductionTests.cs
@@ -1012,6 +1012,86 @@ public sealed class TableLayouterProductionTests
     }
 
     [Fact]
+    public void IntraCell_production_oversized_row_splits_within_itself_across_pages()
+    {
+        // Per Phase 3 Task 17 cycle 5c.2d — through the production
+        // BlockLayouter outer-dispatch path: a table whose SINGLE row is
+        // taller than the page (its cell stacks block children) breaks
+        // WITHIN the row across pages instead of force-overflowing at full
+        // extent. The TableContinuation — now carrying RowSplitOffset —
+        // round-trips through BlockContinuation.LayouterState every page,
+        // re-parking the SAME row 0 until the tail fits. Every block emits
+        // exactly once (lossless, no duplication), no forced-overflow.
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+        var grid = Box.Anonymous(BoxKind.TableGrid, MakeStyle());
+        var row = Box.ForElement(BoxKind.TableRow, MakeStyle(), MakeElement());
+        var cell = Box.ForElement(BoxKind.TableCell, MakeStyle(), MakeElement());
+        var anon = Box.Anonymous(BoxKind.AnonymousBlock, MakeStyle());
+        for (var i = 0; i < 9; i++) // 9 × 200 = 1800 px over an 800 page → 3 pages
+        {
+            var bcStyle = MakeStyle();
+            SetLengthPx(bcStyle, PropertyId.Height, 200);
+            anon.AppendChild(Box.ForElement(
+                BoxKind.BlockContainer, bcStyle, MakeElement()));
+        }
+        cell.AppendChild(anon);
+        row.AppendChild(cell);
+        grid.AppendChild(row);
+        table.AppendChild(grid);
+        root.AppendChild(table);
+
+        LayoutContinuation? incoming = null;
+        var pages = 0;
+        var done = false;
+        while (!done && pages < 10)
+        {
+            using var layouter = new BlockLayouter(
+                rootBox: root, sink: sink,
+                incomingContinuation: incoming,
+                diagnostics: diagSink,
+                shaperResolver: shaper);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var layoutCtx = new LayoutContext(ctx) { Diagnostics = diagSink };
+            using var resolver = new BreakResolver();
+            var result = layouter.AttemptLayout(
+                ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+            pages++;
+            if (result.Outcome == LayoutAttemptOutcome.AllDone)
+            {
+                done = true;
+            }
+            else
+            {
+                Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+                incoming = result.Continuation;
+                var bc = Assert.IsType<BlockContinuation>(incoming);
+                var tc = Assert.IsType<TableContinuation>(bc.LayouterState);
+                Assert.Equal(0, tc.NextRowIndex);       // still inside row 0
+                Assert.True(tc.RowSplitOffset > 0,
+                    "the intra-row split offset must round-trip through the wrapper");
+            }
+        }
+
+        Assert.True(done, "table never completed within the page bound");
+        Assert.Equal(3, pages);
+
+        var blockFragments = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (f.Box.Kind == BoxKind.BlockContainer) blockFragments++;
+        }
+        Assert.Equal(9, blockFragments);
+
+        Assert.DoesNotContain(diagSink.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+    }
+
+    [Fact]
     public void Cycle2_production_table_at_depth_3_splits_cleanly()
     {
         // Per Phase 3 Task 14 cycle 2 hardening (Finding #1) — the

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
@@ -593,6 +593,120 @@ public sealed class TableLayouterTests
     }
 
     [Fact]
+    public void IntraCell_oversized_row_with_stacked_blocks_splits_across_pages()
+    {
+        // Per Phase 3 Task 17 cycle 5c.2d — a single body row whose cell
+        // stacks block children TALLER than the page no longer force-
+        // overflows at full extent: it breaks WITHIN itself at a block-
+        // granularity boundary. Page 1 emits the fitting slice + returns
+        // PageComplete with RowSplitOffset > 0 (still NextRowIndex == 0 —
+        // the split is inside row 0); page 2 resumes the tail + returns
+        // AllDone. Every block emits exactly once (lossless, no dup).
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        // One row, one cell, six 200-px blocks (1200 px) on an 800 page.
+        var (_, table) = BuildStackedCellTable(blockCount: 6, blockHeight: 200);
+
+        TableContinuation cont;
+        using (var page1 = new TableLayouter(
+            rootBox: table, sink: sink, incomingContinuation: null,
+            diagnostics: diagSink, shaperResolver: shaper))
+        {
+            page1.ConfigureEmission(0, 0, 600);
+            var ctx1 = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var lc1 = new LayoutContext(ctx1) { Diagnostics = diagSink };
+            using var r1 = new BreakResolver();
+            var res1 = page1.AttemptLayout(
+                ctx1, ref lc1, r1, LayoutAttemptStrategy.LastResort);
+            Assert.Equal(LayoutAttemptOutcome.PageComplete, res1.Outcome);
+            cont = Assert.IsType<TableContinuation>(res1.Continuation);
+            Assert.Equal(0, cont.NextRowIndex);
+            Assert.True(cont.RowSplitOffset > 0,
+                "expected a non-zero intra-row split offset");
+        }
+
+        using (var page2 = new TableLayouter(
+            rootBox: table, sink: sink, incomingContinuation: cont,
+            diagnostics: diagSink, shaperResolver: shaper))
+        {
+            page2.ConfigureEmission(0, 0, 600);
+            var ctx2 = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var lc2 = new LayoutContext(ctx2) { Diagnostics = diagSink };
+            using var r2 = new BreakResolver();
+            var res2 = page2.AttemptLayout(
+                ctx2, ref lc2, r2, LayoutAttemptStrategy.LastResort);
+            Assert.Equal(LayoutAttemptOutcome.AllDone, res2.Outcome);
+        }
+
+        // All six block-container fragments emitted exactly once across
+        // the two pages (lossless, no duplication).
+        var blockFragments = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (f.Box.Kind == BoxKind.BlockContainer) blockFragments++;
+        }
+        Assert.Equal(6, blockFragments);
+
+        // The row split cleanly — no forced-overflow / truncation.
+        Assert.DoesNotContain(diagSink.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+    }
+
+    [Fact]
+    public void IntraCell_split_row_taller_than_two_pages_paginates_three_pages()
+    {
+        // Per Phase 3 Task 17 cycle 5c.2d — a row taller than TWO pages
+        // splits across three: each intermediate page returns PageComplete
+        // re-parking the SAME row 0 with a growing RowSplitOffset, until
+        // the final tail fits + returns AllDone. Lossless across all pages.
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        // Twelve 200-px blocks (2400 px) on an 800 page → 3 pages.
+        var (_, table) = BuildStackedCellTable(blockCount: 12, blockHeight: 200);
+
+        var pages = 0;
+        TableContinuation? cont = null;
+        var done = false;
+        while (!done && pages < 8)
+        {
+            using var pageLayouter = new TableLayouter(
+                rootBox: table, sink: sink, incomingContinuation: cont,
+                diagnostics: diagSink, shaperResolver: shaper);
+            pageLayouter.ConfigureEmission(0, 0, 600);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var lc = new LayoutContext(ctx) { Diagnostics = diagSink };
+            using var resolver = new BreakResolver();
+            var res = pageLayouter.AttemptLayout(
+                ctx, ref lc, resolver, LayoutAttemptStrategy.LastResort);
+            pages++;
+            if (res.Outcome == LayoutAttemptOutcome.AllDone)
+            {
+                done = true;
+            }
+            else
+            {
+                Assert.Equal(LayoutAttemptOutcome.PageComplete, res.Outcome);
+                cont = Assert.IsType<TableContinuation>(res.Continuation);
+            }
+        }
+
+        Assert.True(done, "table never completed within the page bound");
+        Assert.Equal(3, pages);
+
+        // All twelve blocks emitted exactly once across the three pages.
+        var blockFragments = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (f.Box.Kind == BoxKind.BlockContainer) blockFragments++;
+        }
+        Assert.Equal(12, blockFragments);
+    }
+
+    [Fact]
     public void Cycle1_table_top_caption_emits_only_on_first_page()
     {
         // Per Phase 3 Task 13 cycle 1 — top captions emit only when
@@ -2245,6 +2359,38 @@ public sealed class TableLayouterTests
             row.AppendChild(cell);
             grid.AppendChild(row);
         }
+        table.AppendChild(grid);
+        root.AppendChild(table);
+        return (root, table);
+    }
+
+    /// <summary>Per Phase 3 Task 17 cycle 5c.2d — one row / one cell whose
+    /// content is a STACK of <paramref name="blockCount"/> block children,
+    /// each <paramref name="blockHeight"/> px tall. Unlike
+    /// <see cref="BuildTallRowTable"/> (a single explicit-height block =
+    /// one atomic, unsliceable fragment), the stacked children give the
+    /// intra-cell splitter block-granularity break opportunities, so a row
+    /// taller than the page breaks within itself instead of force-
+    /// overflowing.</summary>
+    private static (Box root, Box table) BuildStackedCellTable(
+        int blockCount, double blockHeight)
+    {
+        var root = Box.CreateRoot(MakeStyle());
+        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+        var grid = Box.Anonymous(BoxKind.TableGrid, MakeStyle());
+        var row = Box.ForElement(BoxKind.TableRow, MakeStyle(), MakeElement());
+        var cell = Box.ForElement(BoxKind.TableCell, MakeStyle(), MakeElement());
+        var anon = Box.Anonymous(BoxKind.AnonymousBlock, MakeStyle());
+        for (var i = 0; i < blockCount; i++)
+        {
+            var bcStyle = MakeStyle();
+            SetLengthPx(bcStyle, PropertyId.Height, blockHeight);
+            var bc = Box.ForElement(BoxKind.BlockContainer, bcStyle, MakeElement());
+            anon.AppendChild(bc);
+        }
+        cell.AppendChild(anon);
+        row.AppendChild(cell);
+        grid.AppendChild(row);
         table.AppendChild(grid);
         root.AppendChild(table);
         return (root, table);

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
@@ -890,6 +890,65 @@ public sealed class TableLayouterTests
     }
 
     [Fact]
+    public void IntraCell_constructor_rejects_malformed_RowSplitOffset()
+    {
+        // Per PR-#201 review P2 — RowSplitOffset is layout-critical (it feeds
+        // the resume slice height + dry-run wrapper size), so the constructor
+        // rejects NaN / infinity / negative just like ConsumedBlockSize. A bad
+        // value would otherwise produce a negative slice + negative-sized cell
+        // fragments.
+        var sink = new RecordingFragmentSink();
+        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+
+        foreach (var bad in new[] { double.NaN, double.PositiveInfinity, -1.0 })
+        {
+            var cont = new TableContinuation(
+                RepeatHead: false, RepeatFoot: false,
+                NextRowIndex: 0, ConsumedBlockSize: 0, ColumnLayoutCache: null,
+                RowSplitOffset: bad);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new TableLayouter(table, sink, incomingContinuation: cont));
+        }
+    }
+
+    [Fact]
+    public void IntraCell_over_large_RowSplitOffset_is_clamped_not_negative()
+    {
+        // Per PR-#201 review P2 — a (finite, non-negative) RowSplitOffset that
+        // exceeds the measured row height is clamped to the row height rather
+        // than driving remaining/sliceHeight negative. The row is treated as
+        // already fully emitted; the layouter completes without crashing and
+        // emits NO negative-sized fragments.
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+        var (_, table) = BuildStackedCellTableVar([300, 300]); // row height 600
+
+        var bogus = new TableContinuation(
+            RepeatHead: false, RepeatFoot: false,
+            NextRowIndex: 0, ConsumedBlockSize: 0, ColumnLayoutCache: null,
+            RowSplitOffset: 99999.0); // >> 600
+        using var layouter = new TableLayouter(
+            rootBox: table, sink: sink, incomingContinuation: bogus,
+            diagnostics: diagSink, shaperResolver: shaper);
+        layouter.ConfigureEmission(0, 0, 600);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var lc = new LayoutContext(ctx) { Diagnostics = diagSink };
+        using var resolver = new BreakResolver();
+
+        var res = layouter.AttemptLayout(ctx, ref lc, resolver, LayoutAttemptStrategy.LastResort);
+
+        // Completes gracefully (row treated as consumed → done), no negative
+        // fragment geometry leaked into the sink.
+        Assert.Equal(LayoutAttemptOutcome.AllDone, res.Outcome);
+        Assert.All(sink.Fragments, f =>
+        {
+            Assert.True(f.BlockSize >= 0, $"negative BlockSize {f.BlockSize}");
+            Assert.True(f.InlineSize >= 0, $"negative InlineSize {f.InlineSize}");
+        });
+    }
+
+    [Fact]
     public void Cycle1_table_out_of_range_resume_index_throws_at_attempt_layout()
     {
         // Per Phase 3 Task 13 cycle 1 — when NextRowIndex exceeds the
@@ -2394,6 +2453,142 @@ public sealed class TableLayouterTests
         table.AppendChild(grid);
         root.AppendChild(table);
         return (root, table);
+    }
+
+    /// <summary>Per PR-#201 review P1/P3 — one row / one cell whose stacked block
+    /// children have NON-UNIFORM heights, so child block starts do NOT land on
+    /// page-budget multiples. Proves the intra-cell splitter cuts at the deepest
+    /// actual block boundary that fits, not the raw page edge.</summary>
+    private static (Box root, Box table) BuildStackedCellTableVar(double[] blockHeights)
+    {
+        var root = Box.CreateRoot(MakeStyle());
+        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+        var grid = Box.Anonymous(BoxKind.TableGrid, MakeStyle());
+        var row = Box.ForElement(BoxKind.TableRow, MakeStyle(), MakeElement());
+        var cell = Box.ForElement(BoxKind.TableCell, MakeStyle(), MakeElement());
+        var anon = Box.Anonymous(BoxKind.AnonymousBlock, MakeStyle());
+        foreach (var h in blockHeights)
+        {
+            var bcStyle = MakeStyle();
+            SetLengthPx(bcStyle, PropertyId.Height, h);
+            anon.AppendChild(Box.ForElement(BoxKind.BlockContainer, bcStyle, MakeElement()));
+        }
+        cell.AppendChild(anon);
+        row.AppendChild(cell);
+        grid.AppendChild(row);
+        table.AppendChild(grid);
+        root.AppendChild(table);
+        return (root, table);
+    }
+
+    // Drive a single-cell stacked-block table across pages; returns the page
+    // count, the per-page RowSplitOffset of each PageComplete, and the total
+    // BlockContainer fragment count (lossless check).
+    private static (int Pages, System.Collections.Generic.List<double> SplitOffsets, int BlockFragments)
+        DriveStackedTablePages(Box table, double pageBlockSize)
+    {
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+        var offsets = new System.Collections.Generic.List<double>();
+        TableContinuation? cont = null;
+        var pages = 0;
+        var done = false;
+        while (!done && pages < 12)
+        {
+            using var layouter = new TableLayouter(
+                rootBox: table, sink: sink, incomingContinuation: cont,
+                diagnostics: diagSink, shaperResolver: shaper);
+            layouter.ConfigureEmission(0, 0, 600);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: pageBlockSize);
+            var lc = new LayoutContext(ctx) { Diagnostics = diagSink };
+            using var resolver = new BreakResolver();
+            var res = layouter.AttemptLayout(ctx, ref lc, resolver, LayoutAttemptStrategy.LastResort);
+            pages++;
+            if (res.Outcome == LayoutAttemptOutcome.AllDone)
+            {
+                done = true;
+            }
+            else
+            {
+                Assert.Equal(LayoutAttemptOutcome.PageComplete, res.Outcome);
+                cont = Assert.IsType<TableContinuation>(res.Continuation);
+                offsets.Add(cont.RowSplitOffset);
+            }
+        }
+        Assert.True(done, "table never completed within the page bound");
+        var blocks = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (f.Box.Kind == BoxKind.BlockContainer) blocks++;
+        }
+        return (pages, offsets, blocks);
+    }
+
+    [Fact]
+    public void IntraCell_split_cuts_at_block_boundary_not_page_edge_600_600()
+    {
+        // Per PR-#201 review P1 — two 600px blocks on an 800px page must split
+        // AFTER the first block (cut at 600px), NOT force-overflow because no
+        // block starts exactly at the 800px budget. Page 1 commits block 0 and
+        // re-parks row 0 with RowSplitOffset == 600; page 2 commits block 1.
+        var (_, table) = BuildStackedCellTableVar([600, 600]);
+        var (pages, offsets, blocks) = DriveStackedTablePages(table, pageBlockSize: 800);
+
+        Assert.Equal(2, pages);
+        Assert.Equal(2, blocks);                 // both blocks emitted, lossless
+        Assert.Single(offsets);
+        Assert.Equal(600.0, offsets[0], precision: 3); // boundary cut, not 800
+    }
+
+    [Fact]
+    public void IntraCell_split_does_not_overflow_a_straddling_block_500_400_200()
+    {
+        // Per PR-#201 review P1 — 500 + 400 + 200 on an 800px page. The 400px
+        // block straddles the 800 edge (500→900); cutting at the raw budget would
+        // emit it overflowing. The boundary-aware cut breaks after the 500px
+        // block instead (RowSplitOffset == 500); the 400+200 tail then fits the
+        // next page in one slice. All three blocks emit, no row overflows its page.
+        var (_, table) = BuildStackedCellTableVar([500, 400, 200]);
+        var (pages, offsets, blocks) = DriveStackedTablePages(table, pageBlockSize: 800);
+
+        Assert.Equal(2, pages);
+        Assert.Equal(3, blocks);
+        Assert.Single(offsets);
+        Assert.Equal(500.0, offsets[0], precision: 3);
+    }
+
+    [Fact]
+    public void IntraCell_first_block_taller_than_page_force_overflows_not_splits()
+    {
+        // Per PR-#201 review P1 — when the FIRST remaining block (1500px) is
+        // taller than the whole page there is no fitting block boundary, so the
+        // splitter must NOT split (which would emit a zero/negative slice) — it
+        // force-overflows the row in full (lossless). AllDone on the first page,
+        // PAGINATION-FORCED-OVERFLOW-001 fires, both blocks present.
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+        var (_, table) = BuildStackedCellTableVar([1500, 300]);
+
+        using var layouter = new TableLayouter(
+            rootBox: table, sink: sink, incomingContinuation: null,
+            diagnostics: diagSink, shaperResolver: shaper);
+        layouter.ConfigureEmission(0, 0, 600);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var lc = new LayoutContext(ctx) { Diagnostics = diagSink };
+        using var resolver = new BreakResolver();
+        var res = layouter.AttemptLayout(ctx, ref lc, resolver, LayoutAttemptStrategy.LastResort);
+
+        Assert.Equal(LayoutAttemptOutcome.AllDone, res.Outcome);
+        var blocks = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (f.Box.Kind == BoxKind.BlockContainer) blocks++;
+        }
+        Assert.Equal(2, blocks); // both emitted (overflowing), nothing lost
+        Assert.Contains(diagSink.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
     }
 
     [Fact]


### PR DESCRIPTION
Phase 3 roadmap **PR 7 — pagination / table / grid hardening**. Three deep deferred-layout tasks, one commit each (in roadmap order), all in the engine's riskiest code. Every change is blast-radius-contained and the LTR/in-flow paths stay byte-identical (snapshots / golden / real-docs unchanged).

## Task 17 — table intra-cell ROW splitting (block-granularity) · `80c8b71`
A single body row whose cell stacks block children taller than the page now breaks **within itself** across pages instead of force-overflowing at full extent (mirrors task 16's prose pagination at block granularity).
- `TableContinuation.RowSplitOffset` carries the cell-relative cut; the resume page re-measures + re-slices deterministically (heavy buffers don't cross the page boundary).
- `MeasuringFragmentSink.FlushSlice` drains only fragments whose top is in the page window; `EmitSlicedRow` emits one sliced row in an **isolated path** — `EmitRowWindow` is untouched, so the 125 non-split table tests are unaffected.
- Cells now measure **full natural height** (`SuppressBlockPagination` on the cell fragmentainer) — pagination is the table's job, not the cell's; post-task-16 prose pagination had started truncating multi-block cells.
- `DryRunCommittedBlockSize` is split-aware so the **production `BlockLayouter` path** propagates the continuation (not just the direct `TableLayouter`).
- Tight scope: no footers / bottom-captions / rowspan-origin; a single atomic block still force-overflows (`inline-only-block-line-splitting`).

## Task 18 — grid cross-page row-extent memo + corrected premise · `bdfe3f0`
Verifying the live path showed the deferral's "3 redundant Resolves" framing was inaccurate: the three `GridSizing.Resolve` calls take **genuinely different inputs** (indefinite-block site 1 vs definite sites 2/3; the probe lacks measurers), so a naive 3→1 share is **incorrect for `fr` grids**, and the expensive cell shaping is **already** shared via `GridMeasurementCache`.
- Landed the safe, byte-identical part: the page-invariant site-1 §11 pre-measure is memoized (`GridMeasurementCache.RowExtentSum`), so resume pages + rewind retries skip it. `RowExtentComputeCount` pins "== 1 across a multi-page grid".
- Deferral updated to `approximated` with the finding; the site-2+3 collapse needs a reftest sweep (stays deferred).

## Task 19 — float content atomicity · `2b9716d`
A grid or flex taller than the page **inside a float** used to paginate, and the out-of-flow float path discarded the continuation — silently **truncating** the overflow + firing `LAYOUT-FLOAT-BREAK-INSIDE-NESTED-001`. Floats don't fragment across pages yet, so nested grid + flex now emit **atomically** (lossless overflow — the correct out-of-flow model).
- `_inAtomicFloatSubtree` (save/restore around the float recursion) suppresses the recursive-site paginatable-grid/flex clamp+flag; in-flow content is byte-identical.
- Residual (documented): nested **table + multicol** in floats still truncate (page-budget-coupled wrapper sizing — a separate cycle); the other two task-19 sub-parts (recursive consumed-extent accounting, `multi-page-allocation-churn`) are **latent** (no visible impact) and stay deferred.
- The regression test was verified meaningful by reverting the gate (the diagnostic fires + the assertion fails without the fix).

## Verification
`7133 unit / 4 skip` · `30` LayoutSnapshots · `97` RealDocuments · PaginationGolden · RenderingCorpus · deferrals-parity (8) · **AOT/JIT parity** · **0-warning Release**. In-flow / LTR paths byte-identical (the existing pinned docs had no overflowing intra-cell content, no float-nested grid/flex, and the grid memo is deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)