### PR TITLE
Phase 3: flex/grid gap gutters + container explicit width — all four conformance criteria MET

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,6 +1,6 @@
 # NetPdf — Progress Status
 
-> **Current state (2026-06-21):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, prose, empty/explicit-height blocks. Conformance is MEASURED (curated suite, PR 1 [#202](https://github.com/raroche/NetPdf/pull/202)). **ALL FOUR conformance exit criteria are now MET** — CSS 2.2 93.3% (28/30), Fragmentation 90% (9/10), Flexbox 100% (18/18), Grid 92.3% (12/13). The CSS 2.2 box-model gaps closed first ([#203](https://github.com/raroche/NetPdf/pull/203): box-sizing block-axis + emit/measure consistency + floats; min/max clamping explicit + auto/fill). Then the **flex/grid gap PR** closed: `gap`/`column-gap`/`row-gap` gutters (flex + grid) + flex/grid containers honoring their own explicit `width` — taking Flexbox 83.3% → 100% (criterion 4 MET) + Grid 80% → 92.3%. Residuals DEFERRED (none block a criterion): auto-height emit (`auto-height-emit-vs-pagination`), percentage min/max (`min-max-percentage-sizing`), grid fr+gap (`grid-gap-fr-track-sizing`), `inline-only-block-line-splitting`, `multi-page-allocation-churn`. What's left to *finish* Phase 3: the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag). Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
+> **Current state (2026-06-21):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, prose, empty/explicit-height blocks. Conformance is MEASURED (curated suite, PR 1 [#202](https://github.com/raroche/NetPdf/pull/202)). **ALL FOUR conformance exit criteria are now MET** — CSS 2.2 93.3% (28/30), Fragmentation 90% (9/10), Flexbox 100% (18/18), Grid 93.3% (14/15). The CSS 2.2 box-model gaps closed first ([#203](https://github.com/raroche/NetPdf/pull/203): box-sizing block-axis + emit/measure consistency + floats; min/max clamping explicit + auto/fill). Then the **flex/grid gap PR** closed: `gap`/`column-gap`/`row-gap` gutters (flex + grid) + flex/grid containers honoring their own explicit `width` — taking Flexbox 83.3% → 100% (criterion 4 MET) + Grid 80% → 93.3%. Residuals DEFERRED (none block a criterion): auto-height emit (`auto-height-emit-vs-pagination`), percentage min/max (`min-max-percentage-sizing`), grid fr+gap (`grid-gap-fr-track-sizing`), `inline-only-block-line-splitting`, `multi-page-allocation-churn`. What's left to *finish* Phase 3: the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag). Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
 >
 > Last merged: PR [#203](https://github.com/raroche/NetPdf/pull/203) (CSS 2.2 box-model gaps — criterion 3 MET). Current branch `phase3-flex-grid-gap-and-container-width`: flex gap, grid gap, flex/grid container width (criteria 4 + 5 raised; all 4 met). `git log --oneline -1` shows the exact commit.
 >
@@ -17,7 +17,7 @@
 | 4 | Visual parity (gradients, shadows, filters, SVG) | ⏸️ Not started |
 | 5 | Packaging + release | 🔵 Interleaved — layout→PDF wiring done |
 
-**Gates (all green, 2026-06-21):** 7149 unit / 3 skip (+ the 3 perf/memory gates) · 30 LayoutSnapshots · 97 RealDocuments · **W3cConformance (4 per-case-baseline gates; published rates CSS 2.2 93% / Frag 90% / Flex 100% / Grid 92%)** · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
+**Gates (all green, 2026-06-21):** 7149 unit / 3 skip (+ the 3 perf/memory gates) · 30 LayoutSnapshots · 97 RealDocuments · **W3cConformance (4 per-case-baseline gates; published rates CSS 2.2 93% / Frag 90% / Flex 100% / Grid 93%)** · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
 
 ## Phase 3 — what's shipped (consolidated)
 
@@ -38,7 +38,7 @@ Phase 3 is "complete" per [phase-3 §Exit criteria](docs/phases/phase-3-layout-a
 | 2 | Anvil sample: footer + "Page N of M" on every page | ✅ (multi-page + counters live) |
 | 3 | W3C CSS 2.2 layout pass-rate ≥ 90% | ✅ **MEASURED 93.3%** (28/30) — MET (box-sizing + min/max fixed, emit/measure consistent); 2 residual gaps: auto-height emit (`auto-height-emit-vs-pagination`), percentage min/max (`min-max-percentage-sizing`) |
 | 4 | W3C Flexbox pass-rate ≥ 85% | ✅ **MEASURED 100%** (18/18) — MET (gap gutters + container honors own `width`) |
-| 5 | W3C Grid L1 pass-rate ≥ 70% | ✅ **MEASURED 92.3%** (12/13) — MET (gap gutters; residual: fr+gap `grid-gap-fr-track-sizing`) |
+| 5 | W3C Grid L1 pass-rate ≥ 70% | ✅ **MEASURED 93.3%** (14/15) — MET (gap gutters; residual: fr+gap `grid-gap-fr-track-sizing`) |
 | 6 | W3C Fragmentation pass-rate ≥ 80% | ✅ **MEASURED 90.0%** (9/10) — MET (gap: break-before:page) |
 | 7 | Perf: 3-pg ≤ 200 ms, 20-pg ≤ 1.5 s p50 | 🟡 **layout-pipeline smoke-gated** (`PerformanceGateTests`: 3-pg ~42 ms, 22-pg ~400 ms — synthetic fonts + table content). The FULL-pipeline target (tables + **images + web fonts**, docs/design/performance.md) is the BenchmarkDotNet flow, not yet a build gate. |
 | 8 | Memory linear with page count | 🟡 **partial** — RETAINED heap flat (gated); ALLOCATION linearity NOT met: multi-page churn is super-linear (`multi-page-allocation-churn` — the `[MemoryDiagnoser]` standard would flag it). |
@@ -46,7 +46,7 @@ Phase 3 is "complete" per [phase-3 §Exit criteria](docs/phases/phase-3-layout-a
 | 10 | Determinism | ✅ |
 | 11 | CHANGELOG + `0.7.0-beta` tagged | ❌ |
 
-**Bottom line:** **ALL FOUR conformance exit criteria are MET** (CSS 2.2 93.3% / Fragmentation 90% / Flexbox 100% / Grid 92.3%). The flex/grid gap PR cleared the last open one — flex/grid `gap`/`column-gap`/`row-gap` gutters + flex/grid containers honoring their own explicit `width` took Flexbox to 100% (criterion 4) + Grid to 92.3%. Residuals (none block a criterion): `auto-height-emit-vs-pagination`, `min-max-percentage-sizing`, `grid-gap-fr-track-sizing`, `inline-only-block-line-splitting`, `multi-page-allocation-churn`. Critical path now: the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag); the conformance story is clean (all criteria met, residuals documented).
+**Bottom line:** **ALL FOUR conformance exit criteria are MET** (CSS 2.2 93.3% / Fragmentation 90% / Flexbox 100% / Grid 93.3%). The flex/grid gap PR cleared the last open one — flex/grid `gap`/`column-gap`/`row-gap` gutters + flex/grid containers honoring their own explicit `width` took Flexbox to 100% (criterion 4) + Grid to 93.3%. Residuals (none block a criterion): `auto-height-emit-vs-pagination`, `min-max-percentage-sizing`, `grid-gap-fr-track-sizing`, `inline-only-block-line-splitting`, `multi-page-allocation-churn`. Critical path now: the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag); the conformance story is clean (all criteria met, residuals documented).
 
 ## Phase 3 — remaining-work roadmap
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,8 +1,8 @@
 # NetPdf — Progress Status
 
-> **Current state (2026-06-21):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, prose, empty/explicit-height blocks. Conformance is MEASURED (curated suite, PR 1 [#202](https://github.com/raroche/NetPdf/pull/202)). **The CSS 2.2 box-model gaps closed:** `box-sizing: border-box` (block-axis emit + the subtree MEASURE so emit/pagination agree + floats) and `LengthPx` min/max-width/height clamping (explicit AND auto/fill), taking **CSS 2.2 84.2% → 93.3% (28/30) — exit criterion 3 MET**. Two CSS 2.2 residuals DEFERRED: auto-height shrink-to-fit (`auto-height-emit-vs-pagination` — growing the emitted height regresses multi-page pagination) + percentage min/max (`min-max-percentage-sizing` — LengthPx only). Measured rates now: CSS 2.2 93.3%, Fragmentation 90%, Flexbox 83.3%, Grid 80% — **3 of 4 MET**; only Flexbox below target (container-own-width gap). What's left to *finish* Phase 3: (a) optionally close the Flexbox container-width gap to clear criterion 4; (b) niche residuals (`inline-only-block-line-splitting`, `multi-page-allocation-churn`, `auto-height-emit-vs-pagination`, `min-max-percentage-sizing`, nested table/multicol in floats); (c) the **`0.7.0-beta` release** (PR 8). Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
+> **Current state (2026-06-21):** Phase 3's layout + pagination engine drives multi-page rendering for tables, flex, grid, multicol, prose, empty/explicit-height blocks. Conformance is MEASURED (curated suite, PR 1 [#202](https://github.com/raroche/NetPdf/pull/202)). **ALL FOUR conformance exit criteria are now MET** — CSS 2.2 93.3% (28/30), Fragmentation 90% (9/10), Flexbox 100% (18/18), Grid 92.3% (12/13). The CSS 2.2 box-model gaps closed first ([#203](https://github.com/raroche/NetPdf/pull/203): box-sizing block-axis + emit/measure consistency + floats; min/max clamping explicit + auto/fill). Then the **flex/grid gap PR** closed: `gap`/`column-gap`/`row-gap` gutters (flex + grid) + flex/grid containers honoring their own explicit `width` — taking Flexbox 83.3% → 100% (criterion 4 MET) + Grid 80% → 92.3%. Residuals DEFERRED (none block a criterion): auto-height emit (`auto-height-emit-vs-pagination`), percentage min/max (`min-max-percentage-sizing`), grid fr+gap (`grid-gap-fr-track-sizing`), `inline-only-block-line-splitting`, `multi-page-allocation-churn`. What's left to *finish* Phase 3: the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag). Perf/memory exit criteria 7–8 are layout-pipeline smoke-gated (PR 5).
 >
-> Last merged: PR [#202](https://github.com/raroche/NetPdf/pull/202) (PR 1 — W3C conformance measurement: curated suite + per-case baseline). Current branch `phase3-css22-box-model-gaps`: box-sizing (block axis), min/max clamping, auto-height (attempted → deferred). `git log --oneline -1` shows the exact commit.
+> Last merged: PR [#203](https://github.com/raroche/NetPdf/pull/203) (CSS 2.2 box-model gaps — criterion 3 MET). Current branch `phase3-flex-grid-gap-and-container-width`: flex gap, grid gap, flex/grid container width (criteria 4 + 5 raised; all 4 met). `git log --oneline -1` shows the exact commit.
 >
 > This file was consolidated from a 1.1 MB chronological log on 2026-06-18; the full per-subtask history is archived in [docs/progress-archive.md](docs/progress-archive.md). **Keep this file compact** — roll the roadmap as each PR lands; don't grow a blow-by-blow log here.
 
@@ -17,7 +17,7 @@
 | 4 | Visual parity (gradients, shadows, filters, SVG) | ⏸️ Not started |
 | 5 | Packaging + release | 🔵 Interleaved — layout→PDF wiring done |
 
-**Gates (all green, 2026-06-21):** 7147 unit / 4 skip (+ the 3 perf/memory gates) · 30 LayoutSnapshots · 97 RealDocuments · **W3cConformance (4 per-case-baseline gates; published rates CSS 2.2 93% / Frag 90% / Flex 83% / Grid 80%)** · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
+**Gates (all green, 2026-06-21):** 7149 unit / 3 skip (+ the 3 perf/memory gates) · 30 LayoutSnapshots · 97 RealDocuments · **W3cConformance (4 per-case-baseline gates; published rates CSS 2.2 93% / Frag 90% / Flex 100% / Grid 92%)** · PaginationGolden · RenderingCorpus · 0-warning Release · AOT/JIT parity · determinism.
 
 ## Phase 3 — what's shipped (consolidated)
 
@@ -37,8 +37,8 @@ Phase 3 is "complete" per [phase-3 §Exit criteria](docs/phases/phase-3-layout-a
 | 1 | 4 invoice corpus files render to a valid PDF | ✅ |
 | 2 | Anvil sample: footer + "Page N of M" on every page | ✅ (multi-page + counters live) |
 | 3 | W3C CSS 2.2 layout pass-rate ≥ 90% | ✅ **MEASURED 93.3%** (28/30) — MET (box-sizing + min/max fixed, emit/measure consistent); 2 residual gaps: auto-height emit (`auto-height-emit-vs-pagination`), percentage min/max (`min-max-percentage-sizing`) |
-| 4 | W3C Flexbox pass-rate ≥ 85% | 📊 **MEASURED 83.3%** (10/12) — OPEN, below target; gaps: flex `gap`, container ignores own `width` (explicit-width case counted head-on per PR 1 review) |
-| 5 | W3C Grid L1 pass-rate ≥ 70% | ✅ **MEASURED 80.0%** (8/10) — MET (gap: column-gap/row-gap) |
+| 4 | W3C Flexbox pass-rate ≥ 85% | ✅ **MEASURED 100%** (18/18) — MET (gap gutters + container honors own `width`) |
+| 5 | W3C Grid L1 pass-rate ≥ 70% | ✅ **MEASURED 92.3%** (12/13) — MET (gap gutters; residual: fr+gap `grid-gap-fr-track-sizing`) |
 | 6 | W3C Fragmentation pass-rate ≥ 80% | ✅ **MEASURED 90.0%** (9/10) — MET (gap: break-before:page) |
 | 7 | Perf: 3-pg ≤ 200 ms, 20-pg ≤ 1.5 s p50 | 🟡 **layout-pipeline smoke-gated** (`PerformanceGateTests`: 3-pg ~42 ms, 22-pg ~400 ms — synthetic fonts + table content). The FULL-pipeline target (tables + **images + web fonts**, docs/design/performance.md) is the BenchmarkDotNet flow, not yet a build gate. |
 | 8 | Memory linear with page count | 🟡 **partial** — RETAINED heap flat (gated); ALLOCATION linearity NOT met: multi-page churn is super-linear (`multi-page-allocation-churn` — the `[MemoryDiagnoser]` standard would flag it). |
@@ -46,11 +46,11 @@ Phase 3 is "complete" per [phase-3 §Exit criteria](docs/phases/phase-3-layout-a
 | 10 | Determinism | ✅ |
 | 11 | CHANGELOG + `0.7.0-beta` tagged | ❌ |
 
-**Bottom line:** **3 of 4 conformance exit criteria MET** (CSS 2.2 93.3% / Fragmentation 90% / Grid 80%) after the CSS 2.2 box-model fixes (box-sizing block-axis + emit/measure consistency + floats; min/max clamping on explicit + auto sizes) cleared criterion 3. Only **Flexbox 83.3% is OPEN** (below 85%; gaps: flex `gap`, container ignores own `width`). Two CSS 2.2 residuals stay deferred — auto-height emit (`auto-height-emit-vs-pagination`) + percentage min/max (`min-max-percentage-sizing`). Critical path now: (a) optionally close the Flexbox container-width gap to clear criterion 4, then (b) the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag).
+**Bottom line:** **ALL FOUR conformance exit criteria are MET** (CSS 2.2 93.3% / Fragmentation 90% / Flexbox 100% / Grid 92.3%). The flex/grid gap PR cleared the last open one — flex/grid `gap`/`column-gap`/`row-gap` gutters + flex/grid containers honoring their own explicit `width` took Flexbox to 100% (criterion 4) + Grid to 92.3%. Residuals (none block a criterion): `auto-height-emit-vs-pagination`, `min-max-percentage-sizing`, `grid-gap-fr-track-sizing`, `inline-only-block-line-splitting`, `multi-page-allocation-churn`. Critical path now: the **`0.7.0-beta` release** (PR 8 — deferral audit + CHANGELOG + tag); the conformance story is clean (all criteria met, residuals documented).
 
 ## Phase 3 — remaining-work roadmap
 
-Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order. PRs 1–7 + the CSS 2.2 box-model PR are DONE. **Criterion 3 is now MET (93.3%)**; the recommended next PR either closes the Flexbox container-width gap (clears criterion 4) or goes straight to the **`0.7.0-beta` release** (PR 8). Surface the fork to Roland if unsure.
+Worked as **3-task PRs** (complete 3 → review → merge → next 3), in order. PRs 1–7 + the CSS 2.2 box-model PR + the flex/grid gap PR are DONE. **All four conformance exit criteria are now MET.** The next (and final Phase-3) PR is the **`0.7.0-beta` release** (PR 8): (20) deferral audit — reconcile `deferrals.md` / `compatibility-matrix.md` with live state; (21) CHANGELOG `0.7.0-beta` entry + exit-criteria sign-off; (22) tag `0.7.0-beta`.
 
 ### CSS 2.2 box-model gaps  [clears criterion 3] ✅ DONE
 1. ✅ **`box-sizing: border-box` (block axis)** — the recursive subtree emitter added padding/border OUTSIDE the declared height (inline axis already honored box-sizing); routed it through `BoxSizingHelper`. Flips `css22-box-sizing-border-box` + 3 new cases.

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -41,8 +41,8 @@ Phase column shows the milestone in which the feature first ships.
 | `position: sticky` | ❌ | post-v1 | Emits `CSS-POSITION-STICKY-UNSUPPORTED-001`. |
 | Tables (auto + fixed layout, border-collapse, span) | ✅ | 3 | |
 | Multi-column (`column-count`, `column-width`) | 🧪 | 3 | Partial / approximated per Phase 3 Task 14 cycle 1. `column-count` ships (equal-column split, serial fill, forced-overflow diagnostic). `column-width` parsed + cascaded but unused at layout time (cycle 2+ ships derivation). Column balancing (`column-fill: balance`), `column-span: all`, painted column rules, multi-page multicol (the multicol container fragmenting across pages) all deferred. See [docs/deferrals.md#multicol-balancing-pagination](deferrals.md#multicol-balancing-pagination). |
-| Flexbox (CSS Flexible Box Layout L1) | ✅ | 3 | Full L1 spec. |
-| CSS Grid (Level 1) | ✅ | 3 | Track sizing with `auto`/`fr`/`minmax`/`fit-content`/`repeat`/`auto-fill`/`auto-fit`; sparse + dense auto-placement; `grid-template-areas`. |
+| Flexbox (CSS Flexible Box Layout L1) | ✅ | 3 | L1 spec incl. `gap`/`column-gap`/`row-gap` gutters (CSS Box Alignment L3 §8 — consume free space before grow/shrink + justify-content) and containers honoring their own explicit `width` + `margin: 0 auto` centering. Known gap: a `%` gutter is treated as 0 ([`gap-percentage-sizing`](deferrals.md#gap-percentage-sizing)). |
+| CSS Grid (Level 1) | ✅ | 3 | Track sizing with `auto`/`fr`/`minmax`/`fit-content`/`repeat`/`auto-fill`/`auto-fit`; sparse + dense auto-placement; `grid-template-areas`; `column-gap`/`row-gap`/`gap` gutters between tracks (incl. spanned items + auto-height extent); container `margin: 0 auto` centering. Known gaps: a `%` gutter is treated as 0 ([`gap-percentage-sizing`](deferrals.md#gap-percentage-sizing)); `fr` tracks don't subtract gutters from their free space ([`grid-gap-fr-track-sizing`](deferrals.md#grid-gap-fr-track-sizing)). |
 | CSS Grid Level 2 (subgrid) | ❌ | post-v1 | Parsed only; emits `CSS-SUBGRID-UNSUPPORTED-001`. Roadmap v1.3. |
 
 ---

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -395,6 +395,36 @@ grepping the ID).
 
 ---
 
+## grid-gap-fr-track-sizing
+
+- **ID** — `grid-gap-fr-track-sizing`
+- **Status** — `approximated`.
+- **Behavior** — Grid `column-gap` / `row-gap` / `gap` gutters are POSITIONED
+  between tracks (the track offsets include the gaps), so fixed / auto / intrinsic
+  track grids lay out correctly. But the gaps are NOT subtracted from the free
+  space `fr` (flexible) tracks distribute — so `grid-template-columns: 1fr 1fr;
+  column-gap: 20px` in a 400px container sizes each fr track at 200 (should be
+  190 = (400-20)/2) and the second track overflows by the gap.
+- **Missing** — CSS Grid L1 §7.2.3 + §11.5 — the leftover space the fr flex factor
+  resolves against is the container extent MINUS the fixed/percentage track bases
+  AND the gutters. Percentage tracks (§7.2.1) still resolve against the FULL
+  content area, so the gap must be threaded as a separate fr-only free-space
+  reduction (not a global content-size reduction).
+- **Trigger** — a corpus/user grid using `fr` (or auto-fill/auto-fit) tracks
+  together with a non-zero gap.
+- **Owner files** — `src/NetPdf.Layout/Layouters/GridSizing.cs` —
+  `ResolveFrTracks` (the multiple call sites at ~lines 170/288/292/310 thread
+  `contentInlineSize` / `contentBlockSize`); the fr free-space derivation needs
+  the gutter total `(trackCount - 1) * gap` subtracted, kept separate from the
+  percentage-track resolution.
+- **Added** — Phase 3 PR (flex/grid gap) — track POSITIONING gap shipped; the fr
+  free-space subtraction was scoped out (intertwined with the grid track-sizing
+  passes).
+- **Removal condition** — fr tracks subtract the gutters from their distributed
+  free space AND the `grid-fr-columns-with-gap` conformance case passes.
+
+---
+
 ## phase-4-painter-wiring
 
 - **ID** — `phase-4-painter-wiring`

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1433,31 +1433,22 @@ grepping the ID).
     `L3_hardening_known_gap_stretch_ignores_min_max_constraints`
     test — when sub-cycle L4+ ships the clamping, that test
     should fail + this bullet should be removed.
-  - **Explicit-width honoring for flex containers**. Per Phase 3
-    Task 15 L4 post-PR-#64 review F#2 — a `display: flex;
-    flex-direction: column; width: 200px` container in a 600px page
-    currently has `_contentInlineSize = 600` (= the available
-    inline range from `BlockLayouter`'s float-adjusted derivation
-    at BlockLayouter.cs:1138). The FlexLayouter then computes
-    `align-items: center` against the 600 page width, not the
-    declared 200. The fix touches the BlockLayouter
-    width-resolution pipeline (cycle-1 BlockLayouter does NOT
-    honor declared `width` as a shrink-to-fit constraint —
-    `borderBoxInlineSize` is always the float-adjusted available
-    range). Tracked by the
-    `L4_hardening_known_gap_column_flex_ignores_declared_width`
-    pinning test + the Skip'd
+  - ~~**Explicit-width honoring for flex/grid containers**~~ —
+    **shipped in the flex/grid gap PR (container-width cycle).**
+    Added `BoxKind.FlexContainer` + `BoxKind.GridContainer` to the
+    `ResolveInFlowBorderBoxInlineSize` gate, so an explicit `width`
+    on a flex/grid container becomes its border-box width (feeding
+    `FlexGeometryHelper` / `GridGeometryHelper`'s content inline
+    size). Alignment, flex-shrink, flex-wrap, and fr track sizing
+    now run against the declared width, not the page width. The
+    three pins flipped to the spec-correct behavior:
     `L4_hardening_column_explicit_width_smaller_than_page_centers_correctly`
-    test. Per Phase 3 Task 15 L6 post-PR-#66 review F#2 — also
-    tracked by the
-    `L6_hardening_known_gap_narrow_flex_in_wide_page_does_not_wrap_yet`
-    production-pipeline test, which pins the wrap-related symptom:
-    `width: 250px` declared on a `flex-wrap: wrap` container in a
-    600px page → wrap fires against the page width (= 4×100=400 <
-    600 → no wrap) instead of the spec-correct declared width
-    (= 4×100=400 > 250 → 2 lines). When the BlockLayouter
-    width-resolution fix lands ALL THREE tests should flip — at
-    which point remove BOTH this bullet AND all three pins.
+    un-Skip'd (item centers in 200 → X=50); the `..._known_gap_...`
+    pin removed; `L6_narrow_flex_in_wide_page_wraps_per_declared_width`
+    now asserts 2 lines. Conformance `flex-explicit-container-width`
+    + `flex-explicit-width-center` + `flex-explicit-width-shrinks-items`
+    + `grid-explicit-container-width` pass. (No real-document output
+    changed — confirmed by the RealDocuments guard.)
   - ~~`order` property~~ — **shipped in Phase 3 Task 15 L10.** New
     `order` Integer property (default 0, applies_to FlexItems) +
     `ReadOrder` extension + `GetFlexChildrenInOrderSequence` shared

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -425,6 +425,38 @@ grepping the ID).
 
 ---
 
+## gap-percentage-sizing
+
+- **ID** — `gap-percentage-sizing`
+- **Status** — `approximated` (a `%` gutter is treated as a 0 gutter — no gap).
+- **Behavior** — `column-gap` / `row-gap` / `gap` on FLEX + GRID containers honor
+  only `<length>` | `normal` today. A PERCENTAGE gutter (`display:flex; gap:10%`)
+  lays out with NO gutter: the property is registered as `Length` (not
+  `LengthPercentage`) in `properties.json`, so a percentage value is rejected at
+  resolution + falls back to `normal`, and `ReadFlexGridGapOrZero` floors any
+  non-`LengthPx` slot to 0 — so the used gutter is 0 rather than the resolved
+  percentage.
+- **Missing** — CSS Box Alignment L3 §8.3 — `row-gap` / `column-gap` are
+  `<length-percentage>`; a percentage resolves against the corresponding dimension
+  of the container content box (column-gap → inline size, row-gap → block size).
+  Two changes are needed: upgrade the property type + resolution path (so a `%`
+  parses instead of being rejected), and resolve the percentage at layout time
+  against the already-known container content extent (kept separate from track /
+  flex sizing, like `grid-gap-fr-track-sizing`).
+- **Trigger** — a corpus/user flex or grid container using a `%` gap.
+- **Owner files** — `src/NetPdf.Css/properties.json` (the `column-gap` / `row-gap`
+  property type), `src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs`
+  (`ReadFlexGridGapOrZero` — add a percentage-resolving overload taking the
+  container content extent), and the gap read sites (`FlexLayouter` ~L636,
+  `GridSizing` gap reads) which must pass the relevant container content dimension.
+- **Added** — Phase 3 PR (flex/grid gap) review [P3] — length gaps shipped;
+  percentage gaps scoped out (property-type change + a layout-time resolution seam).
+- **Removal condition** — `column-gap` / `row-gap` resolve a percentage against the
+  container content box on both axes AND a percentage-gap unit/conformance pin is
+  added (and turns green).
+
+---
+
 ## phase-4-painter-wiring
 
 - **ID** — `phase-4-painter-wiring`

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/LengthResolver.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/LengthResolver.cs
@@ -323,9 +323,12 @@ internal static class LengthResolver
             slot = ComputedSlot.FromKeyword(KeywordIdAuto);
             return true;
         }
-        if (propertyId == PropertyId.ColumnGap
+        if ((propertyId == PropertyId.ColumnGap || propertyId == PropertyId.RowGap)
             && value.Equals("normal", StringComparison.OrdinalIgnoreCase))
         {
+            // CSS Box Alignment L3 §8.1 — `normal` is the initial gap for both
+            // axes (column-gap + row-gap). The flex/grid readers map the Keyword
+            // slot to 0 (multicol's column-gap reader maps it to 1em).
             slot = ComputedSlot.FromKeyword(KeywordIdNormal);
             return true;
         }

--- a/src/NetPdf.Css/ComputedValues/PropertyResolvers/NonNegativeProperties.cs
+++ b/src/NetPdf.Css/ComputedValues/PropertyResolvers/NonNegativeProperties.cs
@@ -71,6 +71,12 @@ internal static class NonNegativeProperties
         // back to the property's initial value (auto / normal) + emits
         // CSS-PROPERTY-VALUE-INVALID-001.
         PropertyId.ColumnWidth, PropertyId.ColumnGap,
+        // Per PR #204 review (Copilot) — row-gap is non-negative too (CSS Box Alignment
+        // L3 §8.1: both gap axes reject negative values). Without this entry a negative
+        // `row-gap` resolved silently to a LengthPx the flex/grid gutter reader floored to
+        // 0, inconsistent with `column-gap` (which invalidates + falls back to `normal` +
+        // emits CSS-PROPERTY-VALUE-INVALID-001).
+        PropertyId.RowGap,
         // Per Phase 5 layout→PDF cycle 3 — <line-width> is non-negative (CSS
         // Backgrounds & Borders 3 §4.2). border-*-width + column-rule-width join
         // the resolver dispatch (LineWidthResolver) + this set together so a

--- a/src/NetPdf.Css/properties.json
+++ b/src/NetPdf.Css/properties.json
@@ -99,6 +99,7 @@
     { "name": "padding-top", "id": "PaddingTop", "type": "LengthPercentage", "default": "0", "inherit": false, "applies_to": "All", "computed": "Specified" },
     { "name": "position", "id": "Position", "type": "Keyword", "default": "static", "inherit": false, "applies_to": "All", "computed": "Specified" },
     { "name": "right", "id": "Right", "type": "LengthPercentageAuto", "default": "auto", "inherit": false, "applies_to": "Positioned", "computed": "Specified" },
+    { "name": "row-gap", "id": "RowGap", "type": "Length", "default": "normal", "inherit": false, "applies_to": "BlockOnly", "computed": "Specified" },
     { "name": "table-layout", "id": "TableLayout", "type": "Keyword", "default": "auto", "inherit": false, "applies_to": "TableElements", "computed": "Specified" },
     { "name": "text-align", "id": "TextAlign", "type": "Keyword", "default": "start", "inherit": true, "applies_to": "All", "computed": "Specified" },
     { "name": "text-decoration-line", "id": "TextDecorationLine", "type": "Keyword", "default": "none", "inherit": false, "applies_to": "All", "computed": "Specified" },

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -9610,9 +9610,17 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // emission-time call; only the return value differs.
         var sortedChildIndices =
             flexContainer.GetFlexChildrenInOrderSequence(cancellationToken);
+        // §8 — pass the gap gutters so the pre-measure wrap decision + cross
+        // extent match emission (FlexLayouter). Row: main=column-gap, cross=row-gap;
+        // column swaps. No-op when no gap is set.
+        var isColumn = direction.IsFlexColumnDirection();
+        var mainGap = flexContainer.Style.ReadFlexGridGapOrZero(
+            isColumn ? PropertyId.RowGap : PropertyId.ColumnGap);
+        var crossGap = flexContainer.Style.ReadFlexGridGapOrZero(
+            isColumn ? PropertyId.ColumnGap : PropertyId.RowGap);
         return FlexLinePacker.SumCrossExtent(
             flexContainer, sortedChildIndices, direction,
-            containerMainSize, isWrapping: true, cancellationToken);
+            containerMainSize, isWrapping: true, cancellationToken, mainGap, crossGap);
     }
 
     /// <summary>Per Phase 3 Task 14 cycle 1 hardening (Finding 1) —

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7004,15 +7004,22 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// placement (post-PR-#164 review P1: the outer dispatch passes the FLOAT-ADJUSTED
     /// available range — the engine's cycle-1 model places in-flow blocks within it, so the
     /// distribution must match or a centred box drifts; the recursion passes the parent's
-    /// content box). A box with AUTO width keeps the fill behavior (auto margins read 0), and
-    /// non-plain kinds (tables/flex/grid/anonymous) are untouched like the width override.</summary>
+    /// content box). A box with AUTO width keeps the fill behavior (auto margins read 0).
+    /// <see cref="BoxKind.FlexContainer"/> / <see cref="BoxKind.GridContainer"/> participate
+    /// too (PR #204 review [P2]) now that they honor their own explicit <c>width</c> — a
+    /// flex/grid container is a block-level box in normal flow, so §10.3.3 auto-margins apply;
+    /// table + anonymous kinds stay untouched (they own their inline-size logic).</summary>
     private static void ResolveAutoInlineMargins(
         Box child, double borderBoxInlineSize, double distributionRangePx,
         ref double marginInlineStart, ref double marginInlineEnd)
     {
         // BlockReplacedElement included (img-pipeline cycle) — `display: block; margin: 0 auto`
         // is the canonical image-centering idiom; the pre-pass gave it an explicit used width.
-        if (child.Kind is not (BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement)) return;
+        // FlexContainer / GridContainer included (PR #204 review [P2]) — `display: flex;
+        // width: 200px; margin: 0 auto` centers the container, matching the explicit-width
+        // gate in ResolveInFlowBorderBoxInlineSize (both sets must stay in lockstep).
+        if (child.Kind is not (BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement
+            or BoxKind.FlexContainer or BoxKind.GridContainer)) return;
         // EXPLICIT width only (a tag test, so the legal `width: 0` / `0%` distributes too —
         // post-PR-#164 review P3); auto-width boxes keep the fill (auto margins read 0).
         if (!HasExplicitWidth(child)) return;
@@ -9329,10 +9336,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         var lineItems = new List<Box>();
         foreach (var child in flexContainer.Children)
             if (child.IsBlockLevel) lineItems.Add(child);
+        // PR #204 review [P1] — the row-nowrap main-axis gutter (column-gap) consumes
+        // the §9.7 free space, so the pre-measure resolves each item's width at the
+        // SAME flex-resolved value FlexLayouter emits at (an item pre-measured too wide
+        // under-counts its wrapped height → mis-skips the row-nowrap pagination gate).
+        var mainGap = flexContainer.Style.ReadFlexGridGapOrZero(PropertyId.ColumnGap);
         var resolvedMain = lineItems.Count > 0
             ? FlexLayouter.ResolveFlexLineMainSizes(
                 lineItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth,
-                flexContentInlineSize, cancellationToken)
+                flexContentInlineSize, mainGap, cancellationToken)
             : System.Array.Empty<double>();
 
         Dictionary<Box, double>? measureCache = null;
@@ -9465,10 +9477,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             - flexContainer.Style.ReadLengthPxOrZero(PropertyId.PaddingRight));
         Dictionary<Box, double>? measureCache = null;
         var totalMain = 0.0;
+        var blockLevelCount = 0;
         foreach (var item in flexContainer.Children)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!item.IsBlockLevel) continue;
+            blockLevelCount++;
             // Flex box-sizing cycle — the declared height (main) + width (cross) are
             // BORDER-box sizes; map the height to a border box honoring `box-sizing`, and
             // measure content at the CONTENT width (border box minus the inline chrome).
@@ -9520,6 +9534,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             }
             totalMain += mainExtent;
         }
+        // PR #204 review [P1] — for column direction the main-axis gutter is row-gap;
+        // the N-1 gutters add to the natural main extent (emission advances the main
+        // cursor by mainGap between items, AttemptLayout ~L1550), so the overflow /
+        // pagination trigger must count them too rather than under-reporting the height.
+        var columnMainGap = flexContainer.Style.ReadFlexGridGapOrZero(PropertyId.RowGap);
+        totalMain += System.Math.Max(0, blockLevelCount - 1) * columnMainGap;
         return totalMain;
     }
 

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -6946,9 +6946,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     ///   (img-pipeline cycle): the sizing pre-pass writes the §10.3.2 used width/height into
     ///   the slots, so an explicit width here is the image's used size — filling would
     ///   stretch it.</item>
-    ///   <item><see cref="BoxKind.FlexContainer"/> / <see cref="BoxKind.GridContainer"/> keep
-    ///   the documented cycle-1 fill behavior (their explicit-width honoring is its own cycle
-    ///   — see <c>docs/deferrals.md</c>).</item>
+    ///   <item><see cref="BoxKind.FlexContainer"/> / <see cref="BoxKind.GridContainer"/> now
+    ///   honor an explicit <c>width</c> too (the flex/grid container-width cycle): the declared
+    ///   border-box width feeds <c>FlexGeometryHelper</c> / <c>GridGeometryHelper</c>'s content
+    ///   inline size, so alignment / wrap / track sizing run against the declared width, not the
+    ///   page width. <c>width: auto</c> keeps the fill behavior.</item>
     /// </list>
     /// §10.3.3 margin DISTRIBUTION ships in the auto-margins cycle — see
     /// <see cref="ResolveAutoInlineMargins"/> (the caller applies it right after this).</summary>
@@ -6956,7 +6958,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         Box child, double availableInlineSize, double containingInlinePx,
         double marginInlineStart, double marginInlineEnd)
     {
-        if (child.Kind is BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement)
+        if (child.Kind is BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement
+            or BoxKind.FlexContainer or BoxKind.GridContainer)
         {
             // Body % lengths (body-percent cycle): an explicit PERCENTAGE width resolves against
             // the CONTAINING block's inline size (CSS 2.2 §10.2 — not the float-adjusted available

--- a/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
+++ b/src/NetPdf.Layout/Layouters/ComputedStyleLayoutExtensions.cs
@@ -489,6 +489,20 @@ internal static class ComputedStyleLayoutExtensions
             : 16.0;
     }
 
+    /// <summary>Per Phase 3 — flex/grid gutter for <see cref="PropertyId.ColumnGap"/>
+    /// / <see cref="PropertyId.RowGap"/> (CSS Box Alignment L3 §8). Unlike
+    /// multicol's <see cref="ReadColumnGap"/> (where <c>normal</c> ≈ 1em), for
+    /// FLEX + GRID containers <c>normal</c> (and unset / non-length) computes to 0
+    /// (§8.1) — so an explicit length is the gutter and everything else is no
+    /// gap. Negative lengths floor at 0.</summary>
+    public static double ReadFlexGridGapOrZero(this ComputedStyle style, PropertyId gapProperty)
+    {
+        var slot = style.Get(gapProperty);
+        return slot.Tag == ComputedSlotTag.LengthPx
+            ? System.Math.Max(0, slot.AsLengthPx())
+            : 0.0;
+    }
+
     /// <summary>Per Phase 3 Task 14 cycle 4 — decode
     /// <see cref="PropertyId.ColumnWidth"/> as a CSS px length. Returns
     /// <see langword="null"/> when the slot is <c>auto</c> / unset OR

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -811,13 +811,23 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             for (var i = resumeLineIndex; i < lines.Count; i++)
             {
                 var isFirstOnPage = i == resumeLineIndex;
+                // §8 — a cross-axis gutter precedes every NON-first line on the page;
+                // include it in the fit cursor so the slice can't approve more lines
+                // than emission (which advances by LineCrossSize + crossGap, ~L1591)
+                // will actually fit on the page (PR #204 review [P1]). The "first line
+                // always commits" rule is preserved: both the gutter and the overflow
+                // check are gated on !isFirstOnPage, so a lone over-tall first line
+                // still lands rather than deferring forever.
+                var lineAdvance = isFirstOnPage
+                    ? lines[i].LineCrossSize
+                    : crossGap + lines[i].LineCrossSize;
                 if (!isFirstOnPage
-                    && rawCursor + lines[i].LineCrossSize > _contentBlockSize)
+                    && rawCursor + lineAdvance > _contentBlockSize)
                 {
                     fragmentEndIndex = i;
                     break;
                 }
-                rawCursor += lines[i].LineCrossSize;
+                rawCursor += lineAdvance;
             }
         }
 
@@ -999,7 +1009,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         var (minSizeProperty, maxSizeProperty) = GetMinMaxMainAxisProperties(flexDirection);
         var resolvedItemMainSizes = ResolveFlexibleMainSizes(
             lines, mainSizeProperty, minSizeProperty, maxSizeProperty,
-            containerMainSize, cancellationToken);
+            containerMainSize, mainGap, cancellationToken);
 
         // Non-block-pagination arc (flex item CONTENT layout) — lay out each
         // flex item's INNER content (text / nested blocks) via a nested
@@ -1903,6 +1913,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId minSizeProperty,
         PropertyId maxSizeProperty,
         double containerMainSize,
+        double mainGap,
         CancellationToken cancellationToken)
     {
         var resolved = new double[_rootBox.Children.Count];
@@ -1913,7 +1924,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             ResolveLineWithMinMaxClamping(
                 line, resolved, mainSizeProperty,
                 minSizeProperty, maxSizeProperty,
-                containerMainSize, cancellationToken);
+                containerMainSize, mainGap, cancellationToken);
         }
 
         return resolved;
@@ -1965,6 +1976,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId minSizeProperty,
         PropertyId maxSizeProperty,
         double containerMainSize,
+        double mainGap,
         CancellationToken cancellationToken)
     {
         // Resolve via the shared static §9.7 helper (position-keyed), then scatter
@@ -1975,7 +1987,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             lineItems[i] = _rootBox.Children[_sortedFlexChildIndices[line.FirstItemIndex + i]];
         var lineResolved = ResolveFlexLineMainSizes(
             lineItems, mainSizeProperty, minSizeProperty, maxSizeProperty,
-            containerMainSize, cancellationToken);
+            containerMainSize, mainGap, cancellationToken);
         for (var i = 0; i < count; i++)
             resolved[_sortedFlexChildIndices[line.FirstItemIndex + i]] = lineResolved[i];
     }
@@ -1997,10 +2009,22 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId minSizeProperty,
         PropertyId maxSizeProperty,
         double containerMainSize,
+        double mainGap,
         CancellationToken cancellationToken)
     {
         var itemCount = lineItems.Count;
         var resolved = new double[itemCount];
+
+        // CSS Box Alignment L3 §8 — the N-1 main-axis gutters consume free space
+        // BEFORE flex grow/shrink distributes the remainder (PR #204 review [P1]).
+        // The gutter total is removed from the distributable free space only; a
+        // percentage flex-basis still resolves against the FULL container main size
+        // (ResolveHypotheticalMainSize below is unchanged), exactly mirroring the
+        // emission site where mainGap is subtracted before justify-content
+        // distributes (AttemptLayout ~L1224). Without this, `gap` + flex-grow/shrink
+        // sized items as if the gap didn't exist, then still inserted the gap at
+        // emission → overflow / wrong widths.
+        var mainGutterTotal = System.Math.Max(0, itemCount - 1) * mainGap;
 
         // Stack-friendly per-item state: hypothetical + (min, max) +
         // frozen flag, keyed by sorted-position within the line.
@@ -2065,7 +2089,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                 }
             }
 
-            var remainingFreeSpace = containerMainSize - sumFrozenResolved - sumUnfrozenHypothetical;
+            var remainingFreeSpace = containerMainSize - mainGutterTotal - sumFrozenResolved - sumUnfrozenHypothetical;
 
             // Distribute remainingFreeSpace among unfrozen items.
             if (remainingFreeSpace > 0 && sumFlexGrow > 0)

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -629,6 +629,15 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         var contentMainOffset = isColumn ? _contentBlockOffset : _contentInlineOffset;
         var contentCrossOffset = isColumn ? _contentInlineOffset : _contentBlockOffset;
 
+        // CSS Box Alignment L3 §8 — gap gutters. The MAIN-axis gutter sits between
+        // items in a line (column-gap for row direction, row-gap for column); the
+        // CROSS-axis gutter sits between wrapped lines (the swapped pair). `normal`
+        // / unset → 0 for flex (ReadFlexGridGapOrZero).
+        var mainGap = _rootBox.Style.ReadFlexGridGapOrZero(
+            isColumn ? PropertyId.RowGap : PropertyId.ColumnGap);
+        var crossGap = _rootBox.Style.ReadFlexGridGapOrZero(
+            isColumn ? PropertyId.ColumnGap : PropertyId.RowGap);
+
         // Per Phase 3 Task 15 L10 — compute the effective flex order
         // ONCE per AttemptLayout entry; both PackLines (line packing)
         // and the per-line emission below walk this list so item
@@ -658,7 +667,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         // <c>_sortedFlexChildIndices[firstItemIndex + i]</c>.
         var lines = PackLines(
             _rootBox, _sortedFlexChildIndices, flexDirection,
-            containerMainSize, isWrapping, cancellationToken);
+            containerMainSize, isWrapping, cancellationToken, mainGap);
 
         // Per Phase 3 Task 16 cycle 1 (Hello World) — multi-page flex
         // split fragment range determination per CSS Flexbox L1 §10
@@ -925,7 +934,10 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             cancellationToken.ThrowIfCancellationRequested();
             sumLineCrossExtents += line.LineCrossSize;
         }
-        var freeCrossSpace = containerCrossSize - sumLineCrossExtents;
+        // §8 — cross-axis gaps between wrapped lines consume free space BEFORE
+        // align-content distributes the remainder. N lines → N-1 gutters.
+        var crossGapTotal = System.Math.Max(0, lines.Count - 1) * crossGap;
+        var freeCrossSpace = containerCrossSize - sumLineCrossExtents - crossGapTotal;
 
         var (lineStartOffset, lineBetweenSpacing, lineStretchAddend) =
             ComputeAlignContentOffsets(resolvedAC, freeCrossSpace, lines.Count, isWrapping);
@@ -1206,7 +1218,11 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             // main-size. (CSS Flexbox L1 §6.3 says wrapped lines are
             // formatted independently for main-axis alignment; the
             // container's main extent remains the alignment basis.)
-            var freeSpace = containerMainSize - line.LineMainSize;
+            // §8 — the main-axis gaps consume free space BEFORE justify-content
+            // distributes the remainder (gaps are not part of the distributed
+            // space). N items → N-1 gutters.
+            var lineMainGapTotal = System.Math.Max(0, line.ItemCount - 1) * mainGap;
+            var freeSpace = containerMainSize - line.LineMainSize - lineMainGapTotal;
             var (startOffset, betweenSpacing) = ComputeJustifyContentOffsets(
                 resolvedJC.Value, resolvedJC.Mode, freeSpace, line.ItemCount);
 
@@ -1528,6 +1544,10 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                 // distribution values (space-between / -around /
                 // -evenly); position values leave it at 0.
                 mainCursor += itemMainSize + betweenSpacing;
+                // §8 — a main-axis gutter follows every item except the last on
+                // the line (so an auto-sized container isn't inflated by a
+                // trailing gap).
+                if (sortedPos < endSortedPos - 1) mainCursor += mainGap;
             }
 
             // Advance the line cross cursor past this line's cross
@@ -1564,7 +1584,11 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             // physical offset is computed by the swap formula at the
             // top of the loop body. For wrap (= !isWrapReverse) this
             // is identical to L1-L10 cursor behavior.
-            swappedAxisCursor += line.LineCrossSize + lineBetweenSpacing;
+            // §8 — a cross-axis gutter follows every line; the trailing one (after
+            // the last line) only advances the discarded cursor — the container's
+            // cross extent reads maxEmittedCrossBottom (the true last-line bottom),
+            // mirroring the lineBetweenSpacing handling.
+            swappedAxisCursor += line.LineCrossSize + lineBetweenSpacing + crossGap;
         }
 
         // Per Phase 3 Task 16 cycle 1 → cycle 4b — multi-page flex
@@ -1717,6 +1741,8 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
     /// every block-level item (L1-L5 single-line algorithm).</param>
     /// <param name="cancellationToken">Propagates cancellation into the
     /// per-item loops.</param>
+    /// <param name="mainGap">CSS Box Alignment L3 §8 main-axis gutter between
+    /// items on a line (0 = none); folded into the wrap decision.</param>
     /// <returns>The packed flex lines; never null. Returns an empty list
     /// when the container has no block-level children (matches the L1-L5
     /// behavior of emitting no item fragments). Per Phase 3 Task 15 L10,
@@ -1748,10 +1774,11 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         FlexDirectionValue direction,
         double containerMainSize,
         bool isWrapping,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        double mainGap)
         => FlexLinePacker.Pack(
             flexContainer, sortedChildIndices, direction,
-            containerMainSize, isWrapping, cancellationToken);
+            containerMainSize, isWrapping, cancellationToken, mainGap);
 
     /// <summary>Per Phase 3 Task 15 L6 — resolve the container's cross-
     /// axis extent for the L1-L5 single-line case + the L6 wrap case.
@@ -1805,6 +1832,11 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             cancellationToken.ThrowIfCancellationRequested();
             sum += line.LineCrossSize;
         }
+        // §8 — cross-axis (row-gap) gutters between wrapped lines add to the auto
+        // cross-size so the container contains its gap-spaced lines. No-op for a
+        // single line / no gap.
+        sum += System.Math.Max(0, lines.Count - 1)
+            * _rootBox.Style.ReadFlexGridGapOrZero(PropertyId.RowGap);
         return sum;
     }
 

--- a/src/NetPdf.Layout/Layouters/FlexLinePacker.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLinePacker.cs
@@ -102,6 +102,8 @@ internal static class FlexLinePacker
     /// <param name="isWrapping">True for <c>flex-wrap: wrap</c> or
     /// <c>wrap-reverse</c>; false for <c>nowrap</c>.</param>
     /// <param name="cancellationToken">Honored once per item.</param>
+    /// <param name="mainGap">CSS Box Alignment L3 §8 main-axis gutter between
+    /// items on a line (0 = none); the wrap decision accounts for it.</param>
     /// <returns>The packed lines. Empty when
     /// <paramref name="sortedChildIndices"/> is empty (= no items to
     /// pack; the caller short-circuits emission).</returns>
@@ -111,7 +113,8 @@ internal static class FlexLinePacker
         FlexDirectionValue direction,
         double containerMainSize,
         bool isWrapping,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        double mainGap = 0.0)
     {
         var lines = new List<FlexLine>();
         // Per PR-#84 review P3 #5 — axis mapping comes from the
@@ -165,7 +168,13 @@ internal static class FlexLinePacker
                 mainProp, containerMainSize);
             var itemCross = CrossBorderBoxSize(item, crossProp);
 
-            if (currentCount > 0 && currentMain + itemMain > containerMainSize)
+            // §8 — adding this item to the current line costs `currentCount`
+            // gutters (one before each of the existing items' successor); the line
+            // wraps when items + their gutters exceed the budget. `currentMain`
+            // tracks item sizes only (gaps excluded), matching the caller's
+            // freeSpace = container - LineMainSize - (ItemCount-1)*gap math.
+            if (currentCount > 0
+                && currentMain + itemMain + currentCount * mainGap > containerMainSize)
             {
                 lines.Add(new FlexLine(
                     FirstItemIndex: currentFirstSortedPos,
@@ -237,7 +246,9 @@ internal static class FlexLinePacker
         FlexDirectionValue direction,
         double containerMainSize,
         bool isWrapping,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        double mainGap = 0.0,
+        double crossGap = 0.0)
     {
         var (mainProp, crossProp) = direction.GetAxisProperties();
 
@@ -266,6 +277,7 @@ internal static class FlexLinePacker
         // a new line starts (current line's items would overflow),
         // commit the current line's cross-extent to the sum + reset.
         var sumLineCross = 0.0;
+        var lineCount = 0;
         var currentCount = 0;
         var currentMain = 0.0;
         var currentCross = 0.0;
@@ -278,9 +290,14 @@ internal static class FlexLinePacker
                 mainProp, containerMainSize);
             var itemCross = CrossBorderBoxSize(item, crossProp);
 
-            if (currentCount > 0 && currentMain + itemMain > containerMainSize)
+            // §8 — wrap accounts for the main-axis gutters (currentCount of them
+            // once this item joins the line). Mirrors Pack so the pre-measure
+            // line count matches emission.
+            if (currentCount > 0
+                && currentMain + itemMain + currentCount * mainGap > containerMainSize)
             {
                 sumLineCross += currentCross;
+                lineCount++;
                 currentCount = 0;
                 currentMain = 0;
                 currentCross = 0;
@@ -294,9 +311,12 @@ internal static class FlexLinePacker
         if (currentCount > 0)
         {
             sumLineCross += currentCross;
+            lineCount++;
         }
 
-        return sumLineCross;
+        // §8 — cross-axis gutters between the wrapped lines add to the extent
+        // (matches FlexLayouter.ResolveContainerCrossSize's emit-side sum).
+        return sumLineCross + System.Math.Max(0, lineCount - 1) * crossGap;
     }
 
     /// <summary>Flex box-sizing cycle — the item's BORDER-box cross size for line packing,

--- a/src/NetPdf.Layout/Layouters/GridLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/GridLayouter.cs
@@ -777,11 +777,13 @@ internal sealed class GridLayouter : ILayouter, IDisposable
             var inlineOffset = _contentInlineOffset + colPositionsRelative[item.Col];
             var blockOffset = _contentBlockOffset
                 + (rowPositionsRelative[item.Row] - rowOffsetShift);
-            // Per Phase 3 Task 18 cycle 6 — size is the sum of the
-            // item's spanned tracks (= the rectangle's extent). For
-            // span=1 items this collapses to the single-track size.
-            var inlineSize = SumTrackSizes(colSizesRelative, item.Col, colSpan);
-            var blockSize = SumTrackSizes(rowSizesRelative, item.Row, rowSpan);
+            // Per Phase 3 Task 18 cycle 6 — size is the spanned tracks' extent
+            // (= the rectangle). Computed from the track POSITIONS (last spanned
+            // track's end edge − first's start) so the gap gutters BETWEEN spanned
+            // tracks are included (§10.1); for span=1 this is the single-track
+            // size.
+            var inlineSize = SpanExtent(colPositionsRelative, colSizesRelative, item.Col, colSpan);
+            var blockSize = SpanExtent(rowPositionsRelative, rowSizesRelative, item.Row, rowSpan);
             _sink.Emit(new BoxFragment(
                 Box: item.Box,
                 InlineOffset: inlineOffset,
@@ -1186,20 +1188,20 @@ internal sealed class GridLayouter : ILayouter, IDisposable
         return (spanClampedEnd, NeedsContinuation: needsContinuation, DeferEntireGrid: false);
     }
 
-    /// <summary>Per Phase 3 Task 18 cycle 6 — sum the contiguous-track
-    /// sizes <c>sizes[start..start+span]</c>. Defends against
-    /// boundary-overrun (= a malformed cache where item.Row + RowSpan
-    /// exceeds rowCount silently clamps to the available extent
-    /// instead of throwing). For span=1 the result is just
-    /// <c>sizes[start]</c>.</summary>
-    private static double SumTrackSizes(
-        IReadOnlyList<double> sizes, int start, int span)
+    /// <summary>Per Phase 3 Task 18 cycle 6 + the flex/grid gap PR — the extent of
+    /// the contiguous tracks <c>[start, start+span)</c>, taken as the last spanned
+    /// track's END edge minus the first's START. Because the track
+    /// <paramref name="positions"/> already include the §10.1 gap gutters, this
+    /// span extent covers the gutters BETWEEN spanned tracks (a plain size-sum
+    /// would omit them, leaving a spanning item too small). Defends against
+    /// boundary-overrun (a malformed cache where start+span exceeds the track
+    /// count silently clamps). For span=1 this is just <c>sizes[start]</c>.</summary>
+    private static double SpanExtent(
+        IReadOnlyList<double> positions, IReadOnlyList<double> sizes, int start, int span)
     {
         if (start < 0 || start >= sizes.Count) return 0;
-        var endExclusive = Math.Min(start + Math.Max(1, span), sizes.Count);
-        double sum = 0;
-        for (var i = start; i < endExclusive; i++) sum += sizes[i];
-        return sum;
+        var last = Math.Min(start + Math.Max(1, span), sizes.Count) - 1;
+        return (positions[last] + sizes[last]) - positions[start];
     }
 
     /// <summary>Per Phase 3 Task 17 cycle 5 + post-PR-#96 review F3 +

--- a/src/NetPdf.Layout/Layouters/GridSizing.cs
+++ b/src/NetPdf.Layout/Layouters/GridSizing.cs
@@ -332,9 +332,13 @@ internal static class GridSizing
         var rowSizes = MaterializeSizes(rowInfos);
         var colSizes = MaterializeSizes(colInfos);
 
-        // Compute positions + finite check.
-        var rowPositions = ComputeTrackPositions(rowSizes, contentBlockOffset);
-        var colPositions = ComputeTrackPositions(colSizes, contentInlineOffset);
+        // Compute positions + finite check. CSS Grid L1 §10.1 — gutters between
+        // tracks (column-gap between columns, row-gap between rows). `normal` /
+        // unset → 0 for grid.
+        var columnGap = gridBox.Style.ReadFlexGridGapOrZero(PropertyId.ColumnGap);
+        var rowGap = gridBox.Style.ReadFlexGridGapOrZero(PropertyId.RowGap);
+        var rowPositions = ComputeTrackPositions(rowSizes, contentBlockOffset, rowGap);
+        var colPositions = ComputeTrackPositions(colSizes, contentInlineOffset, columnGap);
         var isFinite = IsTrackGeometryFinite(rowPositions, rowSizes)
             && IsTrackGeometryFinite(colPositions, colSizes);
         if (!isFinite)
@@ -2926,14 +2930,16 @@ internal static class GridSizing
     // =====================================================================
 
     private static List<double> ComputeTrackPositions(
-        List<double> sizes, double originOffset)
+        List<double> sizes, double originOffset, double gap)
     {
         var positions = new List<double>(sizes.Count);
         var cursor = originOffset;
-        foreach (var size in sizes)
+        for (var i = 0; i < sizes.Count; i++)
         {
             positions.Add(cursor);
-            cursor += size;
+            cursor += sizes[i];
+            // CSS Grid L1 §10.1 — a gutter follows every track except the last.
+            if (i < sizes.Count - 1) cursor += gap;
         }
         return positions;
     }

--- a/src/NetPdf.Layout/Layouters/GridSizing.cs
+++ b/src/NetPdf.Layout/Layouters/GridSizing.cs
@@ -88,6 +88,10 @@ internal static class GridSizing
         public required List<double> RowPositions { get; init; }
         public required List<double> ColPositions { get; init; }
         public required List<PlacedItem> PlacedItems { get; init; }
+        /// <summary>CSS Grid L1 §10.1 row-gap gutter (0 when none) — folded into
+        /// <see cref="RowExtentSum"/> so the auto-height wrapper reserves the
+        /// gutters too (the positions already include them).</summary>
+        public double RowGap { get; init; }
         /// <summary>True when cumulative positions + per-track right/
         /// bottom edges are all finite. Caller skips emission when
         /// false (= protect downstream paint from non-finite geometry).</summary>
@@ -106,6 +110,10 @@ internal static class GridSizing
             {
                 double sum = 0;
                 foreach (var s in RowSizes) sum += s;
+                // §10.1 — the row-gap gutters between the row tracks are part of
+                // the block extent (the row positions already include them), so
+                // an auto-height wrapper must reserve them too.
+                if (RowSizes.Count > 1) sum += (RowSizes.Count - 1) * RowGap;
                 return sum;
             }
         }
@@ -363,6 +371,7 @@ internal static class GridSizing
             RowPositions = rowPositions,
             ColPositions = colPositions,
             PlacedItems = placedItems,
+            RowGap = rowGap,
             IsGeometryFinite = isFinite,
         };
     }

--- a/tests/NetPdf.RealDocuments/Css/PropertyCoverageCorpusTests.cs
+++ b/tests/NetPdf.RealDocuments/Css/PropertyCoverageCorpusTests.cs
@@ -122,7 +122,10 @@ public sealed class PropertyCoverageCorpusTests
         "grid-column", "grid-column-gap",
         "grid-row", "grid-row-gap",
         "grid-template",
-        "gap", "row-gap",
+        // `gap` is a shorthand AngleSharp expands to row-gap/column-gap — not a
+        // registered longhand. row-gap promoted out of the allowlist by the
+        // flex/grid gap PR (now registered + applied like column-gap below).
+        "gap",
         // column-gap promoted out of the allowlist by Phase 3 Task 14
         // cycle 1 — the property is now registered + resolves via the
         // multicol family. Other column-* properties (column-count,

--- a/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/LengthResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/ComputedValues/PropertyResolvers/LengthResolverTests.cs
@@ -472,6 +472,22 @@ public sealed class LengthResolverTests
     }
 
     [Fact]
+    public void Row_gap_negative_is_rejected()
+    {
+        // PR #204 review (Copilot) — CSS Box Alignment L3 §8.1: row-gap rejects
+        // negatives exactly like column-gap. A negative value falls back to the initial
+        // keyword (normal) + emits CSS-PROPERTY-VALUE-INVALID-001 (previously it resolved
+        // to a LengthPx the flex/grid gutter reader silently floored to 0).
+        var sink = new CapturingSink();
+        var result = LengthResolver.Resolve("-10px", PropertyType.Length,
+            PropertyId.RowGap, "row-gap", sink, default);
+        Assert.True(result.IsInvalid);
+        Assert.Contains(sink.Diagnostics, d =>
+            d.Code == CssDiagnosticCodes.CssPropertyValueInvalid001 &&
+            d.Message.Contains("negative", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void Column_width_negative_is_rejected()
     {
         // CSS Multi-column L1 §3.1 — column-width admits non-negative

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -52,6 +52,7 @@ public sealed class DeferralsParityTests
         "auto-height-emit-vs-pagination",
         "min-max-percentage-sizing",
         "grid-gap-fr-track-sizing",
+        "gap-percentage-sizing",
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",
         "inline-atomic-boxes",

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -51,6 +51,7 @@ public sealed class DeferralsParityTests
         "multi-page-allocation-churn",
         "auto-height-emit-vs-pagination",
         "min-max-percentage-sizing",
+        "grid-gap-fr-track-sizing",
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",
         "inline-atomic-boxes",

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterProductionTests.cs
@@ -1001,20 +1001,14 @@ public sealed class FlexLayouterProductionTests
     }
 
     [Fact]
-    public async Task L6_hardening_known_gap_narrow_flex_in_wide_page_does_not_wrap_yet()
+    public async Task L6_narrow_flex_in_wide_page_wraps_per_declared_width()
     {
-        // Per Phase 3 Task 15 L6 post-PR-#66 review F#2 — the L6
-        // production test masked this by narrowing the fragmentainer
-        // contentInlineSize to match the declared flex width. On a
-        // default 600px page, `.flex { width: 250px; flex-wrap: wrap;
-        // }` SHOULD wrap 4×100px items into 2 lines (4*100=400 > 250)
-        // per spec. Because BlockLayouter doesn't honor declared
-        // `width` on block containers (the
-        // `BlockLayouter-flex-explicit-width` deferral from PR #64
-        // F#2), the wrapper is 600px wide and 4×100=400 < 600 → no
-        // wrap. This test PINS the current incomplete behavior. When
-        // the BlockLayouter explicit-width fix lands, this test
-        // should flip to assert 2 lines.
+        // Per Phase 3 Task 15 L6 post-PR-#66 review F#2 — on a default 600px page,
+        // `.flex { width: 250px; flex-wrap: wrap; }` wraps 4×100px items into 2
+        // lines (4*100=400 > 250) per spec. The flex/grid container-width cycle
+        // makes BlockLayouter honor the declared 250px width (it feeds the flex
+        // content width), so the wrap threshold is 250, not the 600px page. This
+        // was the `BlockLayouter-flex-explicit-width` known gap (now closed).
         const string html = """
             <!DOCTYPE html><html><head><style>
                 .flex {
@@ -1036,9 +1030,7 @@ public sealed class FlexLayouterProductionTests
         // Use default 600px page width (no contentInlineSize override).
         var (sink, _, _) = await RenderViaFullPipelineAsync(html);
 
-        // Collect item fragments. Currently — because BlockLayouter
-        // doesn't honor the 250px declared width — wrapper is 600px
-        // so all 4 items fit on one line.
+        // Collect item fragments, sorted into reading order (line, then column).
         var items = sink.Fragments.Where(f =>
             f.Box.SourceElement is not null &&
             f.Box.SourceElement.GetAttribute("class") == "item")
@@ -1046,15 +1038,17 @@ public sealed class FlexLayouterProductionTests
             .ToList();
         Assert.Equal(4, items.Count);
 
-        // KNOWN-GAP PIN — current behavior: all 4 items on one line
-        // at BlockOffset 0 (NOT the spec-correct 2 lines at 0/50).
-        foreach (var item in items)
-        {
-            Assert.Equal(0.0, item.BlockOffset, precision: 3);
-        }
-        // When BlockLayouter-flex-explicit-width is fixed, this
-        // should change to: items[0..1] at BlockOffset 0, items[2..3]
-        // at BlockOffset 50.
+        // 2 lines: items 0,1 on line 1 (BlockOffset 0); items 2,3 wrap to line 2
+        // (BlockOffset 50 = the 50px item height) — the 250px container fits only
+        // two 100px items per line.
+        Assert.Equal(0.0, items[0].BlockOffset, precision: 3);
+        Assert.Equal(0.0, items[1].BlockOffset, precision: 3);
+        Assert.Equal(50.0, items[2].BlockOffset, precision: 3);
+        Assert.Equal(50.0, items[3].BlockOffset, precision: 3);
+        Assert.Equal(0.0, items[0].InlineOffset, precision: 3);
+        Assert.Equal(100.0, items[1].InlineOffset, precision: 3);
+        Assert.Equal(0.0, items[2].InlineOffset, precision: 3);
+        Assert.Equal(100.0, items[3].InlineOffset, precision: 3);
     }
 
     /// <summary>Per Phase 3 Task 15 L2 post-PR-#62 hardening F#4 —

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
@@ -2145,18 +2145,11 @@ public sealed class FlexLayouterTests
             siblingFragment!.Value.BlockOffset, precision: 3);
     }
 
-    [Fact(Skip =
-        "Phase 3 Task 15 L4 post-PR-#64 review F#2 — explicit-width "
-        + "honoring for flex containers requires the BlockLayouter "
-        + "width-resolution pipeline to honor declared `width` as a "
-        + "shrink-to-fit constraint (cycle-1 BlockLayouter derives "
-        + "borderBoxInlineSize from the available inline range + "
-        + "ignores declared width). The fix is out of L4 hardening "
-        + "scope; tracked as the BlockLayouter-flex-explicit-width "
-        + "Missing bullet under docs/deferrals.md#flex-layouter-features. "
-        + "When that gap is closed, remove the Skip + the assertion "
-        + "below verifies items center against the declared 200px "
-        + "container (not the 600px page).")]
+    // Flex/grid container-width cycle — a flex container now HONORS its own
+    // explicit `width` (added to the ResolveInFlowBorderBoxInlineSize gate), so
+    // align-items:center centers items against the declared 200px, not the 600px
+    // page. Was Skip'd as a known gap; the fix flips it to passing.
+    [Fact]
     public void L4_hardening_column_explicit_width_smaller_than_page_centers_correctly()
     {
         // F#2 — page = 600px wide. Flex container has explicit
@@ -2202,60 +2195,6 @@ public sealed class FlexLayouterTests
         Assert.NotNull(itemFragment);
         // F#2 expected: item centered in the 200-px declared width.
         Assert.Equal(50.0, itemFragment!.Value.InlineOffset, precision: 3);
-    }
-
-    [Fact]
-    public void L4_hardening_known_gap_column_flex_ignores_declared_width()
-    {
-        // F#2 known-gap pin — paired with the Skip'd test above.
-        // Documents the CURRENT (incomplete) behavior: a column flex
-        // container with width:200 in a 600px page treats
-        // _contentInlineSize as the full page width, so align-items:
-        // center centers items against 600 (= page) instead of 200
-        // (= declared width). Reviewer-flagged at PR #64.
-        //
-        // When the BlockLayouter width-resolution fix lands + the
-        // Skip'd "smaller_than_page_centers_correctly" test starts
-        // passing, this test will start failing — at which point
-        // remove BOTH this pin AND the matching Missing bullet in
-        // docs/deferrals.md.
-        var sink = new RecordingFragmentSink();
-        using var shaper = new SyntheticShaperResolver();
-
-        var root = Box.CreateRoot(MakeStyle());
-        var flex = BuildFlexContainer();
-        flex.Style.Set(PropertyId.FlexDirection, ComputedSlot.FromKeyword(2)); // column
-        flex.Style.Set(PropertyId.AlignItems, ComputedSlot.FromKeyword(6)); // center
-        SetLengthPx(flex.Style, PropertyId.Height, 300);
-        SetLengthPx(flex.Style, PropertyId.Width, 200);
-
-        var itemStyle = MakeStyle();
-        SetLengthPx(itemStyle, PropertyId.Width, 100);
-        SetLengthPx(itemStyle, PropertyId.Height, 50);
-        var item = Box.ForElement(BoxKind.BlockContainer, itemStyle, MakeElement());
-        flex.AppendChild(item);
-        root.AppendChild(flex);
-
-        using var layouter = new BlockLayouter(
-            rootBox: root, sink: sink,
-            incomingContinuation: null, diagnostics: null,
-            shaperResolver: shaper);
-        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
-        var layoutCtx = new LayoutContext(ctx);
-        using var resolver = new BreakResolver();
-        layouter.AttemptLayout(ctx, ref layoutCtx, resolver,
-            LayoutAttemptStrategy.LastResort);
-
-        BoxFragment? itemFragment = null;
-        foreach (var f in sink.Fragments)
-        {
-            if (f.Box == item) { itemFragment = f; break; }
-        }
-        Assert.NotNull(itemFragment);
-        // Known-gap — item centered against the 600px page, NOT
-        // against the declared 200px container width. Spec-correct
-        // is 50; current is 250.
-        Assert.Equal(250.0, itemFragment!.Value.InlineOffset, precision: 3);
     }
 
     [Fact]
@@ -3651,12 +3590,11 @@ public sealed class FlexLayouterTests
     }
 
     [Fact]
-    public void L6_flex_wrap_nowrap_default_behavior_unchanged()
+    public void L6_flex_wrap_nowrap_keeps_a_single_line_with_shrink()
     {
-        // Sanity: with default flex-wrap (nowrap), the layout is the
-        // L1-L5 single-line algorithm. 3 items of 100 in 250px container
-        // — total 300 > 250, but no wrap. Items pack at inline 0, 100,
-        // 200; item 2 overflows past 250 but does not wrap.
+        // With default flex-wrap (nowrap), the layout is the L1-L5 single-line
+        // algorithm — it never wraps. The container honors its declared 250px
+        // width, so the 3 × 100px items (300 > 250) flex-shrink:1 to fit.
         var sink = new RecordingFragmentSink();
         using var shaper = new SyntheticShaperResolver();
 
@@ -3697,12 +3635,12 @@ public sealed class FlexLayouterTests
         }
 
         Assert.Equal(3, fragments.Count);
-        // All items on the same line (BlockOffset 0); InlineOffset
-        // walks 0/100/200. Item 2 ends at 300 (overflows 250) — that's
-        // the spec'd nowrap behavior (CSS Flexbox L1 §6 + §9.4).
+        // All items on the same line (BlockOffset 0) — nowrap never wraps. The
+        // items shrink to 250/3 ≈ 83.333 each (flex-shrink:1) and pack at
+        // 0 / 83.333 / 166.667, no longer overflowing at 0/100/200.
         Assert.Equal(0.0, fragments[0].InlineOffset, precision: 3);
-        Assert.Equal(100.0, fragments[1].InlineOffset, precision: 3);
-        Assert.Equal(200.0, fragments[2].InlineOffset, precision: 3);
+        Assert.Equal(83.333, fragments[1].InlineOffset, precision: 3);
+        Assert.Equal(166.667, fragments[2].InlineOffset, precision: 3);
         Assert.Equal(0.0, fragments[0].BlockOffset, precision: 3);
         Assert.Equal(0.0, fragments[1].BlockOffset, precision: 3);
         Assert.Equal(0.0, fragments[2].BlockOffset, precision: 3);

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
@@ -171,6 +171,141 @@ public sealed class FlexLayouterTests
     }
 
     [Fact]
+    public void Flex_gap_grow_sizes_items_so_gutter_does_not_overflow()
+    {
+        // PR #204 review [P1] — two `Width: 0; flex-grow: 1` items in a 300px row with
+        // column-gap:20 → the gutter consumes free space first (300-20=280), so each
+        // grows to 140 (not 150). Emitted: item0 at 0, item1 at 140+20=160; the row
+        // fills exactly 140 + 20 + 140 = 300 with no overflow.
+        var sink = new RecordingFragmentSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var flex = BuildFlexContainer();
+        SetLengthPx(flex.Style, PropertyId.Width, 300);
+        SetLengthPx(flex.Style, PropertyId.Height, 100);
+        SetLengthPx(flex.Style, PropertyId.ColumnGap, 20);
+
+        var items = new Box[2];
+        for (var i = 0; i < items.Length; i++)
+        {
+            var style = MakeStyle();
+            SetLengthPx(style, PropertyId.Width, 0);
+            SetLengthPx(style, PropertyId.Height, 50);
+            style.Set(PropertyId.FlexGrow, ComputedSlot.FromNumber(1.0));
+            items[i] = Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
+            flex.AppendChild(items[i]);
+        }
+        root.AppendChild(flex);
+
+        using var layouter = new BlockLayouter(
+            rootBox: root, sink: sink, incomingContinuation: null,
+            diagnostics: null, shaperResolver: shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 300, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+
+        var itemFragments = new List<BoxFragment>();
+        foreach (var f in sink.Fragments)
+            for (var i = 0; i < items.Length; i++)
+                if (f.Box == items[i]) { itemFragments.Add(f); break; }
+
+        Assert.Equal(2, itemFragments.Count);
+        Assert.Equal(140.0, itemFragments[0].InlineSize, precision: 3);
+        Assert.Equal(140.0, itemFragments[1].InlineSize, precision: 3);
+        Assert.Equal(0.0, itemFragments[0].InlineOffset, precision: 3);
+        Assert.Equal(160.0, itemFragments[1].InlineOffset, precision: 3);
+    }
+
+    [Fact]
+    public void Flex_gap_shrink_sizes_items_so_gutter_does_not_overflow()
+    {
+        // PR #204 review [P1] — two `Width: 200; flex-shrink: 1` items in a 300px row
+        // with column-gap:20 → deficit = (200+200) - (300-20) = 120, split evenly so
+        // each shrinks to 140. Emitted: item0 at 0, item1 at 140+20=160; the row fills
+        // exactly 140 + 20 + 140 = 300 instead of overflowing to 320.
+        var sink = new RecordingFragmentSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var flex = BuildFlexContainer();
+        SetLengthPx(flex.Style, PropertyId.Width, 300);
+        SetLengthPx(flex.Style, PropertyId.Height, 100);
+        SetLengthPx(flex.Style, PropertyId.ColumnGap, 20);
+
+        var items = new Box[2];
+        for (var i = 0; i < items.Length; i++)
+        {
+            var style = MakeStyle();
+            SetLengthPx(style, PropertyId.Width, 200);
+            SetLengthPx(style, PropertyId.Height, 50);
+            style.Set(PropertyId.FlexShrink, ComputedSlot.FromNumber(1.0));
+            items[i] = Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
+            flex.AppendChild(items[i]);
+        }
+        root.AppendChild(flex);
+
+        using var layouter = new BlockLayouter(
+            rootBox: root, sink: sink, incomingContinuation: null,
+            diagnostics: null, shaperResolver: shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 300, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+
+        var itemFragments = new List<BoxFragment>();
+        foreach (var f in sink.Fragments)
+            for (var i = 0; i < items.Length; i++)
+                if (f.Box == items[i]) { itemFragments.Add(f); break; }
+
+        Assert.Equal(2, itemFragments.Count);
+        Assert.Equal(140.0, itemFragments[0].InlineSize, precision: 3);
+        Assert.Equal(140.0, itemFragments[1].InlineSize, precision: 3);
+        Assert.Equal(0.0, itemFragments[0].InlineOffset, precision: 3);
+        Assert.Equal(160.0, itemFragments[1].InlineOffset, precision: 3);
+    }
+
+    [Fact]
+    public void Flex_container_explicit_width_auto_margins_center_it()
+    {
+        // PR #204 review [P2] — a flex container is a block-level box in normal flow, so
+        // `display:flex; width:200px; margin:0 auto` centers it: offset (600-200)/2 = 200.
+        // The container-width cycle made the 200px width honored; this makes the auto
+        // margins distribute the leftover too, matching a plain block / centered image.
+        var sink = new RecordingFragmentSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var flex = BuildFlexContainer();
+        SetLengthPx(flex.Style, PropertyId.Width, 200);
+        SetLengthPx(flex.Style, PropertyId.Height, 40);
+        flex.Style.Set(PropertyId.MarginLeft, ComputedSlot.FromKeyword(0));  // authored `auto`
+        flex.Style.Set(PropertyId.MarginRight, ComputedSlot.FromKeyword(0));
+
+        var itemStyle = MakeStyle();
+        SetLengthPx(itemStyle, PropertyId.Width, 50);
+        SetLengthPx(itemStyle, PropertyId.Height, 40);
+        flex.AppendChild(Box.ForElement(BoxKind.BlockContainer, itemStyle, MakeElement()));
+        root.AppendChild(flex);
+
+        using var layouter = new BlockLayouter(
+            rootBox: root, sink: sink, incomingContinuation: null,
+            diagnostics: null, shaperResolver: shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+
+        BoxFragment? wrapper = null;
+        foreach (var f in sink.Fragments)
+            if (f.Box == flex) { wrapper = f; break; }
+        Assert.NotNull(wrapper);
+        Assert.Equal(200.0, wrapper!.Value.InlineSize, precision: 3);
+        Assert.Equal(200.0, wrapper.Value.InlineOffset, precision: 3);
+    }
+
+    [Fact]
     public void Flex_container_single_item_emits_at_origin()
     {
         // A single flex item should emit at the container's content-
@@ -5104,7 +5239,8 @@ public sealed class FlexLayouterTests
             Box.ForElement(BoxKind.BlockContainer, growing, MakeElement()),
         };
         var resolvedAB = FlexLayouter.ResolveFlexLineMainSizes(
-            itemsAB, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, default);
+            itemsAB, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            mainGap: 0, cancellationToken: default);
         Assert.Equal(100.0, resolvedAB[0], precision: 3);
         Assert.Equal(200.0, resolvedAB[1], precision: 3);
 
@@ -5118,8 +5254,59 @@ public sealed class FlexLayouterTests
             thirds[i] = Box.ForElement(BoxKind.BlockContainer, s, MakeElement());
         }
         var resolvedThirds = FlexLayouter.ResolveFlexLineMainSizes(
-            thirds, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, default);
+            thirds, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            mainGap: 0, cancellationToken: default);
         Assert.All(resolvedThirds, w => Assert.Equal(100.0, w, precision: 3));
+    }
+
+    [Fact]
+    public void ResolveFlexLineMainSizes_subtracts_gap_from_grow_and_shrink_free_space()
+    {
+        // PR #204 review [P1] — the N-1 main-axis gutters consume free space BEFORE
+        // flex grow/shrink distributes the remainder (CSS Box Alignment L3 §8), so the
+        // helper resolves item main sizes at the SAME values the emission loop places
+        // (which inserts the gutter). gap + grow/shrink no longer overflows.
+
+        // (a) grow — two `Width: 0; flex-grow: 1` items in 300 with a 20px gutter:
+        //     free space = 300 - 20 = 280 → 140 each (NOT 150, which would overflow
+        //     by the 20px gutter once the gutter is emitted between them).
+        var growA = MakeStyle();
+        SetLengthPx(growA, PropertyId.Width, 0);
+        growA.Set(PropertyId.FlexGrow, ComputedSlot.FromNumber(1.0));
+        var growB = MakeStyle();
+        SetLengthPx(growB, PropertyId.Width, 0);
+        growB.Set(PropertyId.FlexGrow, ComputedSlot.FromNumber(1.0));
+        var growItems = new[]
+        {
+            Box.ForElement(BoxKind.BlockContainer, growA, MakeElement()),
+            Box.ForElement(BoxKind.BlockContainer, growB, MakeElement()),
+        };
+        var grown = FlexLayouter.ResolveFlexLineMainSizes(
+            growItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            mainGap: 20, cancellationToken: default);
+        Assert.Equal(140.0, grown[0], precision: 3);
+        Assert.Equal(140.0, grown[1], precision: 3);
+
+        // (b) shrink — two `Width: 200; flex-shrink: 1` items in 300 with a 20px
+        //     gutter: deficit = (200+200) - (300-20) = 120, split evenly → 140 each,
+        //     so 140 + 20 + 140 = 300 fits exactly (without the gutter term each would
+        //     shrink only to 150 and overflow by the 20px gutter).
+        var shrinkA = MakeStyle();
+        SetLengthPx(shrinkA, PropertyId.Width, 200);
+        shrinkA.Set(PropertyId.FlexShrink, ComputedSlot.FromNumber(1.0));
+        var shrinkB = MakeStyle();
+        SetLengthPx(shrinkB, PropertyId.Width, 200);
+        shrinkB.Set(PropertyId.FlexShrink, ComputedSlot.FromNumber(1.0));
+        var shrinkItems = new[]
+        {
+            Box.ForElement(BoxKind.BlockContainer, shrinkA, MakeElement()),
+            Box.ForElement(BoxKind.BlockContainer, shrinkB, MakeElement()),
+        };
+        var shrunk = FlexLayouter.ResolveFlexLineMainSizes(
+            shrinkItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            mainGap: 20, cancellationToken: default);
+        Assert.Equal(140.0, shrunk[0], precision: 3);
+        Assert.Equal(140.0, shrunk[1], precision: 3);
     }
 
     [Fact]
@@ -8746,6 +8933,63 @@ public sealed class FlexLayouterTests
         {
             if (f.Box.Kind == BoxKind.BlockContainer) pageOneItems++;
         }
+        Assert.Equal(2, pageOneItems);
+    }
+
+    [Fact]
+    public void Row_wrap_pagination_accounts_for_row_gap_when_slicing_lines()
+    {
+        // PR #204 review [P1] — the line-slicing fit loop must count the row-gap that
+        // emission inserts between wrapped lines, or it approves more lines than fit.
+        // 4 items 100×50 wrap to 2 lines (cross 50 each) with row-gap:30. Page budget
+        // 120: WITHOUT counting the gap, line0(0..50) + line1(50..100) "fits" (100 ≤
+        // 120), yet emission advances by 50+30 = 80 → line1 lands at 80..130, 10px
+        // past the page. Counting the gap, line1's fit check is 50 + 30 + 50 = 130 >
+        // 120, so it correctly defers to page 2.
+        var sink = new RecordingFragmentSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var flex = BuildFlexContainer();
+        flex.Style.Set(PropertyId.FlexWrap, ComputedSlot.FromKeyword(1));
+        SetLengthPx(flex.Style, PropertyId.Width, 250);
+        SetLengthPx(flex.Style, PropertyId.Height, 100);
+        SetLengthPx(flex.Style, PropertyId.RowGap, 30);
+
+        for (var i = 0; i < 4; i++)
+        {
+            var style = MakeStyle();
+            SetLengthPx(style, PropertyId.Width, 100);
+            SetLengthPx(style, PropertyId.Height, 50);
+            style.Set(PropertyId.FlexShrink, ComputedSlot.FromNumber(0.0));
+            var item = Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
+            flex.AppendChild(item);
+        }
+
+        using var layouter = new NetPdf.Layout.Layouters.FlexLayouter(
+            rootBox: flex, sink: sink, incomingContinuation: null,
+            diagnostics: null, shaperResolver: shaper);
+        layouter.ConfigureEmission(
+            contentInlineOffset: 0,
+            contentBlockOffset: 0,
+            contentInlineSize: 250,
+            contentBlockSize: 120, // 2 lines fit by cross alone (100) but NOT with the 30px gap (130)
+            allowPagination: true);
+
+        var ctx = new FragmentainerContext(contentInlineSize: 250, blockSize: 200);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+        var result = layouter.AttemptLayout(ctx, ref layoutCtx, resolver,
+            LayoutAttemptStrategy.LastResort);
+
+        // The second line defers: PageComplete with FlexContinuation{LineIndex=1}.
+        Assert.Equal(LayoutAttemptOutcome.PageComplete, result.Outcome);
+        var flexCont = Assert.IsType<FlexContinuation>(result.Continuation);
+        Assert.Equal(1, flexCont.LineIndex);
+
+        // First page emitted only the first line (2 items).
+        var pageOneItems = 0;
+        foreach (var f in sink.Fragments)
+            if (f.Box.Kind == BoxKind.BlockContainer) pageOneItems++;
         Assert.Equal(2, pageOneItems);
     }
 

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
@@ -127,6 +127,50 @@ public sealed class FlexLayouterTests
     }
 
     [Fact]
+    public void Column_gap_inserts_a_main_axis_gutter_between_row_items()
+    {
+        // §8 — column-gap is the row-direction main-axis gutter. 3 items 100/50/80
+        // wide with column-gap:20 land at 0, 120 (100+20), 190 (100+20+50+20).
+        var sink = new RecordingFragmentSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var flex = BuildFlexContainer();
+        SetLengthPx(flex.Style, PropertyId.Height, 100);
+        SetLengthPx(flex.Style, PropertyId.ColumnGap, 20);
+
+        var widths = new[] { 100.0, 50.0, 80.0 };
+        var items = new Box[widths.Length];
+        for (var i = 0; i < widths.Length; i++)
+        {
+            var style = MakeStyle();
+            SetLengthPx(style, PropertyId.Width, widths[i]);
+            SetLengthPx(style, PropertyId.Height, 50);
+            items[i] = Box.ForElement(BoxKind.BlockContainer, style, MakeElement());
+            flex.AppendChild(items[i]);
+        }
+        root.AppendChild(flex);
+
+        using var layouter = new BlockLayouter(
+            rootBox: root, sink: sink, incomingContinuation: null,
+            diagnostics: null, shaperResolver: shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 400, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+
+        var itemFragments = new List<BoxFragment>();
+        foreach (var f in sink.Fragments)
+            for (var i = 0; i < items.Length; i++)
+                if (f.Box == items[i]) { itemFragments.Add(f); break; }
+
+        Assert.Equal(3, itemFragments.Count);
+        Assert.Equal(0.0, itemFragments[0].InlineOffset, precision: 3);
+        Assert.Equal(120.0, itemFragments[1].InlineOffset, precision: 3);
+        Assert.Equal(190.0, itemFragments[2].InlineOffset, precision: 3);
+    }
+
+    [Fact]
     public void Flex_container_single_item_emits_at_origin()
     {
         // A single flex item should emit at the container's content-

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
@@ -3498,6 +3498,42 @@ public sealed class GridLayouterTests
     }
 
     [Fact]
+    public void Grid_container_explicit_width_auto_margins_center_it()
+    {
+        // PR #204 review [P2] — a grid container is a block-level box in normal flow, so
+        // `display:grid; width:200px; margin:0 auto` centers it: offset (600-200)/2 = 200.
+        // Mirrors the flex case; both kinds now participate in §10.3.3 auto-margin
+        // distribution (BlockLayouter.ResolveAutoInlineMargins) like a plain block.
+        var sink = new RecordingFragmentSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(rowsPx: new[] { 40.0 }, colsPx: new[] { 100.0, 100.0 });
+        SetExplicitWidth(grid, 200);
+        SetExplicitHeight(grid, 40);
+        grid.Style.Set(PropertyId.MarginLeft, ComputedSlot.FromKeyword(0));   // authored `auto`
+        grid.Style.Set(PropertyId.MarginRight, ComputedSlot.FromKeyword(0));
+        grid.AppendChild(BuildItemWithExplicitPlacement(row: 1, col: 1));
+
+        var root = Box.CreateRoot(MakeStyle());
+        root.AppendChild(grid);
+
+        using var layouter = new BlockLayouter(
+            rootBox: root, sink: sink, incomingContinuation: null,
+            diagnostics: null, shaperResolver: shaper);
+        var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+        var layoutCtx = new LayoutContext(ctx);
+        using var resolver = new BreakResolver();
+        layouter.AttemptLayout(ctx, ref layoutCtx, resolver, LayoutAttemptStrategy.LastResort);
+
+        BoxFragment? wrapper = null;
+        foreach (var f in sink.Fragments)
+            if (f.Box == grid) { wrapper = f; break; }
+        Assert.NotNull(wrapper);
+        Assert.Equal(200.0, wrapper!.Value.InlineSize, precision: 3);
+        Assert.Equal(200.0, wrapper.Value.InlineOffset, precision: 3);
+    }
+
+    [Fact]
     public void Cycle5b_F4_resume_with_different_inline_size_preserves_RowIndex_no_duplication()
     {
         // Per PR-#97 review F4 — pre-fix: when cache rejected for

--- a/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/GridLayouterTests.cs
@@ -95,6 +95,36 @@ public sealed class GridLayouterTests
     }
 
     [Fact]
+    public void Column_and_row_gap_offset_the_second_track_per_cell()
+    {
+        // §10.1 — column-gap:20 + row-gap:30 on the 2×2 grid above shift the
+        // second column to X=70 (50+20) and the second row to Y=130 (100+30).
+        var sink = new RecordingFragmentSink();
+        var diag = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var grid = BuildGridContainer(rowsPx: new[] { 100.0, 200.0 }, colsPx: new[] { 50.0, 150.0 });
+        grid.Style.Set(PropertyId.ColumnGap, ComputedSlot.FromLengthPx(20));
+        grid.Style.Set(PropertyId.RowGap, ComputedSlot.FromLengthPx(30));
+        var item11 = BuildItemWithExplicitPlacement(row: 1, col: 1);
+        var item12 = BuildItemWithExplicitPlacement(row: 1, col: 2);
+        var item21 = BuildItemWithExplicitPlacement(row: 2, col: 1);
+        var item22 = BuildItemWithExplicitPlacement(row: 2, col: 2);
+        grid.AppendChild(item11);
+        grid.AppendChild(item12);
+        grid.AppendChild(item21);
+        grid.AppendChild(item22);
+
+        RunGridLayouter(grid, sink, diag, shaper);
+
+        Assert.Equal(4, sink.Fragments.Count);
+        AssertFragmentEquals(sink, item11, inlineOffset: 0, blockOffset: 0, inlineSize: 50, blockSize: 100);
+        AssertFragmentEquals(sink, item12, inlineOffset: 70, blockOffset: 0, inlineSize: 150, blockSize: 100);
+        AssertFragmentEquals(sink, item21, inlineOffset: 0, blockOffset: 130, inlineSize: 50, blockSize: 200);
+        AssertFragmentEquals(sink, item22, inlineOffset: 70, blockOffset: 130, inlineSize: 150, blockSize: 200);
+    }
+
+    [Fact]
     public void Negative_minus_two_selects_last_explicit_track_per_spec()
     {
         // Per §8.3 + PR-#92 review F3 — negative line numbers count

--- a/tests/NetPdf.W3cConformance/FlexboxCases.cs
+++ b/tests/NetPdf.W3cConformance/FlexboxCases.cs
@@ -165,17 +165,31 @@ internal static class FlexboxCases
             }),
 
         // §9.2 — an explicit `width` on the flex container itself sizes its main
-        // axis. NetPdf's flex/grid containers ignore their own `width` and fill
-        // the parent content width instead (the rest of this suite works AROUND
-        // that gap by nesting in a sized parent). This case exercises the gap
-        // HEAD-ON so the published Flexbox rate isn't inflated by avoiding it
-        // (PR 1 review [P1]): a 200px container with justify-content:flex-end
-        // must place the 100px item at X=100; the engine fills the 600px body
-        // and places it at X=500. EXPECTED is spec.
+        // axis: a 200px container with justify-content:flex-end places the 100px
+        // item at X=100 (200 - 100), not X=500 (against the 600px page).
         new ConformanceCase("flex-explicit-container-width", "CSS Flexbox L1 §9.2",
             Doc("<div style='display:flex;width:200px;justify-content:flex-end'>"
                 + Item("a", 100, 50) + "</div>"),
-            new[] { new BoxExpectation("a", X: 100) }, // 200 - 100
-            KnownGap: "flex container ignores its own explicit width, fills the parent"),
+            new[] { new BoxExpectation("a", X: 100) }), // 200 - 100
+
+        // §9.2 — justify-content:center against the DECLARED width (300px), so the
+        // 100px item centers at X=100, not against the 600px page.
+        new ConformanceCase("flex-explicit-width-center", "CSS Flexbox L1 §9.2",
+            Doc("<div style='display:flex;width:300px;justify-content:center'>"
+                + Item("a", 100, 50) + "</div>"),
+            new[] { new BoxExpectation("a", X: 100) }), // (300-100)/2
+
+        // §9.2 — an explicit width narrower than the items triggers flex-shrink
+        // against the DECLARED width: 3×100px items in a 240px container shrink to
+        // 80 each (240/3), packing at 0 / 80 / 160.
+        new ConformanceCase("flex-explicit-width-shrinks-items", "CSS Flexbox L1 §9.2/§9.7",
+            Doc("<div style='display:flex;width:240px'>"
+                + Item("a", 100, 50) + Item("b", 100, 50) + Item("c", 100, 50) + "</div>"),
+            new[]
+            {
+                new BoxExpectation("a", X: 0, Width: 80),
+                new BoxExpectation("b", X: 80, Width: 80),
+                new BoxExpectation("c", X: 160, Width: 80),
+            }),
     };
 }

--- a/tests/NetPdf.W3cConformance/FlexboxCases.cs
+++ b/tests/NetPdf.W3cConformance/FlexboxCases.cs
@@ -112,12 +112,57 @@ internal static class FlexboxCases
                 new BoxExpectation("c", X: 0, Y: 50), // wraps under the first line
             }),
 
-        // §8.1 — the `gap` property spaces flex items along the main axis.
-        // (NetPdf does not yet apply flex/grid gap — honest gap; EXPECTED is spec.)
+        // §8.1 — the `gap` shorthand spaces flex items along the main axis.
         new ConformanceCase("flex-gap-main-axis", "CSS Box Alignment L3 §8 / Flexbox L1",
             Doc("<div style='display:flex;gap:20px'>" + Item("a", 100, 50) + Item("b", 100, 50) + "</div>"),
-            new[] { new BoxExpectation("b", X: 120) }, // 100 + 20 gap
-            KnownGap: "flex `gap` gutter isn't inserted between items"),
+            new[]
+            {
+                new BoxExpectation("a", X: 0),
+                new BoxExpectation("b", X: 120), // 100 + 20 gap
+            }),
+
+        // §8 — `column-gap` is the main-axis gutter for row direction (3 items).
+        new ConformanceCase("flex-column-gap-three-items", "CSS Box Alignment L3 §8",
+            Doc("<div style='display:flex;column-gap:10px'>"
+                + Item("a", 80, 50) + Item("b", 80, 50) + Item("c", 80, 50) + "</div>"),
+            new[]
+            {
+                new BoxExpectation("b", X: 90),  // 80 + 10
+                new BoxExpectation("c", X: 180), // 80 + 10 + 80 + 10
+            }),
+
+        // §8 — the main-axis gaps consume free space BEFORE justify-content
+        // distributes the remainder: in a 400px parent, gap:20 then flex-end packs
+        // both items (200) + their gap (20) against the end edge.
+        new ConformanceCase("flex-gap-with-justify-end", "CSS Box Alignment L3 §8",
+            Doc(400, "<div style='display:flex;gap:20px;justify-content:flex-end'>"
+                + Item("a", 100, 50) + Item("b", 100, 50) + "</div>"),
+            new[]
+            {
+                new BoxExpectation("a", X: 180), // freeSpace = 400 - 200 - 20 = 180
+                new BoxExpectation("b", X: 300), // 180 + 100 + 20 gap
+            }),
+
+        // §8 — `row-gap` is the main-axis gutter for COLUMN direction.
+        new ConformanceCase("flex-row-gap-column-direction", "CSS Box Alignment L3 §8",
+            Doc("<div style='display:flex;flex-direction:column;row-gap:15px'>"
+                + Item("a", 100, 40) + Item("b", 100, 60) + "</div>"),
+            new[]
+            {
+                new BoxExpectation("a", Y: 0),
+                new BoxExpectation("b", Y: 55), // 40 + 15 gap
+            }),
+
+        // §8 — cross-axis gutter (`row-gap`) between WRAPPED lines (row direction).
+        new ConformanceCase("flex-row-gap-wrapped-lines", "CSS Box Alignment L3 §8",
+            Doc(250, "<div style='display:flex;flex-wrap:wrap;row-gap:30px'>"
+                + Item("a", 100, 50) + Item("b", 100, 50) + Item("c", 100, 50) + "</div>"),
+            new[]
+            {
+                new BoxExpectation("a", X: 0, Y: 0),
+                new BoxExpectation("b", X: 100, Y: 0),
+                new BoxExpectation("c", X: 0, Y: 80), // wraps; 50 line + 30 row-gap
+            }),
 
         // §9.2 — an explicit `width` on the flex container itself sizes its main
         // axis. NetPdf's flex/grid containers ignore their own `width` and fill

--- a/tests/NetPdf.W3cConformance/GridCases.cs
+++ b/tests/NetPdf.W3cConformance/GridCases.cs
@@ -85,8 +85,7 @@ internal static class GridCases
             {
                 new BoxExpectation("a", X: 0),
                 new BoxExpectation("b", X: 120), // 100 + 20 gap
-            },
-            KnownGap: "column-gap gutter isn't inserted between grid tracks"),
+            }),
 
         // §10.1 — row-gap inserts a gutter between row tracks.
         new ConformanceCase("grid-row-gap", "CSS Grid L1 §10.1",
@@ -97,8 +96,35 @@ internal static class GridCases
             {
                 new BoxExpectation("a", Y: 0),
                 new BoxExpectation("b", Y: 80), // 50 + 30 gap
+            }),
+
+        // §10.1 — the `gap` shorthand sets both row-gap + column-gap; three fixed
+        // columns gutter-spaced.
+        new ConformanceCase("grid-gap-shorthand-columns", "CSS Grid L1 §10.1",
+            Doc("<div style='display:grid;grid-template-columns:60px 60px 60px;"
+                + "gap:15px;grid-auto-rows:40px'>"
+                + "<div id='a'></div><div id='b'></div><div id='c'></div></div>"),
+            new[]
+            {
+                new BoxExpectation("a", X: 0),
+                new BoxExpectation("b", X: 75),  // 60 + 15
+                new BoxExpectation("c", X: 150), // 60 + 15 + 60 + 15
+            }),
+
+        // §10.1 + §7.2.3 — column-gap reduces the space `fr` tracks distribute:
+        // 2 fr in a 400px parent with column-gap:20 → each fr = (400-20)/2 = 190.
+        // (NetPdf positions the gutters but doesn't yet subtract them from the fr
+        // free space — `grid-gap-fr-track-sizing` deferral; EXPECTED is spec.)
+        new ConformanceCase("grid-fr-columns-with-gap", "CSS Grid L1 §7.2.3/§10.1",
+            Doc(400, "<div style='display:grid;grid-template-columns:1fr 1fr;"
+                + "column-gap:20px;grid-auto-rows:40px'>"
+                + "<div id='a'></div><div id='b'></div></div>"),
+            new[]
+            {
+                new BoxExpectation("a", X: 0, Width: 190),
+                new BoxExpectation("b", X: 210, Width: 190), // 190 + 20 gap
             },
-            KnownGap: "row-gap gutter isn't inserted between grid tracks"),
+            KnownGap: "fr tracks don't subtract gaps from their distributed free space"),
 
         // §8.3 — line-based placement (grid-column / grid-row) drops an item
         // into a specific cell.

--- a/tests/NetPdf.W3cConformance/GridCases.cs
+++ b/tests/NetPdf.W3cConformance/GridCases.cs
@@ -150,5 +150,18 @@ internal static class GridCases
                 new BoxExpectation("b", X: 100),
                 new BoxExpectation("c", X: 200),
             }),
+
+        // §7.2.3 — an explicit `width` on the GRID container sizes the fr tracks:
+        // a 200px grid with 1fr 1fr splits into two 100px columns (against the
+        // declared 200, not the 600px page). No gap → unaffected by the fr-gap
+        // deferral.
+        new ConformanceCase("grid-explicit-container-width", "CSS Grid L1 §7.2.3",
+            Doc("<div style='display:grid;width:200px;grid-template-columns:1fr 1fr;"
+                + "grid-auto-rows:40px'><div id='a'></div><div id='b'></div></div>"),
+            new[]
+            {
+                new BoxExpectation("a", X: 0, Width: 100),
+                new BoxExpectation("b", X: 100, Width: 100),
+            }),
     };
 }

--- a/tests/NetPdf.W3cConformance/GridCases.cs
+++ b/tests/NetPdf.W3cConformance/GridCases.cs
@@ -163,5 +163,28 @@ internal static class GridCases
                 new BoxExpectation("a", X: 0, Width: 100),
                 new BoxExpectation("b", X: 100, Width: 100),
             }),
+
+        // §8.3 + §10.1 — a column-spanning item's extent includes the gap gutter
+        // BETWEEN the spanned tracks (PR #204 Copilot review): span 2 of two 100px
+        // columns with column-gap:20 → 100 + 20 + 100 = 220.
+        new ConformanceCase("grid-column-span-with-gap", "CSS Grid L1 §8.3/§10.1",
+            Doc("<div style='display:grid;grid-template-columns:100px 100px;"
+                + "column-gap:20px;grid-auto-rows:40px'>"
+                + "<div id='a' style='grid-column:1 / span 2'></div></div>"),
+            new[] { new BoxExpectation("a", X: 0, Width: 220) }),
+
+        // §10.1 — an AUTO-height grid reserves the row-gap gutters in its block
+        // extent, so a following sibling clears the full grid height (PR #204
+        // Copilot review): 2 × 50px rows + row-gap:30 → grid 130 tall, sibling at
+        // Y=130.
+        new ConformanceCase("grid-row-gap-auto-height-sibling", "CSS Grid L1 §10.1",
+            Doc("<div id='g' style='display:grid;grid-template-columns:100px;"
+                + "grid-template-rows:50px 50px;row-gap:30px'>"
+                + "<div></div><div></div></div><div id='s' style='height:20px'></div>"),
+            new[]
+            {
+                new BoxExpectation("g", Height: 130), // 50 + 30 + 50
+                new BoxExpectation("s", Y: 130),
+            }),
     };
 }

--- a/tests/NetPdf.W3cConformance/README.md
+++ b/tests/NetPdf.W3cConformance/README.md
@@ -18,11 +18,12 @@ a **pass-rate**.
 | CSS 2.2 layout | **93.3%** (28/30) | ≥ 90% | ✅ met |
 | Fragmentation | **90.0%** (9/10) | ≥ 80% | ✅ met |
 | Flexbox L1 | **100%** (18/18) | ≥ 85% | ✅ met |
-| Grid L1 | **92.3%** (12/13) | ≥ 70% | ✅ met |
+| Grid L1 | **93.3%** (14/15) | ≥ 70% | ✅ met |
 
 **All four conformance exit criteria are now met.** The flex/grid gap PR took
 Flexbox to 100% (gap gutters + the flex container honoring its own explicit
-`width`) and Grid to 92.3% (gap gutters; one residual: `fr` tracks + gap). CSS 2.2
+`width`) and Grid to 93.3% (gap gutters incl. spanned-item + auto-height extent;
+one residual: `fr` tracks + gap). CSS 2.2
 rose to 93.3% earlier from the box-model gap fixes (`box-sizing: border-box` on the
 block axis + the measure pass + floats; min/max-width/height clamping on explicit
 AND auto/fill sizes). The remaining CSS 2.2 gaps are auto-height shrink-to-fit and

--- a/tests/NetPdf.W3cConformance/README.md
+++ b/tests/NetPdf.W3cConformance/README.md
@@ -17,14 +17,15 @@ a **pass-rate**.
 |---|---|---|---|
 | CSS 2.2 layout | **93.3%** (28/30) | ≥ 90% | ✅ met |
 | Fragmentation | **90.0%** (9/10) | ≥ 80% | ✅ met |
-| Flexbox L1 | **83.3%** (10/12) | ≥ 85% | ⚠️ below — documented gaps |
-| Grid L1 | **80.0%** (8/10) | ≥ 70% | ✅ met |
+| Flexbox L1 | **100%** (18/18) | ≥ 85% | ✅ met |
+| Grid L1 | **92.3%** (12/13) | ≥ 70% | ✅ met |
 
-Three of the four exit criteria are **met** (CSS 2.2, Fragmentation, Grid); only
-Flexbox is below its target with **documented gaps** (listed below). CSS 2.2 rose
-from 84.2% after the box-model gap fixes (`box-sizing: border-box` on the block
-axis + the measure pass + floats; min/max-width/height clamping on explicit AND
-auto/fill sizes). The two remaining CSS 2.2 gaps are auto-height shrink-to-fit and
+**All four conformance exit criteria are now met.** The flex/grid gap PR took
+Flexbox to 100% (gap gutters + the flex container honoring its own explicit
+`width`) and Grid to 92.3% (gap gutters; one residual: `fr` tracks + gap). CSS 2.2
+rose to 93.3% earlier from the box-model gap fixes (`box-sizing: border-box` on the
+block axis + the measure pass + floats; min/max-width/height clamping on explicit
+AND auto/fill sizes). The remaining CSS 2.2 gaps are auto-height shrink-to-fit and
 percentage min/max (see below).
 
 ## How the gate works — per-case baseline, not a pass-rate floor
@@ -84,17 +85,17 @@ metrics) so they're deterministic without a font dependency.
   [docs/deferrals.md](../../docs/deferrals.md).
 - **`break-before: page`** (Fragmentation §3.1) — forced-break metadata isn't
   propagated from the box yet.
-- **`gap` / `column-gap` / `row-gap`** on flex + grid containers — gutters aren't
-  inserted between tracks/items.
-- **explicit `width` on a flex/grid container** — the container ignores its own
-  `width` and fills the parent content width instead (the rest of the suite
-  works around this by nesting in a sized parent; `flex-explicit-container-width`
-  exercises it head-on so the Flexbox rate isn't inflated by avoiding it).
+- **grid `fr` tracks + gap** (Grid §7.2.3/§10.1) — gap gutters are positioned, but
+  the gaps aren't subtracted from the free space `fr` tracks distribute, so
+  `1fr 1fr; column-gap:20` over-sizes each fr — see `grid-gap-fr-track-sizing` in
+  [docs/deferrals.md](../../docs/deferrals.md).
 
-**Closed this PR:** `box-sizing: border-box` (block-axis emit + the subtree
-measure + floats, so emit and pagination agree) and `LengthPx` min/max-width/height
-clamping on explicit AND auto/fill sizes — their conformance cases moved from
-`KnownGap` to passing (CSS 2.2 84.2% → 93.3%).
+**Closed by the flex/grid gap PR:** flex + grid `gap` / `column-gap` / `row-gap`
+gutters (Flexbox → 100%, Grid fixed-track gaps → 100%) and an explicit `width` on
+a flex/grid container (alignment / shrink / wrap / track sizing now run against
+the declared width). **Closed earlier (box-model PR):** `box-sizing: border-box`
+(block-axis emit + subtree measure + floats) and `LengthPx` min/max-width/height
+clamping on explicit AND auto/fill sizes.
 
 These are tracked in [docs/deferrals.md](../../docs/deferrals.md) /
 [docs/compatibility-matrix.md](../../docs/compatibility-matrix.md).


### PR DESCRIPTION
Closes the remaining flex/grid conformance gaps. **All four conformance exit criteria are now met** — Flexbox 83.3% → **100%** (18/18), Grid 80% → **93.3%** (14/15); CSS 2.2 93.3% + Fragmentation 90% unchanged.

### Task 1 — flex `gap` / `column-gap` / `row-gap` gutters (c4f528a)
Flex containers insert gap gutters between items + wrapped lines (CSS Box Alignment L3 §8). Registered the missing `row-gap` longhand (AngleSharp already expands the `gap` shorthand); added `ReadFlexGridGapOrZero` (flex/grid `normal` → 0). Main-axis gutter consumes free space before justify-content distributes; cross-axis gutter between wrapped lines. Line packing made gap-aware **in lockstep** for emit + pre-measure (`Pack` + `SumCrossExtent`), per the PR #203 measure/emit lesson. All gap params default to 0 → byte-identical without a gap.

### Task 2 — grid `column-gap` / `row-gap` / `gap` gutters (19f4a22)
`GridSizing.ComputeTrackPositions` inserts a gutter between tracks. Fixed / auto / intrinsic track grids place correctly. Scoped: gaps are positioned but not subtracted from the free space `fr` tracks distribute — `1fr 1fr; column-gap:20` over-sizes each fr; documented as the `grid-gap-fr-track-sizing` deferral + a KnownGap conformance case (threading it through the grid track-sizing without disturbing percentage-track resolution is its own change).

### Task 3 — flex/grid containers honor their own explicit `width` (620832f)
Added `FlexContainer` + `GridContainer` to the `ResolveInFlowBorderBoxInlineSize` gate (the documented container-width deferral), so a `display:flex; width:200px` container's alignment / flex-shrink / flex-wrap / fr track sizing run against the declared width, not the page. **Blast radius contained** (criterion 4 was already met, so this was bonus): no real-document output changed, no snapshot/golden diffs; 3 flex tests that documented the old fill bug flipped to spec-correct (centering, nowrap-shrinks, narrow-flex-wraps). Also fixes the row-gap registration follow-ups the full-suite run surfaced (LengthResolver `normal`, property-coverage allowlist).

### Tests
- **Unit:** flex column-gap gutter, grid column+row gap per cell, the 3 flipped container-width pins (un-Skip'd / updated).
- **Conformance:** flex-gap-main-axis + grid-column-gap + grid-row-gap + flex-explicit-container-width flip `KnownGap`→passing; added 9 new gap / explicit-width cases; `grid-fr-columns-with-gap` is the new honest KnownGap.
- **Gates (all green):** 7156 unit / 3 skip · 30 LayoutSnapshots · 97 RealDocuments · PaginationGolden · RenderingCorpus · W3cConformance 4/4 (CSS 2.2 93.3% / Frag 90% / Flexbox 100% / Grid 93.3%) · `./scripts/aot-parity.sh` · 0-warning Release. LTR/in-flow byte-identical (no-gap / auto-width paths unchanged).

### Review round (P1/P2/P3 + Copilot) — 80fbede, ab64b52
- **[P1]** Flex `gap` now consumes grow/shrink free space (`ResolveFlexLineMainSizes` subtracts the gutter total; percentage flex-basis still resolves against the full container main size) — threaded through emission + both pre-measures; the column pre-measure adds its row-gap gutters to the natural main extent.
- **[P1]** Row-wrap pagination slice loop counts the cross-axis gutter between non-first lines, so it can't approve more lines than emission fits (the "first line always commits" rule preserved).
- **[P2]** Flex/grid containers participate in §10.3.3 auto-margin distribution (`display:flex; width:200px; margin:0 auto` centers), in lockstep with the explicit-width gate.
- **[P3]** Percentage gaps documented as the `gap-percentage-sizing` deferral (treated as a 0 gutter) — deferrals.md + parity test + compatibility-matrix.
- **[Copilot]** Negative `row-gap` now invalidates like `column-gap` (`PropertyId.RowGap` joins `NonNegativeProperties`). Grid conformance number reconciled with the README (93.3%, 14/15).
- New tests: gap+grow/shrink (helper + emission), row-gap pagination defer, flex+grid auto-margin centering, negative row-gap rejection. Full gate sweep green + AOT parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
