### PR TITLE
WP-1: RC-9 phantom anonymous blocks — drop inter-tag whitespace + fix cell double-padding

### DIFF
--- a/src/NetPdf.Layout/Boxes/BoxBuilder.cs
+++ b/src/NetPdf.Layout/Boxes/BoxBuilder.cs
@@ -936,7 +936,7 @@ internal static class BoxBuilder
     /// run is preserved (returns <see langword="false"/>) if it contains any inline-level element box
     /// (its <see cref="Box.Text"/> is empty, so it is never "whitespace"), any text run with a
     /// non-whitespace character, or any text run whose <c>white-space</c> preserves whitespace
-    /// (pre / pre-wrap / pre-line / break-spaces — keyword ids 1/3/4/5; only normal=0 and nowrap=2
+    /// (pre / pre-wrap / break-spaces / pre-line — keyword ids 1/3/4/5; only normal=0 and nowrap=2
     /// collapse).</summary>
     private static bool IsCollapsibleWhitespaceOnlyRun(List<Box> run)
     {

--- a/src/NetPdf.Layout/Boxes/BoxBuilder.cs
+++ b/src/NetPdf.Layout/Boxes/BoxBuilder.cs
@@ -899,6 +899,23 @@ internal static class BoxBuilder
         static void FlushRun(Box parent, ref List<Box>? run)
         {
             if (run is null || run.Count == 0) return;
+            // CSS 2.1 §9.2.2.1 — a sequence of inline content between block-level siblings that is
+            // ONLY collapsible white-space generates NO box at all (it would collapse away). Pretty-
+            // printed HTML puts a newline+indent between every pair of block children; without this
+            // each such run became a phantom AnonymousBlock that REUSES the parent's ComputedStyle by
+            // reference (below) and therefore charged the parent's own MARGIN once per whitespace run
+            // (the measure pass already zeroes an anonymous box's border/padding/height — see
+            // BlockLayouter ~L9894 — but not its margin, and the emit paths do not zero it either),
+            // inflating vertical layout and pushing content onto extra pages (RC-9). Mirrors the flex
+            // (FlushFlexTextRun) and table (StripWhitespaceTextRuns) whitespace-dropping already done
+            // elsewhere. Gated on collapsing white-space so pre / pre-wrap / pre-line / break-spaces
+            // keep their significant whitespace; a run with ANY inline element or non-whitespace text
+            // (e.g. `<span>a</span> <span>b</span>`) is preserved whole.
+            if (IsCollapsibleWhitespaceOnlyRun(run))
+            {
+                run = null;
+                return;
+            }
             // The anonymous block REUSES the parent's style REF on purpose: the anonymous direct-text
             // runs also reuse it (BoxBuilder text-run creation), and InlineVerticalAlign detects
             // "block-direct text" by ReferenceEquals(runStyle, blockStyle) to suppress a cell's/block's
@@ -911,6 +928,26 @@ internal static class BoxBuilder
             parent.AppendChild(wrapper);
             run = null;
         }
+    }
+
+    /// <summary><see langword="true"/> when every box in <paramref name="run"/> is a
+    /// <see cref="BoxKind.TextRun"/> holding only collapsible white-space — i.e. the whole run would
+    /// collapse to nothing per CSS 2.1 §9.2.2.1 and must generate no anonymous block box (RC-9). A
+    /// run is preserved (returns <see langword="false"/>) if it contains any inline-level element box
+    /// (its <see cref="Box.Text"/> is empty, so it is never "whitespace"), any text run with a
+    /// non-whitespace character, or any text run whose <c>white-space</c> preserves whitespace
+    /// (pre / pre-wrap / pre-line / break-spaces — keyword ids 1/3/4/5; only normal=0 and nowrap=2
+    /// collapse).</summary>
+    private static bool IsCollapsibleWhitespaceOnlyRun(List<Box> run)
+    {
+        foreach (var c in run)
+        {
+            if (c.Kind != BoxKind.TextRun) return false;
+            if (!IsWhitespaceOnly(c.Text)) return false;
+            var whiteSpace = c.Style.ReadKeywordOrDefault(PropertyId.WhiteSpace, defaultIndex: 0);
+            if (whiteSpace is not (0 or 2)) return false;
+        }
+        return true;
     }
 
     /// <summary><see langword="true"/> when <paramref name="kind"/> establishes

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7328,6 +7328,27 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     private static InlineOnlyBlockMetrics ReadInlineOnlyBlockMetrics(
         Box block, double containingInlinePx, MeasurePurpose measurePurpose)
     {
+        // An AnonymousBlock wrapper (whitespace / block-in-inline fixup, or the inline-only
+        // table-cell wrapper — BoxBuilder.FixupAnonymousBlocks) REUSES its real parent's
+        // ComputedStyle by reference, so reading margin / border / padding / width off block.Style
+        // here would charge the PARENT's own box model to a box that PAINTS none — double-counting
+        // the parent's chrome. This is the RC-9 sub-bug: a `<td>` with inline-only content wraps
+        // its text in an AnonymousBlock carrying the cell's style, so the cell's padding was emitted
+        // TWICE (once on the cell, once on the wrapper) → inflated row heights. The painter skips
+        // anonymous-box decorations and the measure pass already zeroes this chrome (see the
+        // AnonymousBlock guard in the measure recursion ~L9894); mirror it here so the EMIT read and
+        // the measure agree. The wrapper's inherited line-height still governs its wrapped text.
+        if (block.Kind == BoxKind.AnonymousBlock)
+        {
+            return new(
+                MarginInlineStart: 0, MarginInlineEnd: 0, MarginBlockStart: 0, MarginBlockEnd: 0,
+                BorderInlineStart: 0, BorderInlineEnd: 0, BorderBlockStart: 0, BorderBlockEnd: 0,
+                PaddingInlineStart: 0, PaddingInlineEnd: 0, PaddingBlockStart: 0, PaddingBlockEnd: 0,
+                DeclaredWidthPx: 0,
+                LineHeightOverridePx: block.Style.ReadLineHeightPx(
+                    block.Style.ReadLengthPxOrDefault(PropertyId.FontSize, defaultPx: 16)));
+        }
+
         // Rewrite % padding to used px FIRST (body-percent cycle) — TextPainter's content-origin
         // inset reads the same slots at paint time. Only a real layout PERSISTS; a dropped measure
         // leaves the slot Percentage so the speculative containing size never reaches the shared

--- a/tests/NetPdf.LayoutSnapshots/Fixtures/01-simple-paragraph/box-tree.txt
+++ b/tests/NetPdf.LayoutSnapshots/Fixtures/01-simple-paragraph/box-tree.txt
@@ -3,5 +3,3 @@ Root
     BlockContainer @element=body
       BlockContainer @element=p
         TextRun @element=p "Hello world."
-      AnonymousBlock
-        TextRun @element=body "\n"

--- a/tests/NetPdf.LayoutSnapshots/Fixtures/02-list-with-markers/box-tree.txt
+++ b/tests/NetPdf.LayoutSnapshots/Fixtures/02-list-with-markers/box-tree.txt
@@ -14,5 +14,3 @@ Root
           Marker @element=li ::marker
             TextRun @element=li "3. "
           TextRun @element=li "third"
-      AnonymousBlock
-        TextRun @element=body "\n"

--- a/tests/NetPdf.LayoutSnapshots/Fixtures/03-table-with-caption/box-tree.txt
+++ b/tests/NetPdf.LayoutSnapshots/Fixtures/03-table-with-caption/box-tree.txt
@@ -25,5 +25,3 @@ Root
               TableCell @element=td
                 AnonymousBlock
                   TextRun @element=td "Total: 100"
-      AnonymousBlock
-        TextRun @element=body "\n"

--- a/tests/NetPdf.LayoutSnapshots/Fixtures/04-var-and-calc/box-tree.txt
+++ b/tests/NetPdf.LayoutSnapshots/Fixtures/04-var-and-calc/box-tree.txt
@@ -3,5 +3,3 @@ Root
     BlockContainer @element=body
       BlockContainer @element=p
         TextRun @element=p "spacing test"
-      AnonymousBlock
-        TextRun @element=body "\n"

--- a/tests/NetPdf.LayoutSnapshots/Fixtures/05-pseudo-with-attr/box-tree.txt
+++ b/tests/NetPdf.LayoutSnapshots/Fixtures/05-pseudo-with-attr/box-tree.txt
@@ -7,5 +7,3 @@ Root
         TextRun @element=p "item description"
         InlineBox @element=p ::after
           TextRun @element=p "."
-      AnonymousBlock
-        TextRun @element=body "\n"

--- a/tests/NetPdf.LayoutSnapshots/Fixtures/06-hidden-and-aria/box-tree.txt
+++ b/tests/NetPdf.LayoutSnapshots/Fixtures/06-hidden-and-aria/box-tree.txt
@@ -9,5 +9,3 @@ Root
             TextRun @element=p "aria-hidden body"
         BlockContainer @element=p
           TextRun @element=p "visible body"
-      AnonymousBlock
-        TextRun @element=body "\n"

--- a/tests/NetPdf.UnitTests/Layout/Boxes/BoxBuilderTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/Boxes/BoxBuilderTests.cs
@@ -344,6 +344,77 @@ public sealed class BoxBuilderTests
     }
 
     // ============================================================
+    // RC-9 — collapsible inter-tag whitespace generates NO box
+    // (CSS 2.1 §9.2.2.1). Pretty-printed HTML must not synthesize
+    // phantom AnonymousBlocks between block siblings.
+    // ============================================================
+
+    [Fact]
+    public async Task Whitespace_only_run_between_block_siblings_generates_no_anonymous_block()
+    {
+        // Pretty-printed: newline + indent between each pair of <p>. Those
+        // collapsible-whitespace runs must NOT become AnonymousBlocks.
+        var root = await BuildAsync("<div>\n  <p>a</p>\n  <p>b</p>\n  <p>c</p>\n</div>");
+        var div = FindFirst(root, "div")!;
+        Assert.Equal(3, div.Children.Count);
+        foreach (var child in div.Children)
+        {
+            Assert.Equal(BoxKind.BlockContainer, child.Kind);
+            Assert.Equal("p", child.SourceElement!.LocalName);
+        }
+    }
+
+    [Fact]
+    public async Task Pretty_printed_and_tight_markup_produce_the_same_box_tree()
+    {
+        var pretty = await BuildAsync("<div>\n  <p>a</p>\n  <p>b</p>\n</div>");
+        var tight = await BuildAsync("<div><p>a</p><p>b</p></div>");
+        var prettyDiv = FindFirst(pretty, "div")!;
+        var tightDiv = FindFirst(tight, "div")!;
+        Assert.Equal(tightDiv.Children.Count, prettyDiv.Children.Count);
+        Assert.Equal(2, prettyDiv.Children.Count);
+    }
+
+    [Fact]
+    public async Task Whitespace_run_is_preserved_under_white_space_pre()
+    {
+        // white-space: pre preserves the inter-tag whitespace, so the run
+        // between the blocks DOES generate an anonymous block.
+        var root = await BuildAsync(
+            "<div>\n  <p>a</p>\n  <p>b</p>\n</div>",
+            "div { white-space: pre }");
+        var div = FindFirst(root, "div")!;
+        Assert.Contains(div.Children, c => c.Kind == BoxKind.AnonymousBlock);
+    }
+
+    [Fact]
+    public async Task Run_with_inline_elements_and_spaces_is_preserved_between_blocks()
+    {
+        // `<span>a</span> <span>b</span>` between two blocks is NOT
+        // whitespace-only (it carries inline element boxes + a significant
+        // space), so it must be wrapped, not dropped.
+        var root = await BuildAsync(
+            "<div><p>x</p><span>a</span> <span>b</span><p>y</p></div>");
+        var div = FindFirst(root, "div")!;
+        var wrapper = div.Children.Single(c => c.Kind == BoxKind.AnonymousBlock);
+        // The wrapper keeps both spans (and the separating space run).
+        Assert.Contains(wrapper.Children, c => c.SourceElement?.LocalName == "span");
+        Assert.True(wrapper.Children.Count >= 2);
+    }
+
+    [Fact]
+    public async Task Inline_only_table_cell_still_wraps_its_text_after_whitespace_fix()
+    {
+        // Regression guard: the RC-9 whitespace drop must not remove a cell's
+        // real text. `<td>Widget</td>` content stays wrapped in an anonymous
+        // block (CSS Tables L3 §11.5.3 cell content is block-level).
+        var root = await BuildAsync("<table><tr><td>Widget</td></tr></table>");
+        var cell = FindFirst(root, "td")!;
+        var anon = cell.Children.Single(c => c.Kind == BoxKind.AnonymousBlock);
+        Assert.Equal("Widget", anon.Children[0].Text);
+    }
+
+    // ============================================================
     // Style sharing + box-ownership
     // ============================================================
 

--- a/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
+++ b/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
@@ -59,7 +59,10 @@ public sealed class PerformanceGateTests
     [Trait("Category", "Performance")]
     public void Report_20_page_renders_within_1500ms_p50()
     {
-        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Report(sections: 22, rowsPerSection: 18),
+        // rowsPerSection recalibrated 18 → 34 after RC-9 (WP-1): the cell double-padding fix removed the
+        // ~1.5–2× row-height inflation, so the old 22×18 fixture now lays out in ~11 pages. 22×34 restores
+        // the intended ~22-page (exit-criterion-7) workload against the corrected, un-inflated row height.
+        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Report(sections: 22, rowsPerSection: 34),
             warmup: 2, iters: 7);
         // Bound BOTH sides: the deterministic synthetic fixture lands at a fixed page count, so a regression
         // that duplicates pages or over-fragments (→ 30-40 pages) must fail even if it stays under 1.5 s —
@@ -242,7 +245,8 @@ internal static class PerfFixtures
     }
 
     /// <summary>A paginating multi-section tabular report (each section a heading + a small table; the
-    /// tables fragment across pages). 22 sections × 18 rows ≈ 22 pages.</summary>
+    /// tables fragment across pages). 22 sections × 34 rows ≈ 22 pages with correct (un-inflated) row
+    /// heights — see the rowsPerSection note at the call site (RC-9 cell double-padding fix).</summary>
     internal static string Report(int sections, int rowsPerSection)
     {
         var sb = new StringBuilder("<!DOCTYPE html><html><head><style>"

--- a/tests/NetPdf.UnitTests/Rendering/PhantomAnonBlockRc9Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/PhantomAnonBlockRc9Tests.cs
@@ -1,0 +1,94 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-9 — phantom anonymous blocks from inter-tag whitespace. Pretty-printed HTML puts a
+/// newline+indent between every pair of block siblings; before the fix each such collapsible-
+/// whitespace run became an <c>AnonymousBlock</c> that REUSED the parent's ComputedStyle, charging
+/// the parent's own margin once per run (the measure pass zeroed border/padding/height but not the
+/// margin) and, for inline-only table cells, double-counting the cell's padding. Both inflated
+/// vertical layout and pushed content onto extra pages. These render-level tests assert the
+/// pretty-printed geometry now matches the equivalent tight markup.
+/// </summary>
+public sealed class PhantomAnonBlockRc9Tests
+{
+    // Bottom-most text baseline Y in the (uncompressed facade) content stream.
+    private static double BottomTextY(byte[] pdf)
+    {
+        var s = Encoding.Latin1.GetString(pdf);
+        double min = double.MaxValue;
+        foreach (Match m in Regex.Matches(s, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td"))
+        {
+            var y = double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
+            if (y < min) min = y;
+        }
+        return min;
+    }
+
+    // Tallest content rectangle ("x y w h re") — the cell border/background box.
+    private static double TallestRectHeight(byte[] pdf)
+    {
+        var s = Encoding.Latin1.GetString(pdf);
+        double max = 0;
+        foreach (Match m in Regex.Matches(
+            s, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+re"))
+        {
+            var h = Math.Abs(double.Parse(m.Groups[4].Value, CultureInfo.InvariantCulture));
+            if (h > max && h < 400) max = h; // exclude full-page fills
+        }
+        return max;
+    }
+
+    private const string MarginPretty =
+        "<!doctype html><html><head><style>body{margin:0;font-size:14px}"
+        + ".c{margin-bottom:60px}</style></head><body>"
+        + "<div class=\"c\">\n  <div>A</div>\n  <div>B</div>\n  <div>C</div>\n</div>"
+        + "<div>after</div></body></html>";
+
+    private const string MarginTight =
+        "<!doctype html><html><head><style>body{margin:0;font-size:14px}"
+        + ".c{margin-bottom:60px}</style></head><body>"
+        + "<div class=\"c\"><div>A</div><div>B</div><div>C</div></div>"
+        + "<div>after</div></body></html>";
+
+    [Fact]
+    public void Pretty_printed_blocks_do_not_inflate_layout_via_container_margin()
+    {
+        var pretty = BottomTextY(HtmlPdf.ConvertDetailed(MarginPretty).Pdf);
+        var tight = BottomTextY(HtmlPdf.ConvertDetailed(MarginTight).Pdf);
+        // Before the fix the pretty-printed "after" text sat lower on the page by
+        // (whitespace-run count) x 60px. Now the two are identical.
+        Assert.Equal(tight, pretty, precision: 1);
+    }
+
+    [Fact]
+    public void Inline_only_table_cell_does_not_double_count_its_padding()
+    {
+        const string inlineOnly =
+            "<!doctype html><html><head><style>body{margin:0;font-size:12px}"
+            + "table{border-collapse:collapse}td{border:1px solid #000;padding:10px}"
+            + "</style></head><body><table><tr><td>Xy</td></tr></table></body></html>";
+        const string blockChild =
+            "<!doctype html><html><head><style>body{margin:0;font-size:12px}"
+            + "table{border-collapse:collapse}td{border:1px solid #000;padding:10px}.b{margin:0}"
+            + "</style></head><body><table><tr><td><div class=\"b\">Xy</div></td></tr></table></body></html>";
+
+        var inlineOnlyH = TallestRectHeight(HtmlPdf.ConvertDetailed(inlineOnly).Pdf);
+        var blockChildH = TallestRectHeight(HtmlPdf.ConvertDetailed(blockChild).Pdf);
+        // The inline-only cell (whose text is wrapped in an anonymous block sharing the
+        // cell's style) must be the SAME height as the explicit-block-child cell; before
+        // the fix it was taller by ~one padding box (the wrapper re-applied the padding).
+        Assert.True(inlineOnlyH > 0 && blockChildH > 0, "expected cell rectangles in both renders");
+        Assert.Equal(blockChildH, inlineOnlyH, precision: 1);
+    }
+}

--- a/tests/NetPdf.UnitTests/Rendering/PhantomAnonBlockRc9Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/PhantomAnonBlockRc9Tests.cs
@@ -27,11 +27,16 @@ public sealed class PhantomAnonBlockRc9Tests
     {
         var s = Encoding.Latin1.GetString(pdf);
         double min = double.MaxValue;
+        var matches = 0;
         foreach (Match m in Regex.Matches(s, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td"))
         {
+            matches++;
             var y = double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture);
             if (y < min) min = y;
         }
+        // Guard against a false-positive equality where two PDFs both simply lack any
+        // text-position operator (both would return double.MaxValue and compare equal).
+        Assert.True(matches > 0, "expected at least one 'Td' text-position operator in the content stream");
         return min;
     }
 


### PR DESCRIPTION
Second release-readiness work package (RC-9 — the CRITICAL one; "the biggest single win" per the findings). Fixes the dominant source of the corpus's *"too much white space"* and wrong-page-count complaints.

> Branches off `main` (independent of the WP-8 packaging PR #285). Later layout WPs will stack on this one.

## The bug (RC-9)
`BoxBuilder.FixupAnonymousBlocks` wraps every run of inline content between block-level siblings in an `AnonymousBlock` that **reuses the parent's `ComputedStyle` by reference**. Two consequences:

1. **Phantom whitespace blocks.** Pretty-printed HTML has a newline+indent between every pair of block children. Each such collapsible-whitespace run became a phantom block that charged the parent's own **margin** once per run (the measure pass zeroes an anonymous box's border/padding/height at `BlockLayouter` ~L9894, but not its margin; the emit path zeroed neither). Result: inflated vertical layout → content pushed onto extra pages.
2. **Cell double-padding (whitespace-independent).** An inline-only `<td>` wraps its text in an `AnonymousBlock` carrying the **cell's** style, so the cell's padding was emitted **twice** → row heights inflated ~1.5–2×.

## The fixes
- **FIX 1** — `FixupAnonymousBlocks.FlushRun` drops a flushed run when every box is a whitespace-only `TextRun` whose `white-space` collapses (`normal`/`nowrap`; `pre`/`pre-wrap`/`pre-line`/`break-spaces` preserve). A run with any inline element or real text (`<span>a</span> <span>b</span>`) is kept whole. This is CSS 2.1 §9.2.2.1 and mirrors the existing flex/table whitespace stripping.
- **FIX 2** — `ReadInlineOnlyBlockMetrics` (the single emit-path source of truth for inline-only block box-model) early-returns zeroed margin/border/padding/width for `BoxKind.AnonymousBlock`, mirroring the measure guard.

## Proof (repro harness)
| case | before | after |
|---|---|---|
| container `margin-bottom` N, 3 whitespace-separated blocks | following content pushed down 3×N px (N∈{0,26,100}) | **0** |
| inline-only `<td>` cell height (padding 10px) | 43.8px | **27.3px** (== explicit-block-child cell) |
| 22-section × 18-row report | 22 pages | **11 pages** (correct, un-inflated rows) |

## Tests & verification
- **Unit** — `BoxBuilderTests`: 5 box-tree facts (whitespace dropped; pretty == tight; `white-space: pre` preserved; span+space run kept; cell text kept).
- **Integration** — `Rendering/PhantomAnonBlockRc9Tests`: 2 render facts (no margin inflation; cell padding not double-counted).
- **Re-pinned** 6 `LayoutSnapshots` box-trees — each drops exactly one phantom `AnonymousBlock > TextRun "\n"`; fixture 03 correctly keeps the real cell-content wrapper.
- **Perf fixture recalibrated** 22×18 → 22×34: the row-height fix compacts the old fixture to 11 pages, so 22×34 restores the intended ~22-page exit-criterion-7 workload (p50 ~220ms, well under the 1.5s gate).
- **Full suite green**: `dotnet test NetPdf.slnx -c Release` → 0 failed (UnitTests 8521 passed, LayoutSnapshots/RenderingCorpus/RealDocuments/W3cConformance/PaginationGolden/PdfValidation all pass).

## Corpus impact (expected, per the findings)
Certificate 2→1 page, sales-report gaps closed, invoice-10 5→~3 pages, trailing paragraphs pull up to their tables, row pitch corrected. (Visual corpus goldens compare within tolerance against Chrome refs and stayed green — the fix moves output *toward* Chrome.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)