### PR TITLE
fix(paginate): offset-aware nested-table dry-run — stop clipping tables below the page top (Bug B)

### DIFF
--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -141,7 +141,7 @@ namespace NetPdf.Layout.Layouters;
 /// so containers with overflowing block-level descendants silently
 /// clipped past the fragmentainer boundary + subsequent siblings
 /// visually overlapped the overflow. Cycle 2c adds
-/// <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double)"/> — a pre-measure
+/// <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double, double)"/> — a pre-measure
 /// pass that returns the maximum block-axis extent reached by any
 /// descendant. The break-fit chunk size + cursor advance both use
 /// this measured extent (max of own border-box + descendant bottoms),
@@ -2304,7 +2304,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // inside `EmitBlockSubtreeRecursive`. Deferred to cycle
             // 2d.
             var subtreeBlockExtent = MeasureSubtreeVisualBlockExtent(
-                child, cancellationToken, parentContentBlockSize: fragmentainer.BlockSize);
+                child, cancellationToken, parentContentBlockSize: fragmentainer.BlockSize,
+                // This child's block-start offset on the current page — threaded so a table nested in its
+                // subtree (below preceding content / wrapper padding) reserves the correct remaining page
+                // space in its dry-run, instead of over-committing and tripping a false forced-overflow
+                // that clips the table (offset-table clip fix).
+                blockOffsetOnPage: fragmentainer.UsedBlockSize + topShift);
             // Per Phase 3 Task 13 cycle 1 hardening (Finding 2) — for
             // Table / InlineTable wrappers in the OUTER dispatch path,
             // the subtree extent must reflect the SINGLE-PAGE-COMMITTED
@@ -2576,6 +2581,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 // of cumulative cross-page extent.
                 var nothingEmittedThisAttempt = emittedThisAttempt == 0;
                 var atTopOfPage = fragmentainer.UsedBlockSize == initialUsed;
+
 
                 if (nothingEmittedThisAttempt && atTopOfPage)
                 {
@@ -4544,7 +4550,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     ///
     /// <para><b>Cycle 2c subtree-aware cursor advance (this revision).</b>
     /// Per cycle 2c post-PR-29 review #2 — the recursion now also calls
-    /// <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double)"/>
+    /// <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double, double)"/>
     /// for each child + advances the inner cursor by
     /// <c>max(childBorderBox, childSubtreeExtent)</c>, mirroring the
     /// outer loop's behavior. Pre-cycle-2c-fix the recursion advanced
@@ -9495,12 +9501,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// outer-loop child + the depth cap bounds the work; the outer
     /// loop's CT check still runs between children.</para></summary>
     private double MeasureSubtreeVisualBlockExtent(
-        Box parent, CancellationToken cancellationToken, double parentContentBlockSize = 0)
+        Box parent, CancellationToken cancellationToken, double parentContentBlockSize = 0,
+        double blockOffsetOnPage = 0)
         => MeasureSubtreeVisualBlockExtentRecursive(
-            parent, cancellationToken, depth: 0, parentContentBlockSize);
+            parent, cancellationToken, depth: 0, parentContentBlockSize, blockOffsetOnPage);
 
     /// <summary>Per cycle 2c post-PR-29 review #1 (P0) + #3 (P1) —
-    /// recursive worker for <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double)"/>.
+    /// recursive worker for <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double, double)"/>.
     /// Renamed from the same-name overload to fix CS0419 ambiguous cref
     /// errors in class-level XML docs. CT plumbing matches
     /// <see cref="EmitBlockSubtreeRecursive"/> so an oversized broad
@@ -9512,7 +9519,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // DEFINITE containing height — its own `height: N%` resolves against it, and ITS resolved
         // content height chains to the children, mirroring the EMIT pass exactly (a desync here
         // under-reserved the cursor/pagination for %-height subtrees). 0 = indefinite → auto.
-        double parentContentBlockSize = 0)
+        double parentContentBlockSize = 0,
+        // This box's block-start offset on the CURRENT page (accumulated through the recursion). Used so a
+        // nested TABLE's dry-run reserves only the remaining page space when the table starts below the
+        // page top — otherwise the subtree extent overshoots the page and a false forced-overflow clips
+        // the table (offset-table clip fix). 0 = top of page (byte-identical to the pre-fix behavior).
+        double blockOffsetOnPage = 0)
     {
         if (depth > MaxRecursionDepth)
         {
@@ -9616,7 +9628,10 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // PAGINATION-FORCED-OVERFLOW-001.
             var contentHeight = MeasureNestedTableContentExtent(
                 parent, contentInlineSize, cancellationToken,
-                useDryRunCommittedHeight: true);
+                useDryRunCommittedHeight: true,
+                // The table's rows start after the wrapper's top chrome, at this page offset — so the
+                // dry-run reserves only the remaining page space (offset-table clip fix).
+                tableStartOffsetOnPage: blockOffsetOnPage + pBorderStart + pPaddingStart);
             var wrapperBorderPaddingBlock = pBorderStart + pPaddingStart
                 + pPaddingEnd + pBorderEnd;
             var tableDriven = contentHeight + wrapperBorderPaddingBlock;
@@ -9788,11 +9803,6 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
 
             var marginStart = child.Style.ReadLengthPxOrZero(PropertyId.MarginTop);
             var marginEnd = child.Style.ReadLengthPxOrZero(PropertyId.MarginBottom);
-            // Recurse — child's subtree extent (= max of child's own
-            // border-box + its descendants).
-            var childSubtreeExtent = MeasureSubtreeVisualBlockExtentRecursive(
-                child, cancellationToken, depth + 1,
-                parentContentBlockSize: pHeight);   // % height base chains (percent-height cycle).
 
             double topShift;
             if (!hasPrior)
@@ -9805,8 +9815,16 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 topShift = gap - prevMarginEnd;
             }
 
-            // Child's bottom edge in parent's border-box coordinates.
+            // Child's top edge in the parent's border-box coordinates. Computed BEFORE the recursion so we
+            // can thread the child's page offset (this box's page offset + the child's top within it) — a
+            // nested table's dry-run then reserves only the remaining page space (offset-table clip fix).
             var childTopInParent = contentAreaTop + childCursor + topShift;
+
+            // Recurse — child's subtree extent (= max of child's own border-box + its descendants).
+            var childSubtreeExtent = MeasureSubtreeVisualBlockExtentRecursive(
+                child, cancellationToken, depth + 1,
+                parentContentBlockSize: pHeight,   // % height base chains (percent-height cycle).
+                blockOffsetOnPage: blockOffsetOnPage + childTopInParent);
             var childBottomInParent = childTopInParent + childSubtreeExtent;
             if (childBottomInParent > maxExtent)
             {
@@ -9987,7 +10005,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             var resumeSplitOffset = resumeCont?.RowSplitOffset ?? 0.0;
             var dryRunCommitted = tableLayouter.DryRunCommittedBlockSize(
                 fragmentainer, resumeAt,
-                out _, out _, resumeSplitOffset);
+                out _, out _, resumeSplitOffset,
+                // Size the wrapper for the rows that fit at the table's ACTUAL page offset. In the outer
+                // emit path this equals fragmentainer.UsedBlockSize, but in the nested-recursion path
+                // UsedBlockSize is 0 while the table really starts at `wrapperBlockOffsetExpected` — using
+                // the latter keeps the wrapper's committed size in lockstep with what the emission places,
+                // so an offset table isn't over-sized (which clipped its last-fitting row).
+                startOffsetOverride: wrapperBlockOffsetExpected);
             tableContentHeight = dryRunCommitted;
         }
         else
@@ -10027,7 +10051,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         Box wrapper,
         double contentInlineSize,
         CancellationToken cancellationToken,
-        bool useDryRunCommittedHeight = false)
+        bool useDryRunCommittedHeight = false,
+        // The table's block-start offset on the current page within the subtree being measured. Passed to
+        // the dry-run so it reserves only the REMAINING page space when the table starts below the page top
+        // (offset-table clip fix). < 0 = fall back to fragmentainer.UsedBlockSize (the top-of-page default).
+        double tableStartOffsetOnPage = -1.0)
     {
         _measuredTableContentHeightCache ??= new Dictionary<Box, double>();
         if (!useDryRunCommittedHeight
@@ -10108,7 +10136,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         {
             var dryRunCommitted = transientLayouter.DryRunCommittedBlockSize(
                 _capturedFragmentainer, resumeAtRow: 0,
-                out _, out _);
+                out _, out _,
+                startOffsetOverride: tableStartOffsetOnPage);
             // Caller doesn't cache the dry-run mode — different pages
             // may have different committed extents.
             return dryRunCommitted;
@@ -10236,7 +10265,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// <summary>Per Phase 3 Task 15 L3 post-PR-#63 hardening F#1 —
     /// compute the flex wrapper's auto cross-extent WITHOUT stacking
     /// its children vertically. The default
-    /// <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double)"/>
+    /// <see cref="MeasureSubtreeVisualBlockExtent(Box, CancellationToken, double, double)"/>
     /// path (used by every non-flex wrapper) sums the children's
     /// block-axis extents as if they were laid out in block-flow — for
     /// a flex container with <c>height: auto</c> + items 50/100/75 it

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -2582,7 +2582,6 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 var nothingEmittedThisAttempt = emittedThisAttempt == 0;
                 var atTopOfPage = fragmentainer.UsedBlockSize == initialUsed;
 
-
                 if (nothingEmittedThisAttempt && atTopOfPage)
                 {
                     // Forced overflow: the block is taller than the
@@ -9496,10 +9495,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// are treated as opaque (return their own border-box size; their
     /// inner geometry belongs to a dedicated layouter). Pathologically
     /// deep trees throw <see cref="InvalidOperationException"/> at
-    /// the same depth limit. Note: the measure pass does NOT accept a
-    /// CancellationToken — it's a pure traversal called once per
-    /// outer-loop child + the depth cap bounds the work; the outer
-    /// loop's CT check still runs between children.</para></summary>
+    /// the same depth limit. The measure pass accepts a
+    /// <see cref="CancellationToken"/> and threads it into
+    /// <see cref="MeasureSubtreeVisualBlockExtentRecursive"/>, which checks it
+    /// so a large-fan-out subtree (not just deep nesting) stays responsive to
+    /// cancellation between children.</para></summary>
     private double MeasureSubtreeVisualBlockExtent(
         Box parent, CancellationToken cancellationToken, double parentContentBlockSize = 0,
         double blockOffsetOnPage = 0)
@@ -10054,8 +10054,10 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         bool useDryRunCommittedHeight = false,
         // The table's block-start offset on the current page within the subtree being measured. Passed to
         // the dry-run so it reserves only the REMAINING page space when the table starts below the page top
-        // (offset-table clip fix). < 0 = fall back to fragmentainer.UsedBlockSize (the top-of-page default).
-        double tableStartOffsetOnPage = -1.0)
+        // (offset-table clip fix). NaN = "no override" → fall back to fragmentainer.UsedBlockSize (the
+        // top-of-page default); a NaN sentinel (not < 0) keeps a legitimately NEGATIVE offset — from
+        // margin collapsing / negative margins — distinct from "unset".
+        double tableStartOffsetOnPage = double.NaN)
     {
         _measuredTableContentHeightCache ??= new Dictionary<Box, double>();
         if (!useDryRunCommittedHeight

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -805,13 +805,16 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         out bool willForceOverflowOnSingleRow,
         double incomingRowSplitOffset = 0.0,
         // The table's block-start offset on the CURRENT page. In the EMIT path this equals
-        // fragmentainer.UsedBlockSize (the live cursor), so the default (< 0) reads it from there — the
-        // pre-fix behavior. But a MEASURE-pass caller walking a subtree (a table nested below a spacer /
-        // preceding content) sees fragmentainer.UsedBlockSize == 0 even though the table actually starts
-        // lower on the page; it passes the real subtree offset here so the row-fit loop reserves only the
-        // REMAINING page space. Without this the dry-run over-commits by ~one row, the ancestor's subtree
-        // extent overshoots the page, and a false forced-overflow clips the table (offset-table clip bug).
-        double startOffsetOverride = -1.0)
+        // fragmentainer.UsedBlockSize (the live cursor), so the default (NaN = "no override") reads it
+        // from there — the pre-fix behavior. But a MEASURE-pass caller walking a subtree (a table nested
+        // below a spacer / preceding content) sees fragmentainer.UsedBlockSize == 0 even though the table
+        // actually starts lower on the page; it passes the real subtree offset here so the row-fit loop
+        // reserves only the REMAINING page space. Without this the dry-run over-commits by ~one row, the
+        // ancestor's subtree extent overshoots the page, and a false forced-overflow clips the table
+        // (offset-table clip bug). NaN (not < 0) is the sentinel so a legitimately NEGATIVE start offset
+        // — from margin collapsing / negative margins pushing the table above the page-start cursor —
+        // is still honored instead of being mistaken for "no override".
+        double startOffsetOverride = double.NaN)
     {
         needsSplitting = false;
         willForceOverflowOnSingleRow = false;
@@ -856,7 +859,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // border + padding aren't precisely accounted for; sub-cycle
         // 6+ may revise.
         var topCaptionsBlock = isFirstPage ? _measuredTopCaptionsTotal : 0.0;
-        var pageStartOffset = startOffsetOverride >= 0.0
+        var pageStartOffset = !double.IsNaN(startOffsetOverride)
             ? startOffsetOverride
             : fragmentainer.UsedBlockSize;
         var rowStackOriginInFragmentainer =

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -803,7 +803,15 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         int resumeAtRow,
         out bool needsSplitting,
         out bool willForceOverflowOnSingleRow,
-        double incomingRowSplitOffset = 0.0)
+        double incomingRowSplitOffset = 0.0,
+        // The table's block-start offset on the CURRENT page. In the EMIT path this equals
+        // fragmentainer.UsedBlockSize (the live cursor), so the default (< 0) reads it from there — the
+        // pre-fix behavior. But a MEASURE-pass caller walking a subtree (a table nested below a spacer /
+        // preceding content) sees fragmentainer.UsedBlockSize == 0 even though the table actually starts
+        // lower on the page; it passes the real subtree offset here so the row-fit loop reserves only the
+        // REMAINING page space. Without this the dry-run over-commits by ~one row, the ancestor's subtree
+        // extent overshoots the page, and a false forced-overflow clips the table (offset-table clip bug).
+        double startOffsetOverride = -1.0)
     {
         needsSplitting = false;
         willForceOverflowOnSingleRow = false;
@@ -848,8 +856,11 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // border + padding aren't precisely accounted for; sub-cycle
         // 6+ may revise.
         var topCaptionsBlock = isFirstPage ? _measuredTopCaptionsTotal : 0.0;
+        var pageStartOffset = startOffsetOverride >= 0.0
+            ? startOffsetOverride
+            : fragmentainer.UsedBlockSize;
         var rowStackOriginInFragmentainer =
-            fragmentainer.UsedBlockSize + topCaptionsBlock;
+            pageStartOffset + topCaptionsBlock;
         // Per cycle 2 — the body row window emits AFTER the header
         // stack + reserves footerStackHeight at the bottom of the
         // page. So the effective per-page body budget is

--- a/tests/NetPdf.UnitTests/Layout/OffsetTablePaginationTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/OffsetTablePaginationTests.cs
@@ -1,0 +1,70 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NetPdf;
+using NetPdf.Text.Fonts;
+using NetPdf.UnitTests.Text.Fonts.OpenType;
+using Xunit;
+
+namespace NetPdf.UnitTests.Layout;
+
+/// <summary>
+/// Regression tests for the offset-table pagination clip: a tall table that starts BELOW the page top —
+/// because plain content (a heading, a paragraph) precedes it — must fragment across pages WITHOUT clipping
+/// (dropping) any rows. Pre-fix, the nested-table dry-run in the subtree measure ignored the table's block
+/// offset within the subtree, over-committed by ~one row, overshot the page, and tripped a false
+/// forced-overflow that committed the table whole and clipped every row past the first page.
+///
+/// <para>Determinism: the synthetic font gives fixed glyph metrics so row heights — and therefore the
+/// pagination decisions — are reproducible without a system font.</para>
+/// </summary>
+public sealed class OffsetTablePaginationTests
+{
+    private static HtmlPdfOptions Opts() => new() { FontResolver = new SynthResolver() };
+
+    private static string Rows(int n) =>
+        string.Concat(Enumerable.Range(1, n).Select(i =>
+            $"<tr><td>Item {i}</td><td>Description of line item {i}</td><td>${i * 10}.00</td></tr>"));
+
+    private static string Doc(string body) =>
+        "<!DOCTYPE html><html><head><style>@page{size:A4;margin:20mm}"
+        + "table{width:100%;border-collapse:collapse}td{border:1px solid #ccc;padding:6px}</style></head>"
+        + "<body>" + body + "</body></html>";
+
+    [Fact]
+    public void Tall_table_at_page_top_paginates_without_clipping()
+    {
+        // Control — the always-working case (offset 0). Guards it against the offset fix.
+        var r = HtmlPdf.ConvertDetailed(Doc($"<table>{Rows(40)}</table>"), Opts());
+        Assert.True(r.PageCount >= 2, $"a 40-row table should paginate; got {r.PageCount} page(s).");
+        Assert.DoesNotContain(r.Warnings, IsClip);
+    }
+
+    [Theory]
+    [InlineData("<div style='height:50px'></div>")]                      // a spacer pushes the table down
+    [InlineData("<h1>Invoice 0042</h1><p>Bill to: Acme Corp</p>")]       // real preceding content
+    [InlineData("<div style='height:200px'></div>")]                     // a larger offset
+    public void Tall_table_offset_from_page_top_paginates_without_clipping(string preceding)
+    {
+        // The bug: any of these offsets used to clip the table's overflowing rows (data loss).
+        var r = HtmlPdf.ConvertDetailed(Doc($"{preceding}<table>{Rows(40)}</table>"), Opts());
+
+        Assert.True(r.PageCount >= 2, $"the table should still paginate; got {r.PageCount} page(s).");
+        Assert.DoesNotContain(r.Warnings, IsClip);                       // NEVER drop content
+        Assert.DoesNotContain(r.Warnings, IsForcedOverflow);            // and it fragments cleanly, not by force
+    }
+
+    private static bool IsClip(Diagnostic d) => d.Code == "PDF-CONTENT-OVERFLOW-TRUNCATED-001";
+    private static bool IsForcedOverflow(Diagnostic d) => d.Code == "PAGINATION-FORCED-OVERFLOW-001";
+
+    private sealed class SynthResolver : IFontResolver
+    {
+        private static readonly byte[] FontBytes = SyntheticFont.Build();
+
+        public ValueTask<FontFaceData?> ResolveAsync(FontQuery query, CancellationToken ct)
+            => new(new FontFaceData { Bytes = FontBytes, Family = query.Family });
+    }
+}

--- a/tests/NetPdf.UnitTests/Layout/OffsetTablePaginationTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/OffsetTablePaginationTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
 
 using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using NetPdf;
@@ -55,6 +57,81 @@ public sealed class OffsetTablePaginationTests
         Assert.True(r.PageCount >= 2, $"the table should still paginate; got {r.PageCount} page(s).");
         Assert.DoesNotContain(r.Warnings, IsClip);                       // NEVER drop content
         Assert.DoesNotContain(r.Warnings, IsForcedOverflow);            // and it fragments cleanly, not by force
+    }
+
+    // ── Content-preservation: prove every row survives pagination, not just "no warning" ────
+    // The bug is DATA LOSS, so absence of a clip diagnostic isn't enough — assert the cells are
+    // actually painted. Each cell paints exactly one text-show (`<hex> Tj`), so the number of Tj
+    // operators across all pages is a faithful count of cells that reached the page.
+
+    private static int CellTextShows(byte[] pdf) =>
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"[>)]\s*Tj").Count;
+
+    [Fact]
+    public void Offset_table_preserves_every_cell_exactly_like_the_page_top_render()
+    {
+        const int rows = 40;
+        var atTop = HtmlPdf.Convert(Doc($"<table>{Rows(rows)}</table>"), Opts());
+        var offset = HtmlPdf.Convert(
+            Doc($"<div style='height:200px'></div><table>{Rows(rows)}</table>"), Opts());
+
+        // The offset only shifts the table down a page — it must not drop a single cell, so the
+        // total cell count is identical to the (always-correct) page-top render, and covers every
+        // row × column (the spacer div paints no text of its own).
+        Assert.Equal(CellTextShows(atTop), CellTextShows(offset));
+        Assert.True(CellTextShows(offset) >= rows * 3,
+            $"expected ≥ {rows * 3} cell shows (40 rows × 3 cols); got {CellTextShows(offset)} — rows were dropped.");
+    }
+
+    [Fact]
+    public void Table_in_a_padded_bordered_wrapper_preserves_every_row()
+    {
+        // The fix threads a page-start offset through the wrapper's border + padding — exercise that
+        // path directly: a padded, bordered wrapper pushes the table down and shrinks its content box.
+        // The CRITICAL guarantee is content preservation: no clip diagnostic, and every cell painted.
+        // NOTE: a padded/bordered wrapper still trips a (non-lossy) forced-overflow — the documented
+        // `padded-wrapper` residual (an extra page, NOT data loss) — so this test asserts no data is
+        // lost rather than absence of forced-overflow.
+        const int rows = 36;
+        var r = HtmlPdf.ConvertDetailed(
+            Doc($"<div style='padding:40px;border:12px solid #333'><table>{Rows(rows)}</table></div>"), Opts());
+
+        Assert.True(r.PageCount >= 2, $"the wrapped table should paginate; got {r.PageCount} page(s).");
+        Assert.DoesNotContain(r.Warnings, IsClip);          // NEVER drop content
+        Assert.True(CellTextShows(r.Pdf) >= rows * 3,
+            $"expected ≥ {rows * 3} cell shows; got {CellTextShows(r.Pdf)} — rows lost inside the wrapper.");
+    }
+
+    [Fact]
+    public void Table_with_a_caption_offset_preserves_every_row()
+    {
+        // A <caption> adds block extent above the row grid — another source of a non-zero start offset.
+        const int rows = 38;
+        var r = HtmlPdf.ConvertDetailed(
+            Doc($"<div style='height:120px'></div><table><caption>Line items</caption>{Rows(rows)}</table>"), Opts());
+
+        Assert.True(r.PageCount >= 2, $"the captioned table should paginate; got {r.PageCount} page(s).");
+        Assert.DoesNotContain(r.Warnings, IsClip);
+        Assert.True(CellTextShows(r.Pdf) >= rows * 3,
+            $"expected ≥ {rows * 3} cell shows; got {CellTextShows(r.Pdf)} — captioned rows were dropped.");
+    }
+
+    [Fact]
+    public void Offset_table_with_repeating_header_and_footer_preserves_every_body_row()
+    {
+        // thead/tfoot repeat per page; the body rows must still all appear once when the table starts
+        // below the page top. Header + footer only ADD text-shows, so the ≥ body-cell floor still holds.
+        const int bodyRows = 36;
+        var r = HtmlPdf.ConvertDetailed(Doc(
+            "<div style='height:150px'></div><table>"
+            + "<thead><tr><td>#</td><td>Item</td><td>Amount</td></tr></thead>"
+            + "<tfoot><tr><td></td><td>Total</td><td>$999</td></tr></tfoot>"
+            + $"<tbody>{Rows(bodyRows)}</tbody></table>"), Opts());
+
+        Assert.True(r.PageCount >= 2, $"should paginate; got {r.PageCount} page(s).");
+        Assert.DoesNotContain(r.Warnings, IsClip);
+        Assert.True(CellTextShows(r.Pdf) >= bodyRows * 3,
+            $"expected ≥ {bodyRows * 3} body cell shows; got {CellTextShows(r.Pdf)} — body rows lost.");
     }
 
     private static bool IsClip(Diagnostic d) => d.Code == "PDF-CONTENT-OVERFLOW-TRUNCATED-001";


### PR DESCRIPTION
The **Bug B** fix — the pre-existing multi-page-table data-loss the invoice/document corpus surfaced.

## Symptom
A tall `<table>` that starts **below the page top** (preceding content, or a wrapper's top padding, pushes it down) **force-overflowed and CLIPPED its overflowing rows** — silent data loss. A table starting *at* the page top fragmented cleanly.

## Root cause (found by instrumenting the layouter)
The nested-table dry-run that sizes a wrapper for the current page read the table's start offset from `fragmentainer.UsedBlockSize`. In the subtree **measure** pass (and the nested-emit recursion) that value is `0` even when the table actually starts lower — so the dry-run committed a **full page of rows as if from offset 0**. Placed at the real offset, the last committed row overshot the page → the ancestor's subtree extent exceeded the page → a **false** `PAGINATION-FORCED-OVERFLOW-001` committed the table whole and clipped the rest.

## Fix — thread the table's true page offset into the dry-run
- `DryRunCommittedBlockSize` takes a `startOffsetOverride` (defaults to `UsedBlockSize` = pre-fix behavior).
- `MeasureSubtreeVisualBlockExtentRecursive` threads a `blockOffsetOnPage` accumulator through the child-sum loop and passes it to the nested-table branch's dry-run.
- The emit-path `PreMeasureTableIfNeeded` dry-run uses `wrapperBlockOffsetExpected` (the real offset) instead of `UsedBlockSize`, keeping the wrapper's committed size in lockstep with what the emission places.

## Result
Offset tables now paginate **without clipping** — content is never dropped. Verified on the minimal repros (spacer+table, heading+table, larger offset) and the document corpus.

## Known residual (separate, deeper — documented, not in this PR)
A table inside a wrapper with its **own top+bottom padding** can still `PAGINATION-FORCED-OVERFLOW` (the wrapper's bottom padding overshoots the page) — **no data loss (clip is gone)**, but an occasional extra page. That's fragmented-block padding handling ("breaks inside a subtree"), tracked as a follow-up.

## Tests + gates
`OffsetTablePaginationTests` (1 control + 3 offset cases, synthetic font). **All goldens byte-identical** (LayoutSnapshots 30 · PaginationGolden 1 · RealDocuments 105 · RenderingCorpus 36 · W3cConformance 6) · **8387 unit / 3 skip** · 0-warn build · AOT/JIT parity · `fuzz --smoke` 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)