### PR TITLE
WP-5: RC-10 — repeated table header cells no longer get negative size on continuation pages

### DIFF
--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -1688,7 +1688,13 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             {
                 rowBlockOffsets[r] -= resumeRowOffsetShift;
             }
-            for (var r = bodyStart; r < rowCount + 1; r++)
+            // RC-10 (Option A) — start at bodyStart + 1, NOT bodyStart. rowEndBlockOffset is a prefix
+            // array where rowEndBlockOffset[bodyStart] is the END of the last HEADER row (= the header/
+            // body boundary), which must NOT move: the header repeats at its page-1 position every page.
+            // Shifting it corrupted the repeated header cell's size (see EmitHeaderRows Phase B). Safe
+            // because a shift only occurs when resumeAtRow > bodyStart (else the shift is 0), and rowspans
+            // never cross a page break — so no body row emitted on a shifted page starts at bodyStart.
+            for (var r = bodyStart + 1; r < rowCount + 1; r++)
             {
                 rowEndBlockOffset[r] -= resumeRowOffsetShift;
             }
@@ -2572,9 +2578,17 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                     columnOffsets[placement.OriginCol + placement.ColSpan]
                     - columnOffsets[placement.OriginCol];
                 var cellBlockOffset = rowBlockOffsets[r];
-                var cellBlockSize =
-                    rowEndBlockOffset[placement.OriginRow + placement.RowSpan]
-                    - rowEndBlockOffset[placement.OriginRow];
+                // RC-10 (Option B) — size a repeated header cell from the SUM of its spanned row
+                // heights, NOT from the rowEndBlockOffset prefix array. On a resume page the body/
+                // footer offsets are shifted up (see the resumeRowOffsetShift block in AttemptLayout),
+                // and the header/body boundary entry rowEndBlockOffset[bodyStart] was caught in that
+                // shift — so `rowEnd[origin+span] - rowEnd[origin]` for a header cell went NEGATIVE on
+                // continuation pages, and FragmentPainter silently skips a non-positive-size fragment
+                // → the header background/borders vanished on every page after the first. Summing row
+                // heights is immune to any coordinate shift (header rowspans never cross the group).
+                var cellBlockSize = 0.0;
+                for (var rr = placement.OriginRow; rr < placement.OriginRow + placement.RowSpan; rr++)
+                    cellBlockSize += rows[rr].RowHeight;
                 _sink.Emit(new BoxFragment(
                     Box: placement.Cell,
                     InlineOffset: cellInlineOffset,

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -1573,7 +1573,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             {
                 EmitHeaderRows(
                     rows!, placementsByRow, columnOffsetsLocal!,
-                    rowBlockOffsets, rowEndBlockOffset, usedInlineSize,
+                    rowBlockOffsets, usedInlineSize,
                     headerStart: 0, headerEndExclusive: headerCount,
                     flushDiagnostics: _diagnostics ?? layout.Diagnostics,
                     diagnosticsAlreadyFlushed: ref _headerCellDiagnosticsFlushed,
@@ -1804,7 +1804,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             {
                 EmitHeaderRows(
                     rows!, placementsByRow, columnOffsetsLocal!,
-                    rowBlockOffsets, rowEndBlockOffset, usedInlineSize,
+                    rowBlockOffsets, usedInlineSize,
                     headerStart: 0, headerEndExclusive: headerCount,
                     flushDiagnostics: splitHeaderDiagSink,
                     diagnosticsAlreadyFlushed: ref _headerCellDiagnosticsFlushed,
@@ -2107,7 +2107,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                     {
                         EmitHeaderRows(
                             rows!, placementsByRow, columnOffsetsLocal!,
-                            rowBlockOffsets, rowEndBlockOffset, usedInlineSize,
+                            rowBlockOffsets, usedInlineSize,
                             headerStart: 0, headerEndExclusive: headerCount,
                             flushDiagnostics: _diagnostics ?? layout.Diagnostics,
                             diagnosticsAlreadyFlushed: ref _headerCellDiagnosticsFlushed,
@@ -2207,7 +2207,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         {
             EmitHeaderRows(
                 rows!, placementsByRow, columnOffsetsLocal!,
-                rowBlockOffsets, rowEndBlockOffset, usedInlineSize,
+                rowBlockOffsets, usedInlineSize,
                 headerStart: 0, headerEndExclusive: headerCount,
                 flushDiagnostics: _diagnostics ?? layout.Diagnostics,
                 diagnosticsAlreadyFlushed: ref _headerCellDiagnosticsFlushed,
@@ -2535,12 +2535,15 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     /// within the same instance are no-ops for diagnostics. On RESUME
     /// pages the constructor sets the flag to true so the resume
     /// layouter doesn't re-emit duplicate header diagnostics.</para></summary>
+    // NOTE: unlike EmitFooterRows, this no longer takes the rowEndBlockOffset prefix array —
+    // repeated header cells are sized from the SUM of their spanned row heights (RC-10, Phase B
+    // below), which is immune to the continuation-page coordinate shift that made the prefix-array
+    // delta go negative.
     private void EmitHeaderRows(
         List<RowMeasurement> rows,
         List<CellPlacement>?[] placementsByRow,
         double[] columnOffsets,
         double[] rowBlockOffsets,
-        double[] rowEndBlockOffset,
         double usedInlineSize,
         int headerStart,
         int headerEndExclusive,

--- a/src/NetPdf/Rendering/FragmentPainter.cs
+++ b/src/NetPdf/Rendering/FragmentPainter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using SkiaSharp;
 using NetPdf.Css.ComputedValues;
 using NetPdf.Css.ComputedValues.PropertyResolvers;
@@ -161,6 +162,14 @@ internal static class FragmentPainter
             var topPx = contentOriginTopPx + fragment.BlockOffset;
             var widthPx = fragment.InlineSize;
             var heightPx = fragment.BlockSize;
+            // RC-10 hardening — a grossly NEGATIVE fragment size is always an upstream coordinate bug
+            // (a repeated table-header cell once sized itself from a shifted prefix-array boundary and
+            // came out at −880px), and the plain `continue` below made that silent end-to-end. A zero /
+            // hairline-negative size is legitimate (empty box, float rounding) and stays silent; the
+            // −0.5px floor keeps this from tripping on rounding while catching real geometry corruption.
+            Debug.Assert(widthPx >= -0.5 && heightPx >= -0.5,
+                $"FragmentPainter: grossly negative fragment size ({widthPx:0.##}x{heightPx:0.##}) "
+                + $"for {fragment.Box.Kind} — upstream coordinate bug (see RC-10).");
             if (widthPx <= 0 || heightPx <= 0) continue;
 
             // box-decoration-break: slice (inline-only line splitting) — when this fragment is a block-axis

--- a/tests/NetPdf.UnitTests/Rendering/RepeatedTableHeaderRc10Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/RepeatedTableHeaderRc10Tests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -59,10 +60,20 @@ public sealed class RepeatedTableHeaderRc10Tests
     [Fact]
     public void No_negative_size_header_fragments_are_emitted_on_continuation_pages()
     {
-        // A negative "x y w h re" rectangle in any content stream signals the RC-10 coordinate bug.
+        // A negative-SIZE "x y w h re" rectangle in any content stream signals the RC-10 coordinate
+        // bug. Match the full 4-operand form and flag a negative WIDTH (3rd) or HEIGHT (4th) operand
+        // — an earlier version only looked at the number immediately before `re` (height), so a
+        // regression producing a negative width would have slipped through.
         var res = HtmlPdf.ConvertDetailed(MultiPageTable(120), new HtmlPdfOptions { PrintBackgrounds = true });
         var s = Encoding.Latin1.GetString(res.Pdf);
-        var negativeRects = Regex.Matches(s, @"-\d+\.?\d* re").Count;
+        var rect = new Regex(@"(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+re");
+        var negativeRects = 0;
+        foreach (Match m in rect.Matches(s))
+        {
+            var w = double.Parse(m.Groups[3].Value, CultureInfo.InvariantCulture);
+            var h = double.Parse(m.Groups[4].Value, CultureInfo.InvariantCulture);
+            if (w < 0 || h < 0) negativeRects++;
+        }
         Assert.Equal(0, negativeRects);
     }
 }

--- a/tests/NetPdf.UnitTests/Rendering/RepeatedTableHeaderRc10Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/RepeatedTableHeaderRc10Tests.cs
@@ -1,0 +1,68 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-10 — a repeated <c>&lt;thead&gt;</c> cell got a NEGATIVE BlockSize on continuation pages, so
+/// FragmentPainter silently skipped its background + borders: the header band was invisible on every
+/// page after the first (white-on-white where the templates used white header text). Root cause: the
+/// resume-page offset normalization shifted the header/body boundary entry of the rowEnd prefix array,
+/// so <c>rowEnd[origin+span] - rowEnd[origin]</c> went negative. Fixed by (A) not shifting that
+/// boundary and (B) sizing repeated header cells from the sum of their row heights.
+/// </summary>
+public sealed class RepeatedTableHeaderRc10Tests
+{
+    private static string MultiPageTable(int rows) =>
+        "<!doctype html><html><head><style>"
+        + "@page{size:A4;margin:20mm} body{margin:0;font-size:12px}"
+        + "table{width:100%;border-collapse:collapse}"
+        + "thead th{background:#333333;color:#ffffff;padding:6px}"
+        + "td{padding:4px;border-bottom:1px solid #ccc}"
+        + "</style></head><body><table><thead><tr><th>Item</th><th>Qty</th><th>Price</th></tr></thead><tbody>"
+        + string.Concat(Enumerable.Range(0, rows).Select(i =>
+            $"<tr><td>Item {i}</td><td>{i % 9 + 1}</td><td>${i * 3}</td></tr>"))
+        + "</tbody></table></body></html>";
+
+    // Per-page content streams (those carrying text or rects).
+    private static List<string> PageStreams(byte[] pdf)
+    {
+        var s = Encoding.Latin1.GetString(pdf);
+        return Regex.Matches(s, @"stream\r?\n(.*?)\r?\nendstream", RegexOptions.Singleline)
+            .Select(m => m.Groups[1].Value)
+            .Where(x => x.Contains(" Tf") || x.Contains(" re"))
+            .ToList();
+    }
+
+    [Fact]
+    public void Repeated_header_background_paints_on_every_page_not_just_the_first()
+    {
+        var res = HtmlPdf.ConvertDetailed(MultiPageTable(120), new HtmlPdfOptions { PrintBackgrounds = true });
+        Assert.True(res.PageCount >= 3, $"expected a multi-page table; got {res.PageCount} pages");
+
+        var darkFill = new Regex(@"0\.2(?:\d*)? 0\.2(?:\d*)? 0\.2(?:\d*)? rg");
+        var pagesWithHeaderBg = PageStreams(res.Pdf).Count(st => darkFill.IsMatch(st));
+
+        // The three header cells' dark background must appear on EVERY page the table spans, not only
+        // page 1. (Before the fix only page 1 painted it.)
+        Assert.True(pagesWithHeaderBg >= res.PageCount,
+            $"header background painted on {pagesWithHeaderBg} page-streams but the table spans {res.PageCount} pages");
+    }
+
+    [Fact]
+    public void No_negative_size_header_fragments_are_emitted_on_continuation_pages()
+    {
+        // A negative "x y w h re" rectangle in any content stream signals the RC-10 coordinate bug.
+        var res = HtmlPdf.ConvertDetailed(MultiPageTable(120), new HtmlPdfOptions { PrintBackgrounds = true });
+        var s = Encoding.Latin1.GetString(res.Pdf);
+        var negativeRects = Regex.Matches(s, @"-\d+\.?\d* re").Count;
+        Assert.Equal(0, negativeRects);
+    }
+}


### PR DESCRIPTION
Fourth release-readiness work package (table fragmentation). Fixes **RC-10** — the systemic "invisible repeated header" bug that hits **every multi-page table** in the corpus.

> **Stacked on #287 (WP-2)** → base `wp2-ua-stylesheet`. Merge the earlier PRs first.

## The bug (RC-10)
A repeated `<thead>` cell's background + borders were invisible on every page **after the first**. `pdftotext` proves the header *text* repeats on every continuation page — but the cell's decoration band was silently dropped, reading as a blank (white-on-white) strip where templates use white header text. Affected: invoices 03/04/09/10/11/12, 08-sales, 01-cruise, and more.

**Root cause:** on a resume page the body/footer offsets are shifted up by `resumeRowOffsetShift`, and the shift loop over the `rowEndBlockOffset` **prefix** array started at `bodyStart` — which is the *end boundary of the last header row* (the header/body boundary). Shifting it made `EmitHeaderRows` Phase B compute the repeated header cell size as `rowEnd[origin+span] − rowEnd[origin]` = (headerHeight − shift), i.e. **negative** once the shift exceeded the header height. `FragmentPainter` then silently `continue`s past a non-positive-size fragment → the header band vanished. (The header text still painted, from the content buffer, which is why it looked like "header present, styling lost".)

## The fix (both options, defense in depth)
- **Option A** — start the `rowEndBlockOffset` shift at `bodyStart + 1`, leaving the header/body boundary un-shifted.
- **Option B** — size a repeated header cell from the **sum of its spanned row heights** instead of the prefix-array delta → immune to any coordinate shift.
- **Hardening** — a tolerant `Debug.Assert` in `FragmentPainter` for a grossly-negative fragment size (`< −0.5px`), so a future coordinate bug of this class fails loudly. Zero / hairline sizes stay silent.

## Tests & verification
- `RepeatedTableHeaderRc10Tests` — a 120-row dark-header table paints the header background on **every** page (was page 1 only); **no** negative-size rectangles in any stream.
- Repro: header bg fills went from `[page1: 3, page2+: 0]` → `[all pages: 3]`.
- **Full suite green** (`dotnet test NetPdf.slnx -c Release`, exit 0).

## Scope note — RC-7 deferred
RC-7 (a table whose `thead`+`tfoot` exceed the **current-page remainder** has its body **dropped / force-overflowed** rather than breaking to a fresh page — the user-reported **02-travel-quote missing table**) is a distinct, **higher-risk** change: it needs a *break-before-table continuation*, which touches the table↔`BlockLayouter` pagination contract and its zero-progress guards (the gate at `BlockLayouter.cs:5230` deliberately excludes tables to avoid wasting page space). To avoid rushing the single riskiest change in the plan — infinite-continuation hazards need isolated verification — RC-7 is deferred to a **dedicated follow-up PR** (WP-5b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)