### PR TITLE
WP-3: RC-2 + RC-2b + RC-11 — auto cross-size flex items sized/aligned/painted from content

### DIFF
--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -1177,6 +1177,20 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             foreach (var cs in itemBaselineCrossSizes)
                 if (!double.IsNaN(cs) && cs > autoRowContentCross) autoRowContentCross = cs;
         }
+        // RC-2b / RC-11 — for an AUTO-height NOWRAP row the resolved container cross (and thus the
+        // single line's cross extent, `lineCrossExtent = containerCrossSize` below) came out 0 because
+        // FlexLinePacker sizes each line from the items' DECLARED cross only (an auto item declares 0).
+        // Fold in the content-measured max (`autoRowContentCross`) so a `stretch` item grows to the
+        // real content cross and every item's emission line extent is non-zero — otherwise each item's
+        // geometry fragment has BlockSize 0 and FragmentPainter culls its background/border/radius. Safe
+        // to update here: the wrap-only align-content free-space (L1037) and the item-content measure
+        // (L1130, which INTENTIONALLY measures at auto cross to PRODUCE these sizes) both already ran,
+        // and the emission loop reads `containerCrossSize` further below. Byte-identical when the content
+        // is no taller than the already-resolved cross (fold is a max).
+        if (isAutoHeightRow && autoRowContentCross > containerCrossSize)
+        {
+            containerCrossSize = autoRowContentCross;
+        }
 
         // PR #189 review P2 — the row-nowrap content-measure budget is a PRACTICAL cap
         // (NestedContentMeasurer.EffectivelyUnboundedBlockBudgetPx), not truly unbounded:
@@ -1537,10 +1551,27 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                     // the flex-flow start (flex-start), which IS the line's permuted cross-start under
                     // `wrap-reverse`. So the helper takes the flex-flow `isCrossAxisReversed` for that
                     // fallback separately from the (possibly container-/item-logical) natural orientation.
+                    // RC-2 / RC-11 — an AUTO cross-size item was placed (and its geometry fragment
+                    // emitted) with a cross size of 0: `center`/`flex-end` centered it as if it were
+                    // zero-height (off by half / a full line cross), and the emitted item box had
+                    // BlockSize 0 so FragmentPainter culled its ENTIRE background/border/radius (the
+                    // dropped card/chip/pill decorations across the corpus). Feed the CONTENT-measured
+                    // cross border box (`itemBaselineCrossSizes`, computed for every ROW flex above) as
+                    // the align cross size for an auto item. The Stretch branch ignores it (it grows to
+                    // the line cross extent regardless), so stretch stays byte-identical; the positional
+                    // branches now use the real content size for both the space math AND the returned
+                    // effective cross size the geometry fragment paints. Row-only (column baseline data
+                    // isn't computed — a documented residual, deferrals.md).
+                    var alignCrossSize = itemCrossSize;
+                    if (itemIsCrossSizeAuto && itemBaselineCrossSizes is not null
+                        && !double.IsNaN(itemBaselineCrossSizes[itemIdx]))
+                    {
+                        alignCrossSize = itemBaselineCrossSizes[itemIdx];
+                    }
                     (itemCrossOffsetWithinLine, itemEffectiveCrossSize) =
                         ComputeAlignItemsPlacement(
                             effectiveAlign.Value, effectiveAlign.Mode,
-                            lineCrossExtent, itemCrossSize,
+                            lineCrossExtent, alignCrossSize,
                             itemIsCrossSizeAuto,
                             lineCrossCursor,
                             naturalCrossReversed: naturalReversed,

--- a/tests/NetPdf.UnitTests/Rendering/FlexAutoCrossSizeRc11Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexAutoCrossSizeRc11Tests.cs
@@ -1,0 +1,73 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-2 / RC-2b / RC-11 — auto cross-size flex items. In a ROW container, an item with auto cross
+/// size (the universal card / chip / pill pattern) was placed and EMITTED with a cross size of 0:
+/// FlexLinePacker sizes lines from declared cross only, so the container / line cross came out 0
+/// (RC-2b), `align-items: center`/`flex-end` centered the item as if zero-height (RC-2), and — worst —
+/// the item's geometry fragment had BlockSize 0, so FragmentPainter culled its ENTIRE background /
+/// border / radius (RC-11, the dropped card decorations across 10+ corpus templates). Fixed by folding
+/// the content-measured cross (itemBaselineCrossSizes / autoRowContentCross) into the container cross
+/// and the per-item align cross size.
+/// </summary>
+public sealed class FlexAutoCrossSizeRc11Tests
+{
+    // Count the card background (#e0e7ff ≈ 0.878 0.905 1) and border (#4f46e5 ≈ 0.31 0.27 0.90) fills.
+    private static (int bg, int border) CardFills(byte[] pdf)
+    {
+        var s = Encoding.Latin1.GetString(pdf);
+        return (
+            Regex.Matches(s, @"0\.87\d* 0\.90\d* 1(?:\.0+)? rg").Count,
+            Regex.Matches(s, @"0\.3\d* 0\.2\d* 0\.89\d* rg").Count);
+    }
+
+    private static string Row(string extraItemCss = "", string containerCss = "") =>
+        "<!doctype html><html><head><style>body{margin:0}"
+        + ".row{display:flex;gap:10px;" + containerCss + "}"
+        + ".card{flex:1;background:#e0e7ff;border:2px solid #4f46e5;border-radius:8px;padding:12px;" + extraItemCss + "}"
+        + "</style></head><body><div class=\"row\">"
+        + "<div class=\"card\">Alpha</div><div class=\"card\">Bravo</div><div class=\"card\">Charlie</div>"
+        + "</div></body></html>";
+
+    [Fact]
+    public void Auto_height_row_flex_cards_paint_their_background_and_border()
+    {
+        // RC-11: three auto-height cards in a row must each paint bg + border, identical to the same
+        // cards given an explicit height (the control). Before the fix the auto version painted NEITHER.
+        var auto = CardFills(HtmlPdf.ConvertDetailed(Row(), new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        var fixedH = CardFills(HtmlPdf.ConvertDetailed(Row("height:60px"), new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+
+        Assert.Equal(3, fixedH.bg);      // control: 3 cards, 3 backgrounds
+        Assert.Equal(3, fixedH.border);
+        Assert.Equal(fixedH.bg, auto.bg);
+        Assert.Equal(fixedH.border, auto.border);
+    }
+
+    [Fact]
+    public void Align_items_center_auto_item_still_paints_its_decoration()
+    {
+        // RC-2 + RC-11: with align-items:center the auto items were centered as if 0-height AND their
+        // decoration was culled. They must still paint their background/border under center alignment.
+        var centered = CardFills(HtmlPdf.ConvertDetailed(
+            Row(containerCss: "align-items:center"), new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        Assert.Equal(3, centered.bg);
+        Assert.Equal(3, centered.border);
+    }
+
+    [Fact]
+    public void Align_items_flex_end_auto_item_still_paints_its_decoration()
+    {
+        var end = CardFills(HtmlPdf.ConvertDetailed(
+            Row(containerCss: "align-items:flex-end"), new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        Assert.Equal(3, end.bg);
+        Assert.Equal(3, end.border);
+    }
+}


### PR DESCRIPTION
Sixth release-readiness work package (flex cross-size family). One mechanism fixes three symptoms, including the very visible **dropped card/chip/pill decorations**.

> **Stacked on #289 (WP-4)** → base `wp4-nested-root-dispatch`. Merge the earlier PRs first.

## The bug
In a **row** flex container, an item with an **auto** cross size (the universal card / chip / pill / icon-lockup pattern) was placed and emitted with a cross size of **0** — `FlexLinePacker` sizes each line from the items' *declared* cross only:
- **RC-2b** — the resolved container cross (and the nowrap line's cross extent) came out 0, so a `stretch` item stretched to nothing.
- **RC-2** — `align-items: center` / `flex-end` positioned the item as if zero-height (off by half a line / a full line).
- **RC-11** (the visible one) — the item's geometry fragment had `BlockSize 0`, so `FragmentPainter` culled its **entire** background / border / border-radius. This is the dropped decorations across 10+ corpus templates (incl. 04's white-on-white "$9,486.20", the 10-ticket seat chips + dashed stub perforation).

## The fix
The content-measured cross border box already exists — `itemBaselineCrossSizes` (computed for every row flex) and its max `autoRowContentCross` (PR #280 T1 folded it into the *wrapper* extent only). This feeds it into the two remaining places:
1. Fold `autoRowContentCross` into `containerCrossSize` for an auto-height nowrap row → a `stretch` item grows to the real content cross; the line extent is non-zero.
2. Pass the per-item content cross to `ComputeAlignItemsPlacement` for an auto item → `center`/`flex-end` use the real size for both the space math and the effective cross the geometry fragment paints. The `Stretch` branch ignores it (grows to the line extent), so **stretch is byte-identical**.

## Results (repro)
| case | before | after |
|---|---|---|
| auto-height row cards — bg / border fills | **0 / 0** | 3 / 3 (== explicit-height control) |
| `align-items: center` auto cards | decoration culled | painted |
| `align-items: flex-end` auto cards | decoration culled | painted |

## Tests & verification
- `FlexAutoCrossSizeRc11Tests` — auto-height cards == fixed-height control; center + flex-end auto items paint decoration.
- **Full suite green** — UnitTests 8532 passed; `RenderingCorpus` visual regression within tolerance (moves output toward Chrome); no flex regressions across 8500+ tests.

## Residual (documented)
- `flex-wrap: wrap` per-line cross is still declared-only (`FlexLinePacker.LineCrossSize`), so wrapped auto-height items (the 06-voucher overprint blocker) are a separate follow-up.
- Column containers (no row baseline data) unchanged — a pre-existing documented residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)