### PR TITLE
WP-4: RC-6 + RC-8 — nested flex/grid/table roots dispatch to their own layouter

### DIFF
--- a/src/NetPdf.Layout/Layouters/GridLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/GridLayouter.cs
@@ -1343,41 +1343,82 @@ internal sealed class GridLayouter : ILayouter, IDisposable
             IsRtl = outerLayout.IsRtl,
         };
 
-        using var itemLayouter = new BlockLayouter(
-            rootBox: itemBox,
-            sink: translatingSink,
-            incomingContinuation: null,
-            diagnostics: _diagnostics,
-            shaperResolver: _shaperResolver,
-            // Per Phase 3 Task 17 cycle 5c.2b post-PR-#100 review
-            // P1#1 — grid items are a CSS Fragmentation L3
-            // "parallel flow" + GridLayouter discards the inner
-            // BlockLayouter's result (= no continuation propagation
-            // to the outer grid). A paginatable direct-child grid
-            // inside a grid item would return
-            // PageComplete(GridContinuation) → silent row loss on
-            // the discarded continuation. Suppress grid pagination
-            // here until nested-continuation propagation is wired
-            // (= 5c.2d scope).
-            disableGridPagination: true,
-            // PR-#182 review P1 — a grid cell with a tall nested column-flex
-            // would otherwise PageComplete(FlexContinuation) into this discarded
-            // result + drop the deferred items. Suppress flex pagination too so
-            // the cell content is atomic.
-            disableFlexPagination: true,
-            // Non-block-pagination arc (grid content-sized rows) — the common
-            // grid item (`<div>text</div>`) has DIRECT inline children; opt the
-            // nested layouter into emitting the inline-only ROOT's own content
-            // (else the block-only child loop skips the cell's text — the same
-            // gap flex items had). See BlockLayouter's _layoutRootInlineContent.
-            layoutRootInlineContent: true);
+        // RC-6 / RC-8 — ROOT-display dispatch (mirrors NestedContentMeasurer). A grid item that is
+        // ITSELF a flex / grid / table container must be laid out by the matching layouter, NOT a plain
+        // BlockLayouter (which dispatches only CHILDREN): a table grid item would otherwise have every
+        // row skipped and be silently DROPPED (RC-8), and a flex grid item would stack its items.
         using var itemResolver = new BreakResolver();
-        _ = itemLayouter.AttemptLayout(
-            innerFragmentainer,
-            ref innerLayout,
-            itemResolver,
-            LayoutAttemptStrategy.LastResort,
-            cancellationToken);
+        ILayouter itemLayouter;
+        if (itemBox.Kind is BoxKind.FlexContainer or BoxKind.InlineFlexContainer)
+        {
+            var flex = new FlexLayouter(
+                rootBox: itemBox, sink: translatingSink, incomingContinuation: null,
+                diagnostics: _diagnostics, shaperResolver: _shaperResolver,
+                recordPositionedGeometry: null);
+            flex.ConfigureEmission(0, 0, cellInlineSize, cellBlockSize, allowPagination: false);
+            itemLayouter = flex;
+        }
+        else if (itemBox.Kind is BoxKind.GridContainer or BoxKind.InlineGridContainer)
+        {
+            var grid = new GridLayouter(
+                rootBox: itemBox, sink: translatingSink, incomingContinuation: null,
+                diagnostics: _diagnostics, shaperResolver: _shaperResolver);
+            grid.ConfigureEmission(0, 0, cellInlineSize, cellBlockSize, allowPagination: false);
+            itemLayouter = grid;
+        }
+        else if (itemBox.Kind is BoxKind.Table or BoxKind.InlineTable)
+        {
+            var table = new TableLayouter(
+                rootBox: itemBox, sink: translatingSink, incomingContinuation: null,
+                diagnostics: _diagnostics, shaperResolver: _shaperResolver);
+            table.ConfigureEmission(0, 0, cellInlineSize);
+            _ = table.MeasureContentHeight(innerFragmentainer, ref innerLayout, cancellationToken);
+            itemLayouter = table;
+        }
+        else
+        {
+            itemLayouter = new BlockLayouter(
+                rootBox: itemBox,
+                sink: translatingSink,
+                incomingContinuation: null,
+                diagnostics: _diagnostics,
+                shaperResolver: _shaperResolver,
+                // Per Phase 3 Task 17 cycle 5c.2b post-PR-#100 review
+                // P1#1 — grid items are a CSS Fragmentation L3
+                // "parallel flow" + GridLayouter discards the inner
+                // BlockLayouter's result (= no continuation propagation
+                // to the outer grid). A paginatable direct-child grid
+                // inside a grid item would return
+                // PageComplete(GridContinuation) → silent row loss on
+                // the discarded continuation. Suppress grid pagination
+                // here until nested-continuation propagation is wired
+                // (= 5c.2d scope).
+                disableGridPagination: true,
+                // PR-#182 review P1 — a grid cell with a tall nested column-flex
+                // would otherwise PageComplete(FlexContinuation) into this discarded
+                // result + drop the deferred items. Suppress flex pagination too so
+                // the cell content is atomic.
+                disableFlexPagination: true,
+                // Non-block-pagination arc (grid content-sized rows) — the common
+                // grid item (`<div>text</div>`) has DIRECT inline children; opt the
+                // nested layouter into emitting the inline-only ROOT's own content
+                // (else the block-only child loop skips the cell's text — the same
+                // gap flex items had). See BlockLayouter's _layoutRootInlineContent.
+                layoutRootInlineContent: true);
+        }
+        try
+        {
+            _ = itemLayouter.AttemptLayout(
+                innerFragmentainer,
+                ref innerLayout,
+                itemResolver,
+                LayoutAttemptStrategy.LastResort,
+                cancellationToken);
+        }
+        finally
+        {
+            (itemLayouter as System.IDisposable)?.Dispose();
+        }
     }
 
     /// <summary>Per PR-#92 review F1 — a fragment-sink wrapper that

--- a/src/NetPdf.Layout/Layouters/GridLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/GridLayouter.cs
@@ -1347,6 +1347,13 @@ internal sealed class GridLayouter : ILayouter, IDisposable
         // ITSELF a flex / grid / table container must be laid out by the matching layouter, NOT a plain
         // BlockLayouter (which dispatches only CHILDREN): a table grid item would otherwise have every
         // row skipped and be silently DROPPED (RC-8), and a flex grid item would stack its items.
+        //
+        // KNOWN LIMITATION (follow-up): the plain-block branch below is an abspos delegation boundary
+        // (its nested BlockLayouter runs a post-flow abspos pass), but the flex/grid/table container-root
+        // branches are not — Flex/Grid/TableLayouter don't emit out-of-flow descendants, and the outer
+        // grid abspos walk deliberately doesn't descend into items. So a position:absolute descendant of
+        // a container-ROOT grid item is not emitted here. Tracked for the root-dispatch abspos follow-up
+        // (see WP-4 handoff); the common RC-6/RC-8 cases have no such descendant.
         using var itemResolver = new BreakResolver();
         ILayouter itemLayouter;
         if (itemBox.Kind is BoxKind.FlexContainer or BoxKind.InlineFlexContainer)
@@ -1368,12 +1375,31 @@ internal sealed class GridLayouter : ILayouter, IDisposable
         }
         else if (itemBox.Kind is BoxKind.Table or BoxKind.InlineTable)
         {
-            var table = new TableLayouter(
+            // A table grid item lays out ATOMICALLY like the flex/grid branches (allowPagination:
+            // false). TableLayouter has no allowPagination toggle — it paginates against the
+            // fragmentainer block size — so give it an effectively-unbounded budget (mirrors
+            // NestedContentMeasurer's table branch). Against the cell-sized budget a multi-page
+            // table would PageComplete(TableContinuation), and since grid-item content is atomic
+            // (cycle-1: no nested-continuation propagation, the result is discarded) its remaining
+            // rows would be silently truncated. Overflowing the cell is the spec'd cycle-1 behavior.
+            var tableFragmentainer = new FragmentainerContext(
+                contentInlineSize: cellInlineSize,
+                blockSize: NestedContentMeasurer.EffectivelyUnboundedBlockBudgetPx);
+            var tableLayout = new LayoutContext(tableFragmentainer)
+            {
+                Diagnostics = outerLayout.Diagnostics,
+                WritingMode = outerLayout.WritingMode,
+                IsRtl = outerLayout.IsRtl,
+            };
+            using var table = new TableLayouter(
                 rootBox: itemBox, sink: translatingSink, incomingContinuation: null,
                 diagnostics: _diagnostics, shaperResolver: _shaperResolver);
             table.ConfigureEmission(0, 0, cellInlineSize);
-            _ = table.MeasureContentHeight(innerFragmentainer, ref innerLayout, cancellationToken);
-            itemLayouter = table;
+            _ = table.MeasureContentHeight(tableFragmentainer, ref tableLayout, cancellationToken);
+            _ = table.AttemptLayout(
+                tableFragmentainer, ref tableLayout, itemResolver,
+                LayoutAttemptStrategy.LastResort, cancellationToken);
+            return;
         }
         else
         {

--- a/src/NetPdf.Layout/Layouters/NestedContentMeasurer.cs
+++ b/src/NetPdf.Layout/Layouters/NestedContentMeasurer.cs
@@ -110,9 +110,11 @@ internal static class NestedContentMeasurer
         // The box is its own content's decoration owner: a content fragment
         // whose box IS this box (the inline-only-root case) paints text only.
         var buffer = new BufferingMeasureSink(decorationOwner: box);
+        var innerInlineSize = availInlineContentSize > 0 ? availInlineContentSize : 1;
+        var innerBlockSize = Math.Max(blockBudget, 1);
         var innerFragmentainer = new FragmentainerContext(
-            contentInlineSize: availInlineContentSize > 0 ? availInlineContentSize : 1,
-            blockSize: Math.Max(blockBudget, 1));
+            contentInlineSize: innerInlineSize,
+            blockSize: innerBlockSize);
         var innerLayout = new LayoutContext(innerFragmentainer)
         {
             WritingMode = writingMode,
@@ -121,33 +123,109 @@ internal static class NestedContentMeasurer
             // Carries the purpose transitively into the nested layouter (+ its own nested measures).
             MeasurePurpose = purpose,
         };
-        using var layouter = new BlockLayouter(
-            rootBox: box,
-            sink: buffer,
-            incomingContinuation: null,
-            // PR-#182 review P2 — an optional diagnostics sink (the caller passes
-            // a BUFFERING one for flex item content so a nested inline / font
-            // problem surfaces, flushed only when the item commits). Null = the
-            // grid sizing / pre-measure dry-runs (grid's real emission surfaces
-            // content diagnostics on its own DispatchGridItemContents pass).
-            diagnostics: diagnostics,
-            shaperResolver: shaperResolver,
-            // A nested paginatable grid / flex inside the box is a CSS
-            // Fragmentation "parallel flow"; suppress its pagination here (the
-            // content commits atomically) so a discarded continuation doesn't
-            // silently lose content (PR-#182 review P1 — flex too, not just grid).
-            disableGridPagination: true,
-            disableFlexPagination: true,
-            // The common item (`<div>text</div>`) has DIRECT inline children;
-            // opt the nested layouter into emitting the inline-only ROOT's own
-            // content (else the block-only child loop skips the box's text).
-            layoutRootInlineContent: true,
-            suppressOutOfFlowEmission: suppressOutOfFlowEmission);
-        // PR #208 [P2] — intrinsic (min-content) measurement ignores break-word's soft
-        // opportunities so they don't collapse min-content to glyph width (mirrors the
-        // table cell min-content pass via TableLayouter.MeasureCellContent).
-        layouter.SetIntrinsicSizingMode(intrinsicSizingMode);
         using var resolver = new BreakResolver();
+
+        // RC-6 / RC-8 — ROOT-display dispatch. The nested content root may ITSELF be a flex / grid /
+        // table container: a flex item that is `display: flex` (RC-6 — the SVG-logo-above-name brand
+        // rows), or a `<table>` that is a DIRECT flex/grid item (RC-8 — 07-tax's missing totals table).
+        // A plain BlockLayouter only flex/grid-dispatches its CHILDREN and never consults the ROOT box's
+        // own display, so a flex root stacks its items as block flow, and a table root — whose
+        // TableRowGroup/TableRow children are neither block-flow-owned nor inline — has EVERY child
+        // skipped, measuring 0 extent → the table is silently DROPPED (a rule-7 violation). Route each
+        // container root to its own layouter, mirroring the child dispatch BlockLayouter already does.
+        ILayouter layouter;
+        if (box.Kind is BoxKind.FlexContainer or BoxKind.InlineFlexContainer)
+        {
+            var flex = new FlexLayouter(
+                rootBox: box, sink: buffer, incomingContinuation: null,
+                diagnostics: diagnostics, shaperResolver: shaperResolver,
+                recordPositionedGeometry: null);
+            flex.ConfigureEmission(
+                contentInlineOffset: 0, contentBlockOffset: 0,
+                contentInlineSize: innerInlineSize, contentBlockSize: innerBlockSize,
+                allowPagination: false);
+            layouter = flex;
+        }
+        else if (box.Kind is BoxKind.GridContainer or BoxKind.InlineGridContainer)
+        {
+            var grid = new GridLayouter(
+                rootBox: box, sink: buffer, incomingContinuation: null,
+                diagnostics: diagnostics, shaperResolver: shaperResolver);
+            grid.ConfigureEmission(
+                contentInlineOffset: 0, contentBlockOffset: 0,
+                contentInlineSize: innerInlineSize, contentBlockSize: innerBlockSize,
+                allowPagination: false);
+            layouter = grid;
+        }
+        else if (box.Kind is BoxKind.Table or BoxKind.InlineTable)
+        {
+            // A nested table root lays out ATOMICALLY (a CSS Fragmentation "parallel flow", like the
+            // flex/grid branches with allowPagination:false). Give it an effectively-unbounded block
+            // budget so it emits EVERY row rather than paginating against the caller's (possibly small)
+            // measure budget — otherwise the buffer's ContentBlockExtent reports only the fitting rows
+            // and the caller (e.g. grid track sizing) under-sizes the track and truncates the table.
+            var tableFragmentainer = new FragmentainerContext(
+                contentInlineSize: innerInlineSize,
+                blockSize: EffectivelyUnboundedBlockBudgetPx);
+            var tableLayout = new LayoutContext(tableFragmentainer)
+            {
+                WritingMode = writingMode,
+                IsRtl = isRtl,
+                Diagnostics = diagnostics,
+                MeasurePurpose = purpose,
+            };
+            using var table = new TableLayouter(
+                rootBox: box, sink: buffer, incomingContinuation: null,
+                diagnostics: diagnostics, shaperResolver: shaperResolver);
+            table.ConfigureEmission(
+                contentInlineOffset: 0, contentBlockOffset: 0, contentInlineSize: innerInlineSize);
+            // The table computes its column layout + row heights here (mirrors the emit dispatch);
+            // AttemptLayout then emits the row/cell fragments into the buffer.
+            _ = table.MeasureContentHeight(tableFragmentainer, ref tableLayout, cancellationToken);
+            if (speculative) _nestingDepth++;
+            try
+            {
+                _ = table.AttemptLayout(
+                    tableFragmentainer, ref tableLayout, resolver,
+                    LayoutAttemptStrategy.LastResort, cancellationToken);
+            }
+            finally
+            {
+                if (speculative) _nestingDepth--;
+            }
+            return buffer;
+        }
+        else
+        {
+            var block = new BlockLayouter(
+                rootBox: box,
+                sink: buffer,
+                incomingContinuation: null,
+                // PR-#182 review P2 — an optional diagnostics sink (the caller passes
+                // a BUFFERING one for flex item content so a nested inline / font
+                // problem surfaces, flushed only when the item commits). Null = the
+                // grid sizing / pre-measure dry-runs (grid's real emission surfaces
+                // content diagnostics on its own DispatchGridItemContents pass).
+                diagnostics: diagnostics,
+                shaperResolver: shaperResolver,
+                // A nested paginatable grid / flex inside the box is a CSS
+                // Fragmentation "parallel flow"; suppress its pagination here (the
+                // content commits atomically) so a discarded continuation doesn't
+                // silently lose content (PR-#182 review P1 — flex too, not just grid).
+                disableGridPagination: true,
+                disableFlexPagination: true,
+                // The common item (`<div>text</div>`) has DIRECT inline children;
+                // opt the nested layouter into emitting the inline-only ROOT's own
+                // content (else the block-only child loop skips the box's text).
+                layoutRootInlineContent: true,
+                suppressOutOfFlowEmission: suppressOutOfFlowEmission);
+            // PR #208 [P2] — intrinsic (min-content) measurement ignores break-word's soft
+            // opportunities so they don't collapse min-content to glyph width (mirrors the
+            // table cell min-content pass via TableLayouter.MeasureCellContent).
+            block.SetIntrinsicSizingMode(intrinsicSizingMode);
+            layouter = block;
+        }
+
         // Count THIS speculative measure against the nesting budget while its content (which may
         // spawn its own nested measures) lays out; balanced + ONLY for speculative measures.
         if (speculative) _nestingDepth++;
@@ -160,6 +238,7 @@ internal static class NestedContentMeasurer
         finally
         {
             if (speculative) _nestingDepth--;
+            (layouter as IDisposable)?.Dispose();
         }
         return buffer;
     }

--- a/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
@@ -1,0 +1,83 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-6 / RC-8 — nested root-display dispatch. A nested content root (a flex / grid item's content,
+/// abspos content, …) that is ITSELF a flex / grid / table container was measured by a plain
+/// BlockLayouter, which only dispatches its CHILDREN — so a flex root stacked its items as block flow
+/// (RC-6) and a table root, whose rows are neither block-flow nor inline, had every child skipped and
+/// was silently DROPPED (RC-8, a rule-7 violation — 07-tax's totals table). Fixed by routing each
+/// container root to its own layouter in NestedContentMeasurer.
+/// </summary>
+public sealed class NestedRootDispatchTests
+{
+    private static int TextRunCount(byte[] pdf) =>
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @" Td\b").Count;
+
+    private const string TableRows =
+        "<table><tr><td>Subtotal</td><td>$100</td></tr>"
+        + "<tr><td>GST</td><td>$10</td></tr><tr><td>Total</td><td>$110</td></tr></table>";
+
+    [Fact]
+    public void Table_as_a_direct_flex_item_is_not_dropped()
+    {
+        // RC-8: `<table>` as a direct flex item must render every row, identical to the same table in
+        // a plain block (the control). Before the fix the flex version emitted ZERO text.
+        var flex = HtmlPdf.ConvertDetailed(
+            "<style>.w{display:flex}td{border:1px solid #000;padding:4px}</style>"
+            + "<div class=\"w\">" + TableRows + "</div>");
+        var block = HtmlPdf.ConvertDetailed(
+            "<style>.w{display:block}td{border:1px solid #000;padding:4px}</style>"
+            + "<div class=\"w\">" + TableRows + "</div>");
+
+        Assert.True(TextRunCount(block.Pdf) > 0, "control (block) table should render text");
+        Assert.Equal(TextRunCount(block.Pdf), TextRunCount(flex.Pdf));
+    }
+
+    [Fact]
+    public void Table_as_a_direct_grid_item_is_not_silently_dropped()
+    {
+        // RC-8 for grid: a `<table>` grid item was silently dropped (0 text, 0 warnings). It now
+        // renders. (A grid auto-row track that under-sizes a large table item and truncates it is a
+        // separate grid track-sizing residual — but it emits PDF-CONTENT-OVERFLOW-TRUNCATED-001, so
+        // it is no longer SILENT: rule 7 — never drop content silently — is satisfied either way.)
+        var grid = HtmlPdf.ConvertDetailed(
+            "<style>.w{display:grid}td{border:1px solid #000;padding:4px}</style>"
+            + "<div class=\"w\">" + TableRows + "</div>");
+        var block = HtmlPdf.ConvertDetailed(
+            "<style>.w{display:block}td{border:1px solid #000;padding:4px}</style>"
+            + "<div class=\"w\">" + TableRows + "</div>");
+
+        Assert.True(TextRunCount(block.Pdf) > 0);
+        Assert.True(TextRunCount(grid.Pdf) > 0, "table grid item must render content, not be silently dropped");
+        var fullyRendered = TextRunCount(grid.Pdf) == TextRunCount(block.Pdf);
+        Assert.True(fullyRendered || grid.Warnings.Count > 0,
+            "a partially-rendered table grid item must surface a diagnostic (never a silent drop)");
+    }
+
+    [Fact]
+    public void Flex_item_that_is_itself_flex_lays_out_horizontally_not_stacked()
+    {
+        // RC-6: a flex item that is `display: flex` (icon + name lockup). Before the fix it fell to
+        // block flow so the name stacked BELOW the logo at the left edge. Now it lays out as flex, so
+        // the name's text is horizontally offset past the logo box.
+        var res = HtmlPdf.ConvertDetailed(
+            "<style>body{margin:0}.brand{display:flex;align-items:center}"
+            + ".logo{display:flex;width:40px;height:40px;background:#333}.name{margin-left:10px}</style>"
+            + "<div class=\"brand\"><div class=\"logo\"></div><div class=\"name\">Acme</div></div>");
+        var s = Encoding.Latin1.GetString(res.Pdf);
+        var m = Regex.Match(s, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td");
+        Assert.True(m.Success, "expected a text run for the name");
+        var nameX = double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+        // The logo item is 40px ≈ 30pt wide; the name must start clearly to its right, not at x≈0.
+        Assert.True(nameX > 25, $"name x-position {nameX} should be past the logo (flex layout), not stacked at the left");
+    }
+}

--- a/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
@@ -64,6 +64,30 @@ public sealed class NestedRootDispatchTests
     }
 
     [Fact]
+    public void Tall_table_grid_item_in_a_small_track_renders_every_row_not_truncated()
+    {
+        // A multi-row `<table>` grid item whose grid track is SHORTER than the table. The item content
+        // is atomic (the grid discards the inner layouter's result), so laying the table out against the
+        // small cell-sized budget would PageComplete(TableContinuation) and silently truncate the
+        // remaining rows. It must instead lay out atomically (effectively-unbounded budget) and emit
+        // every row — overflowing the cell — identical to the same table in a plain block.
+        var manyRows = new StringBuilder("<table>");
+        for (var i = 0; i < 20; i++)
+            manyRows.Append("<tr><td>Row</td><td>").Append(i).Append("</td></tr>");
+        manyRows.Append("</table>");
+
+        var grid = HtmlPdf.ConvertDetailed(
+            "<style>.w{display:grid;grid-template-rows:40px}td{padding:2px}</style>"
+            + "<div class=\"w\">" + manyRows + "</div>");
+        var block = HtmlPdf.ConvertDetailed(
+            "<style>.w{display:block}td{padding:2px}</style>"
+            + "<div class=\"w\">" + manyRows + "</div>");
+
+        Assert.True(TextRunCount(block.Pdf) > 0, "control (block) table should render text");
+        Assert.Equal(TextRunCount(block.Pdf), TextRunCount(grid.Pdf));
+    }
+
+    [Fact]
     public void Flex_item_that_is_itself_flex_lays_out_horizontally_not_stacked()
     {
         // RC-6: a flex item that is `display: flex` (icon + name lockup). Before the fix it fell to


### PR DESCRIPTION
Fifth release-readiness work package (nested root-dispatch). Fixes **RC-6** and **RC-8** — the latter a **silent data-loss BLOCKER**.

> **Stacked on #288 (WP-5)** → base `wp5-table-fragmentation`. Merge the earlier PRs first.

## The bug
A nested content root that is **itself** a flex / grid / table container was laid out by a plain `BlockLayouter`, which dispatches only its **children** and never consults the **root** box's own display:
- **RC-6** — a flex item that is `display: flex` (the SVG-logo-beside-name brand lockups in 01–04 travel headers, 09-offer, invoice-08 `.mark`, 05-payment chip) fell to **block flow** → its items **stacked** vertically instead of a row.
- **RC-8** (BLOCKER, fully silent) — a `<table>` that is a **direct flex/grid item** (07-tax's Subtotal/GST/Total table) had every child skipped (its `TableRowGroup`/`TableRow` children are neither block-flow-owned nor inline) → 0 extent → the table **vanished with `warnings=0`**, a direct violation of rule 7.

## The fix
Root-display dispatch mirroring the child dispatch `BlockLayouter` already does:
- `NestedContentMeasurer.Measure` (the flex/grid item-content + abspos-content measure entry) routes a flex / grid / table **root** to `FlexLayouter` / `GridLayouter` / `TableLayouter`. The table root lays out atomically against an effectively-unbounded block budget so it emits **all** rows.
- `GridLayouter.DispatchGridItemContents` (the grid item **emission** path, which bypasses `NestedContentMeasurer`) gets the same root dispatch.

## Results (repro)
| item content | before | after |
|---|---|---|
| `<table>` as a **flex** item | 0 text (dropped) | **6/6 rows** (== block control) |
| flex item that is `display:flex` | name stacked at left (x≈0) | name **beside** logo (x≈102) |
| `<table>` as a **grid** item | 0 text, **0 warnings** (silent) | renders + `PDF-CONTENT-OVERFLOW-TRUNCATED-001` (**non-silent**) |

## Tests & verification
- `NestedRootDispatchTests` — table-in-flex == block control; table-in-grid renders + is non-silent; flex-in-flex name horizontally offset.
- **Full suite green** (`dotnet test NetPdf.slnx -c Release`, exit 0) — no regressions across 8500+ tests.

## Follow-ups
- Grid auto-row-track sizing for a large table grid item (the truncation residual — now diagnosed, not silent).
- `DispatchAbsoluteChildContents` root-flex dispatch (05-payment abspos chip) folds into the **WP-6** abspos PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)