### PR TITLE
fix(layout): corpus fidelity — 08 bar-fill bleed + max-width margin:auto centering

### DIFF
--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7363,6 +7363,19 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             ResolveAutoInlineMargins(
                 block, borderBox, containingInlinePx, ref marginInlineStart, ref marginInlineEnd);
         }
+        else if (HasExplicitMaxWidth(block))
+        {
+            // Corpus-fidelity (11 certificate `.citation`) — an AUTO-width block that `max-width`
+            // clamps below the available range still has a definite used width, so `margin: 0 auto`
+            // centers it (CSS 2.2 §10.3.3 + §10.4). ComputeInlineOnlyBlockLayout applies the same
+            // auto-fill + max-width clamp to the emitted width, so distribute against the same used
+            // border box. No-op when max-width doesn't clamp (used width == range → leftover 0).
+            var autoFill = Math.Max(0, containingInlinePx - marginInlineStart - marginInlineEnd);
+            var usedBorderBox = block.ClampBorderBoxToMinMax(
+                autoFill, PropertyId.MinWidth, PropertyId.MaxWidth, containingInlinePx);
+            ResolveAutoInlineMargins(
+                block, usedBorderBox, containingInlinePx, ref marginInlineStart, ref marginInlineEnd);
+        }
         return new(
             // Body % lengths (body-percent cycle): margins/paddings/width take percentages against
             // the containing block's INLINE size (CSS 2.2 §8.3/§8.4/§10.2), like the block paths.
@@ -7393,6 +7406,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// explicit. The §10.3.3 gates key on this tag test (post-PR-#164 review P3).</summary>
     private static bool HasExplicitWidth(Box child) =>
         child.Style.Get(PropertyId.Width).Tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
+
+    /// <summary>An explicit <c>max-width</c> (LengthPx / Percentage). A <c>width: auto</c> block that
+    /// <c>max-width</c> clamps below the available range still has a definite used width, so
+    /// <c>margin: 0 auto</c> centers it (CSS 2.2 §10.3.3 + §10.4) — see
+    /// <see cref="ResolveAutoInlineMargins"/>.</summary>
+    private static bool HasExplicitMaxWidth(Box child) =>
+        child.Style.Get(PropertyId.MaxWidth).Tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
 
     /// <summary>Body `box-sizing: border-box` (box-sizing cycle) — the KeywordResolver box-sizing
     /// table: 0 = content-box (the initial), 1 = border-box. Mirrors the margin-box reader
@@ -7507,9 +7527,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // gate in ResolveInFlowBorderBoxInlineSize (both sets must stay in lockstep).
         if (child.Kind is not (BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement
             or BoxKind.FlexContainer or BoxKind.GridContainer)) return;
-        // EXPLICIT width only (a tag test, so the legal `width: 0` / `0%` distributes too —
-        // post-PR-#164 review P3); auto-width boxes keep the fill (auto margins read 0).
-        if (!HasExplicitWidth(child)) return;
+        // EXPLICIT width (a tag test, so the legal `width: 0` / `0%` distributes too — post-PR-#164
+        // review P3) OR an explicit `max-width` (a `width: auto` block that max-width clamps below the
+        // range still has a definite used width, so `margin: 0 auto` centers it — CSS 2.2 §10.3.3 +
+        // §10.4; the `borderBoxInlineSize` passed in is already the max-width-clamped used width, so the
+        // leftover below is 0 when max-width doesn't actually clamp → byte-identical for the fill case).
+        // A plain auto-width box with no max-width keeps the fill behavior (auto margins read 0).
+        if (!HasExplicitWidth(child) && !HasExplicitMaxWidth(child)) return;
         var leftAuto = child.Style.Get(PropertyId.MarginLeft).Tag == ComputedSlotTag.Keyword;
         var rightAuto = child.Style.Get(PropertyId.MarginRight).Tag == ComputedSlotTag.Keyword;
         if (!leftAuto && !rightAuto) return;

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -3359,8 +3359,28 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                 var itemDiag = effectiveDiagnostics is null ? null : new BufferingDiagnosticsSink();
                 diagBuffers[itemIdx] = itemDiag;
 
+                // Corpus-fidelity (08 sales-report bar bleed) — the nested measure uses its block
+                // budget as the percentage-HEIGHT base for the item's block children (BlockLayouter
+                // resolves a top-level child's `height: N%` against `fragmentainer.BlockSize`). For a
+                // ROW flex item with a DEFINITE cross size (an explicit `height`, e.g. a fixed-height
+                // `.bar-track`), that base must be the ITEM's content height — NOT the page — so a
+                // `height: 100%` child (a gradient `.bar-fill`) fills the track, not the whole page.
+                // Auto-cross items + column items keep the page budget (they content-size / their main
+                // axis is the block budget). Byte-identical unless a definite-height row item has a
+                // percentage-height child, which today resolves against the page (the bug).
+                var itemBlockBudget = contentMeasureBlockBudget;
+                if (!isColumn && !IsCrossSizeAuto(item, flexDirection))
+                {
+                    var itemContentCross = item.Style.CrossBorderBoxSizePx(crossSizeProperty)
+                        - item.Style.BlockBorderPaddingPx();
+                    if (itemContentCross > 0)
+                    {
+                        itemBlockBudget = itemContentCross;
+                    }
+                }
+
                 var buffer = LayoutItemContentIntoBuffer(
-                    item, usedInline, contentMeasureBlockBudget, writingMode, isRtl,
+                    item, usedInline, itemBlockBudget, writingMode, isRtl,
                     itemDiag, cancellationToken);
                 buffers[itemIdx] = buffer;
 

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -1129,7 +1129,8 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             : fragmentainer.BlockSize;
         var (itemContentBuffers, itemDiagnosticBuffers) = MeasureFlexItemContents(
             lines, resolvedItemMainSizes, flexDirection, isColumn,
-            mainSizeProperty, crossSizeProperty, containerCrossSize, isWrapping,
+            mainSizeProperty, crossSizeProperty, containerCrossSize,
+            containerDefiniteCrossSize, isWrapping,
             fragmentainer, layout.WritingMode, layout.IsRtl,
             effectiveDiagnostics, contentMeasureBudget, cancellationToken);
 
@@ -3305,6 +3306,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId mainSizeProperty,
         PropertyId crossSizeProperty,
         double containerCrossSize,
+        double containerDefiniteCrossSize,
         bool isWrapping,
         FragmentainerContext fragmentainer,
         WritingMode writingMode,
@@ -3362,21 +3364,30 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                 // Corpus-fidelity (08 sales-report bar bleed) — the nested measure uses its block
                 // budget as the percentage-HEIGHT base for the item's block children (BlockLayouter
                 // resolves a top-level child's `height: N%` against `fragmentainer.BlockSize`). For a
-                // ROW flex item with a DEFINITE cross size (an explicit `height`, e.g. a fixed-height
-                // `.bar-track`), that base must be the ITEM's content height — NOT the page — so a
-                // `height: 100%` child (a gradient `.bar-fill`) fills the track, not the whole page.
-                // Auto-cross items + column items keep the page budget (they content-size / their main
-                // axis is the block budget). Byte-identical unless a definite-height row item has a
-                // percentage-height child, which today resolves against the page (the bug).
+                // ROW flex item with a DEFINITE cross size, that base must be the ITEM's content
+                // height — NOT the page — so a `height: 100%` child (a gradient `.bar-fill`) fills the
+                // track, not the whole page. A definite cross is either an explicit length OR a
+                // percentage against a definite container cross (`.bar { height: 100% }` in a fixed-
+                // height row container — 10's barcodes), resolved via the same container-base overload
+                // the emission path uses. The content-cross clamps at 0 (border/padding may consume
+                // the whole height, box-sizing:border-box), and a DEFINITE ZERO is preserved as the
+                // %-height base (do NOT fall back to the page). Auto-cross / column items keep the page
+                // budget (they content-size / their main axis is the block budget). Byte-identical
+                // unless a definite-cross row item has a percentage-height child (the bug).
                 var itemBlockBudget = contentMeasureBlockBudget;
-                if (!isColumn && !IsCrossSizeAuto(item, flexDirection))
+                var crossSlot = item.Style.Get(crossSizeProperty);
+                // A DEFINITE cross size: an explicit length, OR a percentage against a DEFINITE
+                // container cross (finite base). A percentage against an INDEFINITE container is AUTO
+                // per CSS Sizing 3 §5.1.1 — the item content-sizes, so it keeps the page budget (NOT a
+                // spurious 0). Auto keywords are likewise not definite.
+                var definiteCross = crossSlot.Tag == ComputedSlotTag.LengthPx
+                    || (crossSlot.Tag == ComputedSlotTag.Percentage
+                        && double.IsFinite(containerDefiniteCrossSize));
+                if (!isColumn && definiteCross)
                 {
-                    var itemContentCross = item.Style.CrossBorderBoxSizePx(crossSizeProperty)
-                        - item.Style.BlockBorderPaddingPx();
-                    if (itemContentCross > 0)
-                    {
-                        itemBlockBudget = itemContentCross;
-                    }
+                    var crossBorderBox = item.Style.CrossBorderBoxSizePx(
+                        crossSizeProperty, containerDefiniteCrossSize);
+                    itemBlockBudget = Math.Max(0, crossBorderBox - item.Style.BlockBorderPaddingPx());
                 }
 
                 var buffer = LayoutItemContentIntoBuffer(

--- a/tests/NetPdf.UnitTests/Rendering/FlexDefiniteHeightPercentChildTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexDefiniteHeightPercentChildTests.cs
@@ -1,0 +1,58 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// Corpus-fidelity (08 sales-report bar bleed). A block child with <c>height: 100%</c> inside a ROW
+/// flex item that has a DEFINITE cross size (an explicit <c>height</c>) must fill the ITEM's height,
+/// not the whole page. The nested content measure uses its block budget as the percentage-height base
+/// for the item's block children; before the fix it passed the page height, so a gradient
+/// <c>.bar-fill</c> painted (and clipped) down the entire page instead of a fixed-height <c>.bar-track</c>.
+/// </summary>
+public sealed class FlexDefiniteHeightPercentChildTests
+{
+    [Fact]
+    public void Percent_height_child_of_a_fixed_height_row_flex_item_fills_the_item_not_the_page()
+    {
+        const string html = "<!DOCTYPE html><html><head><style>*{box-sizing:border-box}"
+            + ".row{display:flex;align-items:center}"
+            + ".track{flex:1;height:18px;overflow:hidden;border-radius:6px}"
+            + ".fill{height:100%;border-radius:6px;background:linear-gradient(90deg,#4338ca,#7c3aed)}</style></head><body>"
+            + "<div class=\"row\"><div class=\"track\"><div class=\"fill\" style=\"width:100%\"></div></div></div>"
+            + "<p>content below the bar</p></body></html>";
+        var pdf = Encoding.Latin1.GetString(
+            HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+
+        // Layout-level check (robust to paint-operator form): the `<p>` sits directly below the 18px
+        // bar, so its text baseline is near the TOP of the A4 content area (~768pt = 796 top − 18px
+        // bar − a line). Before the fix, the fill's height:100% resolved against the page (~750pt), so
+        // the bar box was ~750px tall and pushed the `<p>` to the BOTTOM of the page (small y).
+        double pY = double.NaN;
+        foreach (Match sm in Regex.Matches(pdf, @"stream\r?\n(.*?)\r?\nendstream", RegexOptions.Singleline))
+        {
+            var s = sm.Groups[1].Value;
+            if (!s.Contains(" Tf")) continue;
+            foreach (Match bt in Regex.Matches(s, @"BT(.*?)ET", RegexOptions.Singleline))
+            {
+                var b = bt.Groups[1].Value;
+                if (!Regex.IsMatch(b, @"<[0-9A-Fa-f]+> *T[jJ]")) continue;
+                var tm = Regex.Match(b, @"(-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) Tm");
+                if (tm.Success) { pY = double.Parse(tm.Groups[6].Value, CultureInfo.InvariantCulture); continue; }
+                var td = Regex.Match(b, @"(-?[\d.]+) (-?[\d.]+) (?:Td|TD)");
+                if (td.Success) pY = double.Parse(td.Groups[2].Value, CultureInfo.InvariantCulture);
+            }
+        }
+        Assert.False(double.IsNaN(pY), "no text found");
+        Assert.True(pY > 700,
+            $"the paragraph below the bar is at y={pY:0.#}pt — it was pushed toward the page bottom "
+            + "because the height:100% bar-fill resolved against the page instead of the 18px track.");
+    }
+}

--- a/tests/NetPdf.UnitTests/Rendering/FlexDefiniteHeightPercentChildTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexDefiniteHeightPercentChildTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
 
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using NetPdf;
@@ -28,13 +27,59 @@ public sealed class FlexDefiniteHeightPercentChildTests
             + ".fill{height:100%;border-radius:6px;background:linear-gradient(90deg,#4338ca,#7c3aed)}</style></head><body>"
             + "<div class=\"row\"><div class=\"track\"><div class=\"fill\" style=\"width:100%\"></div></div></div>"
             + "<p>content below the bar</p></body></html>";
+        var pY = ParagraphBaselineY(html);
+        Assert.False(double.IsNaN(pY), "no text found");
+        Assert.True(pY > 700,
+            $"the paragraph below the bar is at y={pY:0.#}pt — it was pushed toward the page bottom "
+            + "because the height:100% bar-fill resolved against the page instead of the 18px track.");
+    }
+
+    [Fact]
+    public void Percent_height_item_in_a_definite_height_row_container_fills_the_item_not_the_page()
+    {
+        // The ITEM's own cross size is a PERCENTAGE (`height:100%`), definite only because the row
+        // container has an explicit height. The percentage must resolve against the container's
+        // definite cross (60px) — NOT the page — so the item's own `height:100%` grandchild fill is a
+        // 60px bar, and the `<p>` stays near the top. Before the container-base overload, the item's
+        // percentage cross resolved to 0/page and the fill leaked down the page.
+        const string html = "<!DOCTYPE html><html><head><style>*{box-sizing:border-box}"
+            + ".row{display:flex;align-items:stretch;height:60px}"
+            + ".track{flex:1;height:100%;overflow:hidden}"
+            + ".fill{height:100%;background:linear-gradient(90deg,#4338ca,#7c3aed)}</style></head><body>"
+            + "<div class=\"row\"><div class=\"track\"><div class=\"fill\" style=\"width:100%\"></div></div></div>"
+            + "<p>content below the bar</p></body></html>";
+        var pY = ParagraphBaselineY(html);
+        Assert.False(double.IsNaN(pY), "no text found");
+        Assert.True(pY > 680,
+            $"the paragraph below the bar is at y={pY:0.#}pt — the item's percentage cross did not "
+            + "resolve against the 60px definite container height.");
+    }
+
+    [Fact]
+    public void Definite_zero_content_height_is_preserved_not_replaced_by_the_page_budget()
+    {
+        // box-sizing:border-box; height:18px; padding:9px 0 → content height is exactly 0. That DEFINITE
+        // ZERO must be the percentage-height base (a `height:100%` child gets 0) — the measure must NOT
+        // fall back to the page budget. The `<p>` therefore stays near the top (the bar is ~18px tall,
+        // its content 0). A page-budget fallback would make the fill ~750px and push the `<p>` down.
+        const string html = "<!DOCTYPE html><html><head><style>*{box-sizing:border-box}"
+            + ".row{display:flex;align-items:center}"
+            + ".track{flex:1;height:18px;padding:9px 0;overflow:hidden}"
+            + ".fill{height:100%;background:linear-gradient(90deg,#4338ca,#7c3aed)}</style></head><body>"
+            + "<div class=\"row\"><div class=\"track\"><div class=\"fill\" style=\"width:100%\"></div></div></div>"
+            + "<p>content below the bar</p></body></html>";
+        var pY = ParagraphBaselineY(html);
+        Assert.False(double.IsNaN(pY), "no text found");
+        Assert.True(pY > 700,
+            $"the paragraph below the bar is at y={pY:0.#}pt — a definite-zero content height was "
+            + "replaced by the page budget, so the fill leaked down the page.");
+    }
+
+    // The last text baseline's y (the `<p>` below the bar), robust to Tm/Td/TD operator form.
+    private static double ParagraphBaselineY(string html)
+    {
         var pdf = Encoding.Latin1.GetString(
             HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
-
-        // Layout-level check (robust to paint-operator form): the `<p>` sits directly below the 18px
-        // bar, so its text baseline is near the TOP of the A4 content area (~768pt = 796 top − 18px
-        // bar − a line). Before the fix, the fill's height:100% resolved against the page (~750pt), so
-        // the bar box was ~750px tall and pushed the `<p>` to the BOTTOM of the page (small y).
         double pY = double.NaN;
         foreach (Match sm in Regex.Matches(pdf, @"stream\r?\n(.*?)\r?\nendstream", RegexOptions.Singleline))
         {
@@ -50,9 +95,6 @@ public sealed class FlexDefiniteHeightPercentChildTests
                 if (td.Success) pY = double.Parse(td.Groups[2].Value, CultureInfo.InvariantCulture);
             }
         }
-        Assert.False(double.IsNaN(pY), "no text found");
-        Assert.True(pY > 700,
-            $"the paragraph below the bar is at y={pY:0.#}pt — it was pushed toward the page bottom "
-            + "because the height:100% bar-fill resolved against the page instead of the 18px track.");
+        return pY;
     }
 }

--- a/tests/NetPdf.UnitTests/Rendering/MaxWidthAutoMarginCenteringTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/MaxWidthAutoMarginCenteringTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Roland Aroche and NetPdf contributors.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -13,37 +14,99 @@ namespace NetPdf.UnitTests.Rendering;
 /// Corpus-fidelity (11 certificate `.citation`). A block whose used width comes from <c>max-width</c>
 /// (auto width clamped below the available range) with <c>margin: 0 auto</c> must be CENTERED
 /// (CSS 2.2 §10.3.3 + §10.4) — not left-aligned. Before the fix, auto-margin distribution fired only
-/// for an EXPLICIT width, so a max-width-clamped auto-width block stayed at the left. Covered for both
-/// a text-bearing (inline-only) block and an empty one; both must center like an explicit-width block.
+/// for an EXPLICIT width, so a max-width-clamped auto-width block stayed at the left.
+///
+/// The geometry is asserted against the ACTUAL content box (discovered from a full-width baseline
+/// block), so the used width and centered left-x are pinned exactly — not merely "it moved right".
 /// </summary>
 public sealed class MaxWidthAutoMarginCenteringTests
 {
-    private static double BlockLeftX(string html)
+    // (leftX, width) of the single solid `.c` background rect, in PDF user units (pt).
+    private static (double X, double W) BlockRect(string html)
     {
         var pdf = Encoding.Latin1.GetString(
             HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
-        // The block's background rect is ~300px (225pt) wide; return its left x.
-        foreach (Match m in Regex.Matches(pdf, @"(-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) re\s+f"))
+        (double X, double W) best = (double.NaN, -1);
+        foreach (Match m in Regex.Matches(pdf,
+            @"(-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) re\s+f"))
         {
             var w = double.Parse(m.Groups[3].Value, CultureInfo.InvariantCulture);
-            if (w > 180 && w < 260) return double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+            var h = double.Parse(m.Groups[4].Value, CultureInfo.InvariantCulture);
+            // Skip hairlines; the `.c` fill is the widest real rect (only one bg block per doc).
+            if (h > 5 && w > 40 && w > best.W)
+                best = (double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture), w);
         }
-        return double.NaN;
+        return best;
+    }
+
+    // The content box [L, L+CW] discovered from an auto-width block that fills the whole content area.
+    private static (double L, double CW) ContentBox()
+    {
+        var (x, w) = BlockRect(
+            "<style>.c{background:#e5e5e5}</style><div class=\"c\">full width baseline block</div>");
+        return (x, w);
     }
 
     [Theory]
+    // Text-bearing (inline-only) block — the corpus `.citation` shape.
     [InlineData("<style>.c{background:#e5e5e5;max-width:300px;margin:0 auto}</style>"
-        + "<div class=\"c\">text long enough to reach the max width limit right here now yes indeed ok</div>")]
+        + "<div class=\"c\">text long enough to reach the max width limit right here now yes indeed ok</div>",
+        225.0)]
     // Block-children (general recursion path) — a child <p> gives the wrapper height + a paint rect.
     [InlineData("<style>.c{background:#e5e5e5;max-width:300px;margin:0 auto}.c p{margin:0}</style>"
-        + "<div class=\"c\"><p>block child content reaching the max-width bound here now ok yes</p></div>")]
-    public void Max_width_block_with_auto_margins_is_centered(string html)
+        + "<div class=\"c\"><p>block child content reaching the max-width bound here now ok yes</p></div>",
+        225.0)]
+    public void Max_width_block_with_auto_margins_is_centered(string html, double expectedWidthPt)
     {
-        // An A4 content area is ~595pt − 2×~45pt margins; a centered 225pt (300px) block starts at
-        // ~(595 − 225)/2 ≈ 185pt. A left-aligned block starts at the content-left (~45–75pt).
-        var x = BlockLeftX(html);
+        var (l, cw) = ContentBox();
+        var (x, w) = BlockRect(html);
         Assert.False(double.IsNaN(x), "no block background rect found");
-        Assert.True(x > 150,
-            $"max-width block left x={x:0.#}pt — it was left-aligned, not centered by margin:0 auto.");
+        // 300px == 225pt; the auto-width block clamps to the max-width.
+        Assert.True(System.Math.Abs(w - expectedWidthPt) < 2,
+            $"used width={w:0.#}pt, expected ~{expectedWidthPt:0.#}pt (max-width clamp).");
+        var expectedX = l + (cw - w) / 2.0;
+        Assert.True(System.Math.Abs(x - expectedX) < 2,
+            $"left x={x:0.#}pt, expected centered ~{expectedX:0.#}pt (content box L={l:0.#}, CW={cw:0.#}).");
+    }
+
+    [Fact]
+    public void Max_width_percent_block_with_auto_margins_is_centered()
+    {
+        var (l, cw) = ContentBox();
+        var (x, w) = BlockRect(
+            "<style>.c{background:#e5e5e5;max-width:50%;margin:0 auto}</style>"
+            + "<div class=\"c\">a fifty percent max-width block centered by auto margins ok yes indeed</div>");
+        Assert.True(System.Math.Abs(w - cw * 0.5) < 2,
+            $"used width={w:0.#}pt, expected ~{cw * 0.5:0.#}pt (50% of content box CW={cw:0.#}).");
+        var expectedX = l + (cw - w) / 2.0;
+        Assert.True(System.Math.Abs(x - expectedX) < 2,
+            $"left x={x:0.#}pt, expected centered ~{expectedX:0.#}pt.");
+    }
+
+    [Fact]
+    public void Max_width_block_with_one_sided_auto_margin_is_right_aligned()
+    {
+        var (l, cw) = ContentBox();
+        var (x, w) = BlockRect(
+            "<style>.c{background:#e5e5e5;max-width:300px;margin-left:auto;margin-right:0}</style>"
+            + "<div class=\"c\">a max-width block pushed to the right by a single auto left margin ok</div>");
+        Assert.True(System.Math.Abs(w - 225.0) < 2, $"used width={w:0.#}pt, expected ~225pt.");
+        // margin-left:auto absorbs ALL the free space → block sits flush at the content-right edge.
+        var expectedX = l + (cw - w);
+        Assert.True(System.Math.Abs(x - expectedX) < 2,
+            $"left x={x:0.#}pt, expected right-aligned ~{expectedX:0.#}pt (R−W).");
+    }
+
+    [Fact]
+    public void Non_clamping_max_width_100pct_with_auto_margins_fills_and_does_not_shift()
+    {
+        var (l, cw) = ContentBox();
+        var (x, w) = BlockRect(
+            "<style>.c{background:#e5e5e5;max-width:100%;margin:0 auto}</style>"
+            + "<div class=\"c\">a max-width 100 percent block that does not clamp and keeps full width</div>");
+        // max-width:100% doesn't clamp auto width → used width == content width, no free space to
+        // distribute → left x stays at the content-left (auto margins resolve to 0).
+        Assert.True(System.Math.Abs(w - cw) < 2, $"used width={w:0.#}pt, expected full CW={cw:0.#}pt.");
+        Assert.True(System.Math.Abs(x - l) < 2, $"left x={x:0.#}pt, expected content-left ~{l:0.#}pt.");
     }
 }

--- a/tests/NetPdf.UnitTests/Rendering/MaxWidthAutoMarginCenteringTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/MaxWidthAutoMarginCenteringTests.cs
@@ -1,0 +1,49 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// Corpus-fidelity (11 certificate `.citation`). A block whose used width comes from <c>max-width</c>
+/// (auto width clamped below the available range) with <c>margin: 0 auto</c> must be CENTERED
+/// (CSS 2.2 §10.3.3 + §10.4) — not left-aligned. Before the fix, auto-margin distribution fired only
+/// for an EXPLICIT width, so a max-width-clamped auto-width block stayed at the left. Covered for both
+/// a text-bearing (inline-only) block and an empty one; both must center like an explicit-width block.
+/// </summary>
+public sealed class MaxWidthAutoMarginCenteringTests
+{
+    private static double BlockLeftX(string html)
+    {
+        var pdf = Encoding.Latin1.GetString(
+            HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        // The block's background rect is ~300px (225pt) wide; return its left x.
+        foreach (Match m in Regex.Matches(pdf, @"(-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) re\s+f"))
+        {
+            var w = double.Parse(m.Groups[3].Value, CultureInfo.InvariantCulture);
+            if (w > 180 && w < 260) return double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+        }
+        return double.NaN;
+    }
+
+    [Theory]
+    [InlineData("<style>.c{background:#e5e5e5;max-width:300px;margin:0 auto}</style>"
+        + "<div class=\"c\">text long enough to reach the max width limit right here now yes indeed ok</div>")]
+    // Block-children (general recursion path) — a child <p> gives the wrapper height + a paint rect.
+    [InlineData("<style>.c{background:#e5e5e5;max-width:300px;margin:0 auto}.c p{margin:0}</style>"
+        + "<div class=\"c\"><p>block child content reaching the max-width bound here now ok yes</p></div>")]
+    public void Max_width_block_with_auto_margins_is_centered(string html)
+    {
+        // An A4 content area is ~595pt − 2×~45pt margins; a centered 225pt (300px) block starts at
+        // ~(595 − 225)/2 ≈ 185pt. A left-aligned block starts at the content-left (~45–75pt).
+        var x = BlockLeftX(html);
+        Assert.False(double.IsNaN(x), "no block background rect found");
+        Assert.True(x > 150,
+            $"max-width block left x={x:0.#}pt — it was left-aligned, not centered by margin:0 auto.");
+    }
+}


### PR DESCRIPTION
Two root-caused, tested layout fixes from your latest corpus review (both **pre-existing**, repro'd at `4d151f4` — not regressions; all repo golden suites byte-identical).

## 08-sales-report — bar-fill gradient bled down the whole page (most severe)

`.bar-fill { height:100% }` inside a fixed-height row flex item (`.bar-track { flex:1; height:18px; overflow:hidden }`) painted its gradient (and clip) **~751pt down the entire page** instead of the 18px track — and the blown-up box forced page overflow.

Cause: `MeasureFlexItemContents` measured every item's content with the **page-sized** block budget, and the nested layouter uses its fragmentainer block-size as the percentage-**height** base for the item's children — so `height:100%` resolved against the page, not the item. Fix: a definite-cross row flex item passes its **content cross-size** (18px) as the nested measure's block budget. `FlexDefiniteHeightPercentChildTests`.

## 11-certificate — `.citation` intro text not centered

A block whose used width comes from `max-width` with `margin:0 auto` (the `.citation`) was left-aligned. Auto-margin distribution fired only for an **explicit** `width`; an auto-width box clamped by `max-width` kept the fill behavior. Fix: distribute auto-margins for an explicit width **or** an explicit max-width (the passed border-box is already max-width-clamped → byte-identical when it doesn't clamp). Applied to both the general block path and the inline-only-block metrics (which text blocks like `.citation` use and which skipped auto-margins entirely). `MaxWidthAutoMarginCenteringTests`.

## Gate

0-warn build · 8510 unit · LayoutSnapshots/PaginationGolden/RenderingCorpus/RealDocuments byte-identical · AOT parity verified · fuzz 0 findings. (CI is billing-blocked — jobs fail in ~2s with zero steps; gate run locally.)

## Not in this PR — remaining review items (honest status)

- **invoice-05/07 "AMOUNT DUE BY" no padding** — non-replaced inline-box horizontal margin (`.total-line span { margin-right:28px }`) is **unimplemented** (`CollectInlineTextRuns` recurses into a `<span>` without its edge margins/border/padding). This is a genuine feature (inline-box edges) with justify/wrapping interactions — deserves its own focused PR, not a rushed spacer.
- **11 recipient name font** (`Snell Roundhand`/`Apple Chancery`/… cursive) — a font-availability limitation; needs a bundled script font to match. Not fixable in layout.
- **11 ID `DE-04187` over the border line** + **12 logo / section whitespace / "Wanderlux…" behind the line** — minor per-doc polish; each needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)