### PR TITLE
WP-2: RC-UA — built-in user-agent stylesheet

### DIFF
--- a/src/NetPdf/Phase2/Phase2Pipeline.cs
+++ b/src/NetPdf/Phase2/Phase2Pipeline.cs
@@ -203,7 +203,10 @@ internal static class Phase2Pipeline
         // supplies heading sizes/weights/margins, b/strong/th bold, em/i italic, list indentation,
         // th centering, etc. that were otherwise missing on un-styled HTML.
         output.Add(UserAgentStylesheet.Instance);
-        var order = 0;
+        // The UA sheet occupies source-order index 0 (see UserAgentStylesheet.Build), so author
+        // sheets start at 1 — Order is a GLOBAL, unique source-order index across all stylesheets
+        // and anything that keys by it (diagnostics, sheet pinning) must not see a duplicate 0.
+        var order = 1;
         foreach (var rawSheet in document.StyleSheets.OfType<ICssStyleSheet>())
         {
             // Per Rec 6: pair via OwnerNode rather than ordinal index. When

--- a/src/NetPdf/Phase2/Phase2Pipeline.cs
+++ b/src/NetPdf/Phase2/Phase2Pipeline.cs
@@ -198,6 +198,11 @@ internal static class Phase2Pipeline
     private static ImmutableArray<CssStylesheet> ExtractStylesheets(IDocument document)
     {
         var output = ImmutableArray.CreateBuilder<CssStylesheet>();
+        // The engine's built-in user-agent stylesheet always comes first (RC-UA). It sits at the
+        // CssStylesheetOrigin.UserAgent origin (the lowest), so every author rule overrides it; it
+        // supplies heading sizes/weights/margins, b/strong/th bold, em/i italic, list indentation,
+        // th centering, etc. that were otherwise missing on un-styled HTML.
+        output.Add(UserAgentStylesheet.Instance);
         var order = 0;
         foreach (var rawSheet in document.StyleSheets.OfType<ICssStyleSheet>())
         {

--- a/src/NetPdf/UserAgentStylesheet.cs
+++ b/src/NetPdf/UserAgentStylesheet.cs
@@ -1,0 +1,88 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Threading;
+using AngleSharp;
+using AngleSharp.Css.Dom;
+using AngleSharp.Css.Parser;
+using NetPdf.Css.Parser;
+using NetPdf.Css.Parser.Preprocessing;
+
+namespace NetPdf;
+
+/// <summary>
+/// The engine's built-in user-agent stylesheet (RC-UA / WP-8→WP-2). Before this, the only
+/// element defaults NetPdf applied were DISPLAY types (<c>HtmlDefaultDisplay</c>); everything the
+/// HTML rendering model's UA sheet provides — heading sizes/weights/margins, <c>b</c>/<c>strong</c>/
+/// <c>th</c> bold, <c>em</c>/<c>i</c> italic, list indentation, <c>th</c> centering, etc. — was
+/// missing unless the author set it, so bare <c>&lt;h1&gt;</c>/<c>&lt;strong&gt;</c> rendered at
+/// body size / regular weight.
+/// <para>
+/// <b>Clean-room provenance.</b> The rules below are transcribed from the public specifications —
+/// CSS 2.2 Appendix D "Default style sheet for HTML 4" (https://www.w3.org/TR/CSS22/sample.html)
+/// and the WHATWG HTML Standard §"Rendering" — NOT from any browser's shipped UA sheet. DISPLAY
+/// declarations are intentionally omitted: box display is owned by
+/// <c>NetPdf.Layout.Boxes.HtmlDefaultDisplay</c>, and duplicating it here would create two sources
+/// of truth. Only typographic + box-model defaults live here.
+/// </para>
+/// <para>
+/// Registered at <see cref="CssStylesheetOrigin.UserAgent"/> (the lowest cascade origin, id 0), so
+/// any author rule — even a low-specificity type selector — overrides it. Parsed + adapted ONCE and
+/// cached (the AST is immutable), then prepended to every conversion's stylesheet list.
+/// </para>
+/// </summary>
+internal static class UserAgentStylesheet
+{
+    // Transcribed from CSS 2.2 Appendix D + WHATWG HTML "Rendering". Physical margins/padding
+    // (LTR — the engine's primary writing mode). No `display` (see class doc). Kept small + literal.
+    private const string Css = """
+        h1 { font-size: 2em; font-weight: bold; margin-top: 0.67em; margin-bottom: 0.67em; }
+        h2 { font-size: 1.5em; font-weight: bold; margin-top: 0.83em; margin-bottom: 0.83em; }
+        h3 { font-size: 1.17em; font-weight: bold; margin-top: 1em; margin-bottom: 1em; }
+        h4 { font-size: 1em; font-weight: bold; margin-top: 1.33em; margin-bottom: 1.33em; }
+        h5 { font-size: 0.83em; font-weight: bold; margin-top: 1.67em; margin-bottom: 1.67em; }
+        h6 { font-size: 0.67em; font-weight: bold; margin-top: 2.33em; margin-bottom: 2.33em; }
+        b, strong { font-weight: bold; }
+        i, em, cite, var, dfn, address { font-style: italic; }
+        p { margin-top: 1em; margin-bottom: 1em; }
+        blockquote { margin-top: 1em; margin-bottom: 1em; margin-left: 40px; margin-right: 40px; }
+        figure { margin-top: 1em; margin-bottom: 1em; margin-left: 40px; margin-right: 40px; }
+        ul, ol { margin-top: 1em; margin-bottom: 1em; padding-left: 40px; }
+        dl { margin-top: 1em; margin-bottom: 1em; }
+        dd { margin-left: 40px; }
+        pre { font-family: monospace; white-space: pre; margin-top: 1em; margin-bottom: 1em; }
+        code, kbd, samp, tt { font-family: monospace; }
+        small { font-size: smaller; }
+        sub { font-size: smaller; vertical-align: sub; }
+        sup { font-size: smaller; vertical-align: super; }
+        a { text-decoration: underline; }
+        caption { text-align: center; }
+        th { font-weight: bold; text-align: center; }
+        td, th { padding: 1px; }
+        hr { border-width: 1px; border-style: solid; margin-top: 0.5em; margin-bottom: 0.5em; }
+        """;
+
+    private static readonly CssStylesheet Sheet = Build();
+
+    /// <summary>The cached, adapted UA stylesheet (immutable AST). Prepend to the per-conversion
+    /// sheet list; the cascade sorts it below every author sheet by origin.</summary>
+    public static CssStylesheet Instance => Sheet;
+
+    private static CssStylesheet Build()
+    {
+        var context = BrowsingContext.New(Configuration.Default.WithCss());
+        var parser = context.GetService<ICssParser>()!;
+        ICssStyleSheet raw = parser.ParseStyleSheet(Css);
+        // Run the same preprocessor the author path uses so any declaration AngleSharp would
+        // otherwise drop is recovered identically (harmless here — the sheet is plain).
+        var preprocess = CssPreprocessor.Process(Css);
+        return CssParserAdapter.Adapt(
+            raw, preprocess,
+            href: null,
+            origin: CssStylesheetOrigin.UserAgent,
+            ownerKind: CssStylesheetOwnerKind.Unknown,
+            mediaQuery: null,
+            isDisabled: false,
+            order: 0);
+    }
+}

--- a/tests/NetPdf.UnitTests/Css/UserAgentStylesheetTests.cs
+++ b/tests/NetPdf.UnitTests/Css/UserAgentStylesheetTests.cs
@@ -1,0 +1,102 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using NetPdf;
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.Properties;
+using NetPdf.Layout.Boxes;
+using NetPdf.Layout.Layouters;
+using NetPdf.Phase2;
+using Xunit;
+
+namespace NetPdf.UnitTests.Css;
+
+/// <summary>
+/// RC-UA — the built-in user-agent stylesheet. Before it, un-styled HTML lost every default the
+/// HTML rendering model's UA sheet provides (heading sizes/weights/margins, b/strong/th bold,
+/// em/i italic, list indentation, th centering). These tests drive the real conversion pipeline
+/// (which prepends <see cref="UserAgentStylesheet"/>) and assert the computed values on bare markup,
+/// plus that any author rule overrides the UA default.
+/// </summary>
+public sealed class UserAgentStylesheetTests
+{
+    private static async Task<Box> BuildAsync(string html)
+    {
+        var result = await Phase2Pipeline.RunFromHtmlAsync(html, new HtmlPdfOptions());
+        return result.BoxRoot;
+    }
+
+    private static Box? Find(Box root, string tag)
+    {
+        if (root.SourceElement?.LocalName.Equals(tag, System.StringComparison.OrdinalIgnoreCase) == true)
+            return root;
+        foreach (var c in root.Children)
+        {
+            var hit = Find(c, tag);
+            if (hit is not null) return hit;
+        }
+        return null;
+    }
+
+    [Fact]
+    public async Task Bare_h1_is_bold_and_two_em()
+    {
+        var h1 = Find(await BuildAsync("<h1>Title</h1>"), "h1")!;
+        Assert.Equal(32.0, h1.Style.ReadLengthPxOrDefault(PropertyId.FontSize, 16), precision: 1); // 2em × 16px
+        Assert.Equal(700, h1.Style.ReadFontWeight());
+    }
+
+    [Fact]
+    public async Task Author_font_size_and_weight_override_the_ua_default()
+    {
+        var h1 = Find(await BuildAsync(
+            "<html><head><style>h1{font-size:8px;font-weight:400}</style></head><body><h1>x</h1></body></html>"),
+            "h1")!;
+        Assert.Equal(8.0, h1.Style.ReadLengthPxOrDefault(PropertyId.FontSize, 16), precision: 1);
+        Assert.Equal(400, h1.Style.ReadFontWeight());
+    }
+
+    [Fact]
+    public async Task Strong_is_bold_and_em_is_italic_without_author_css()
+    {
+        var root = await BuildAsync("<p><strong>a</strong><em>b</em></p>");
+        Assert.Equal(700, Find(root, "strong")!.Style.ReadFontWeight());
+        // font-style keyword ids: normal=0, italic=1, oblique=2.
+        Assert.Equal(1, Find(root, "em")!.Style.ReadKeywordOrDefault(PropertyId.FontStyle, 0));
+    }
+
+    [Fact]
+    public async Task Th_is_bold_and_centered()
+    {
+        var th = Find(await BuildAsync("<table><tr><th>H</th></tr></table>"), "th")!;
+        Assert.Equal(700, th.Style.ReadFontWeight());
+        // text-align keyword ids: start=0,end=1,left=2,right=3,center=4,justify=5.
+        Assert.Equal(4, th.Style.ReadKeywordOrDefault(PropertyId.TextAlign, 0));
+    }
+
+    [Fact]
+    public async Task Lists_have_default_left_padding()
+    {
+        var ul = Find(await BuildAsync("<ul><li>x</li></ul>"), "ul")!;
+        Assert.Equal(40.0, ul.Style.ReadLengthPxOrZero(PropertyId.PaddingLeft), precision: 1);
+    }
+
+    [Fact]
+    public void Bare_h1_renders_at_two_em_end_to_end()
+    {
+        // End-to-end through the facade: the h1 glyph run uses a 24pt font (2em × 16px × 0.75 pt/px),
+        // distinct from the 12pt (16px) body text — proving the UA sheet reaches the paint stage.
+        var pdf = HtmlPdf.ConvertDetailed("<h1>Title</h1><p>body</p>").Pdf;
+        var s = Encoding.Latin1.GetString(pdf);
+        var sizes = Regex.Matches(s, @"/[A-Za-z0-9]+ (\d+(?:\.\d+)?) Tf")
+            .Select(m => double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture))
+            .Distinct().ToList();
+        Assert.Contains(sizes, sz => System.Math.Abs(sz - 24.0) < 0.5);
+        Assert.Contains(sizes, sz => System.Math.Abs(sz - 12.0) < 0.5);
+    }
+}

--- a/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
+++ b/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
@@ -49,7 +49,10 @@ public sealed class PerformanceGateTests
     [Trait("Category", "Performance")]
     public void Invoice_3_page_renders_within_200ms_p50()
     {
-        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Invoice(lineItems: 80), warmup: 5, iters: 15);
+        // lineItems recalibrated 80 → 68 after RC-UA (WP-2): the UA stylesheet adds the h1 and <p>
+        // default margins the fixture didn't previously carry, so 80 rows now spill to 4 pages. 68
+        // rows restores the intended clean 3-page (exit-criterion-7) workload.
+        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Invoice(lineItems: 68), warmup: 5, iters: 15);
         Assert.Equal(3, pages);   // the fixture must actually paginate to 3 pages for the gate to be meaningful
         Assert.True(p50 <= 200.0,
             $"Exit criterion 7: the 3-page invoice p50 {p50:F1} ms exceeds the 200 ms gate.");


### PR DESCRIPTION
Third release-readiness work package (RC-UA). Adds the engine's built-in **user-agent stylesheet** — the biggest source of "un-styled HTML looks wrong" findings in the corpus sweep.

> **Stacked on #286 (WP-1).** Base is `wp1-phantom-anon-blocks` so this diff shows only the UA-sheet change. Merge #286 first, then this.

## The gap (RC-UA)
The only element defaults NetPdf applied were **display types** (`HtmlDefaultDisplay`). Everything else the HTML rendering model's UA sheet provides was missing unless the author set it — bare `<h1>` rendered at body size / regular weight, `<strong>`/`<th>` weren't bold, `<em>` wasn't italic, `<ul>`/`<ol>` had no hanging indent. (The cascade *layering* for `CssStylesheetOrigin.UserAgent` already existed and was unit-tested; only the production sheet was missing.)

## The fix
New `UserAgentStylesheet` — a **clean-room** minimal UA sheet transcribed from **CSS 2.2 Appendix D** + **WHATWG HTML "Rendering"** (not from any browser's shipped sheet):
- h1–h6 sizes / weights / margins
- `b`/`strong`/`th` bold; `i`/`em`/`cite`/`var`/`dfn`/`address` italic
- `p`/`blockquote`/`figure`/`ul`/`ol`/`dl`/`dd` margins; `ul`/`ol` `padding-left: 40px`
- `pre`+`code`/`kbd`/`samp` monospace; `small`/`sub`/`sup` `smaller`; `a` underline
- `caption` + `th` `text-align: center`; `td`/`th` `padding: 1px`; `hr`

`display` is intentionally omitted — `HtmlDefaultDisplay` owns it (one source of truth). The sheet is parsed + adapted **once** and cached (immutable AST), then prepended to every conversion at `CssStylesheetOrigin.UserAgent` (origin id 0, the lowest), so **any author rule overrides it**.

## Tests & verification
- `UserAgentStylesheetTests` — 6 facts: bare `h1` = 2em + bold; author `font-size`/`font-weight` overrides the UA default; `strong` bold + `em` italic; `th` bold + centered; `ul` `padding-left` 40px; end-to-end 24pt `h1` glyph run through the facade.
- Recalibrated the 3-page invoice perf fixture **80 → 68** line items: the UA `h1`/`<p>` default margins (which the fixture didn't previously carry) push 80 rows to 4 pages, so 68 restores the intended 3-page exit-criterion-7 workload.
- **Full suite green** — UnitTests 8527 passed; `LayoutSnapshots`/`RenderingCorpus`/`RealDocuments` unaffected (the sheet changes computed values, not box structure, and the styled corpus sets its own rules). **0** unsupported-property diagnostics from the sheet.

## Corpus impact
Fixes the "UA-default styling loss" cluster: h1–h6 sizes/weights/margins, `b`/`strong`/`th` bold, `em`/`i` italic, list hanging indent, `th` centering across invoices 01–04/07/08/10–12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)