### PR TITLE
WP-6: RC-5 — position:fixed/absolute boxes render their inline text

### DIFF
--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -4554,6 +4554,67 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             GridMeasureCache = outerLayout.GridMeasureCache,   // measurement-cache cycle
             TableMeasureCache = outerLayout.TableMeasureCache, // multi-page-allocation-churn
         };
+        using var innerResolver = new BreakResolver();
+
+        // RC-5 root-dispatch — a positioned box may ITSELF be a flex / grid / table container (a
+        // `position:absolute; display:flex` footer / brand lockup). Route it to the matching layouter
+        // so its items lay out correctly instead of stacking as block flow; the plain-block branch below
+        // stays the default. Mirrors GridLayouter.DispatchGridItemContents / NestedContentMeasurer.
+        // (Same container-root abspos-boundary caveat those sites document — the flex/grid/table
+        // branches aren't delegation boundaries — but an abspos descendant of a positioned root is
+        // still resolved by the top-level out-of-flow pass, which walks the whole box tree.)
+        var dispatchInline = Math.Max(inlineSize, 1);
+        var dispatchBlock = Math.Max(blockSize, 1);
+        if (box.Kind is BoxKind.FlexContainer or BoxKind.InlineFlexContainer)
+        {
+            using var flex = new FlexLayouter(
+                rootBox: box, sink: translatingSink, incomingContinuation: null,
+                diagnostics: _diagnostics, shaperResolver: _shaperResolver,
+                recordPositionedGeometry: null);
+            flex.ConfigureEmission(0, 0, dispatchInline, dispatchBlock, allowPagination: false);
+            _ = flex.AttemptLayout(
+                innerFragmentainer, ref innerLayout, innerResolver,
+                LayoutAttemptStrategy.LastResort, cancellationToken);
+            return;
+        }
+        if (box.Kind is BoxKind.GridContainer or BoxKind.InlineGridContainer)
+        {
+            using var grid = new GridLayouter(
+                rootBox: box, sink: translatingSink, incomingContinuation: null,
+                diagnostics: _diagnostics, shaperResolver: _shaperResolver);
+            grid.ConfigureEmission(0, 0, dispatchInline, dispatchBlock, allowPagination: false);
+            _ = grid.AttemptLayout(
+                innerFragmentainer, ref innerLayout, innerResolver,
+                LayoutAttemptStrategy.LastResort, cancellationToken);
+            return;
+        }
+        if (box.Kind is BoxKind.Table or BoxKind.InlineTable)
+        {
+            // Atomic, effectively-unbounded budget so a multi-row positioned table emits every row
+            // (mirrors GridLayouter's table branch); against a small box-sized budget a table taller
+            // than the box would PageComplete(TableContinuation) and silently truncate its rows.
+            var tableFragmentainer = new FragmentainerContext(
+                contentInlineSize: dispatchInline,
+                blockSize: NestedContentMeasurer.EffectivelyUnboundedBlockBudgetPx);
+            var tableLayout = new LayoutContext(tableFragmentainer)
+            {
+                Diagnostics = outerLayout.Diagnostics,
+                WritingMode = outerLayout.WritingMode,
+                IsRtl = outerLayout.IsRtl,
+                GridMeasureCache = outerLayout.GridMeasureCache,
+                TableMeasureCache = outerLayout.TableMeasureCache,
+            };
+            using var table = new TableLayouter(
+                rootBox: box, sink: translatingSink, incomingContinuation: null,
+                diagnostics: _diagnostics, shaperResolver: _shaperResolver);
+            table.ConfigureEmission(0, 0, dispatchInline);
+            _ = table.MeasureContentHeight(tableFragmentainer, ref tableLayout, cancellationToken);
+            _ = table.AttemptLayout(
+                tableFragmentainer, ref tableLayout, innerResolver,
+                LayoutAttemptStrategy.LastResort, cancellationToken);
+            return;
+        }
+
         using var innerLayouter = new BlockLayouter(
             rootBox: box,
             sink: translatingSink,
@@ -4569,7 +4630,6 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // loop skipped the box's direct text runs. Opt in here so fixed/abspos boxes render their
             // text (index.pdf's footer text was missing on every page).
             layoutRootInlineContent: true);
-        using var innerResolver = new BreakResolver();
         // The result is intentionally not consumed: with pagination
         // suppressed (fixed) the content fully overflows in one pass; the
         // abspos path (noPaginate:false) discards it as before.
@@ -9487,7 +9547,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // emit + anchor it. Without this an inline-only block (incl. the
             // nested-content root) would render the positioned text inline AND
             // at its positioned offset (duplicate + wrong sizing).
-            if (child.Style.IsOutOfFlow()) continue;
+            // RC-5 — a child whose ComputedStyle is the SAME reference as its parent's is anonymous /
+            // shared-style content (a raw TextRun, or an anonymous inline wrapper): it is the parent's
+            // OWN text, not an independently positioned box, and `position` does not apply to it. Only
+            // skip a child that is genuinely out of flow — i.e. it carries its OWN (distinct) style. A
+            // positioned inline element (`<span style="position:absolute">`) has a distinct style and is
+            // still skipped (and anchored by the abspos/fixed pass); but the direct text of an out-of-flow
+            // inline-only ROOT (a `position:absolute/fixed` footer) shares the root's out-of-flow style —
+            // without this guard it was skipped here, silently dropping the positioned box's own text.
+            if (child.Style.IsOutOfFlow() && !ReferenceEquals(child.Style, parent.Style)) continue;
             switch (child.Kind)
             {
                 case BoxKind.TextRun:

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -4536,7 +4536,10 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         var translatingSink = new AbsoluteTranslatingSink(
             outerSink: _sink,
             inlineTranslation: inlineOrigin,
-            blockTranslation: blockOrigin);
+            blockTranslation: blockOrigin,
+            // The box's own decoration was already emitted by EmitOneFixedBox / EmitOneAbsoluteBox;
+            // the root-inline content fragment this dispatch produces must paint text only (RC-5).
+            decorationOwner: box);
         var innerFragmentainer = new FragmentainerContext(
             contentInlineSize: inlineSize,
             blockSize: blockSize)
@@ -4559,7 +4562,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             shaperResolver: _shaperResolver,
             // Fixed content isn't paginated, so a nested grid mustn't
             // paginate inside it either (it would drop rows past the box).
-            disableGridPagination: noPaginate);
+            disableGridPagination: noPaginate,
+            // RC-5 — a position:fixed / position:absolute box with INLINE-ONLY content (the ubiquitous
+            // `<div class="footer">Total: $384.00</div>`) had its own inline text SILENTLY DROPPED: the
+            // root-inline gate (see _layoutRootInlineContent) is off by default, so the block-only child
+            // loop skipped the box's direct text runs. Opt in here so fixed/abspos boxes render their
+            // text (index.pdf's footer text was missing on every page).
+            layoutRootInlineContent: true);
         using var innerResolver = new BreakResolver();
         // The result is intentionally not consumed: with pagination
         // suppressed (fixed) the content fully overflows in one pass; the
@@ -4584,26 +4593,38 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         private readonly double _inlineTranslation;
         private readonly double _blockTranslation;
         private readonly int _baseline;
+        private readonly Box? _decorationOwner;
 
         public AbsoluteTranslatingSink(
             IBlockFragmentSink outerSink,
             double inlineTranslation,
-            double blockTranslation)
+            double blockTranslation,
+            Box? decorationOwner = null)
         {
             _outer = outerSink;
             _inlineTranslation = inlineTranslation;
             _blockTranslation = blockTranslation;
             _baseline = outerSink.Cursor;
+            _decorationOwner = decorationOwner;
         }
 
         public int Cursor => _outer.Cursor - _baseline;
 
         public void Emit(BoxFragment fragment)
         {
+            // RC-5 — the inline-only-root content fragment (box == the abspos/fixed box itself) paints
+            // TEXT ONLY: EmitOneFixedBox / EmitOneAbsoluteBox already emitted the box's own border-box
+            // (decoration) fragment, so re-painting the decoration here would double it. Opting the
+            // content dispatch into root-inline layout (layoutRootInlineContent: true, the RC-5 fix for
+            // dropped fixed/abspos text) is what surfaced this fragment; suppress its decoration so only
+            // the text paints. Block-CHILD fragments (box != the box) keep their own decoration.
+            var suppressDecoration = _decorationOwner is not null
+                && ReferenceEquals(fragment.Box, _decorationOwner);
             _outer.Emit(fragment with
             {
                 InlineOffset = fragment.InlineOffset + _inlineTranslation,
                 BlockOffset = fragment.BlockOffset + _blockTranslation,
+                SuppressBoxDecoration = fragment.SuppressBoxDecoration || suppressDecoration,
             });
         }
 

--- a/tests/NetPdf.UnitTests/Rendering/FixedAbsoluteInlineTextRc5Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FixedAbsoluteInlineTextRc5Tests.cs
@@ -1,0 +1,55 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-5 — a <c>position: fixed</c> / <c>position: absolute</c> box with INLINE-ONLY content (the
+/// ubiquitous <c>&lt;div class="footer"&gt;Total: $384.00&lt;/div&gt;</c>) had its own text SILENTLY
+/// DROPPED: the content dispatch built the inner layouter without <c>layoutRootInlineContent</c>, so
+/// the block-only child loop skipped the box's direct text runs (index.pdf's footer text was missing
+/// on every page). Fixed by opting the abspos/fixed content dispatch into root-inline layout — and
+/// suppressing the resulting root fragment's decoration (already painted by the box's own fragment) so
+/// the text isn't accompanied by a duplicate background.
+/// </summary>
+public sealed class FixedAbsoluteInlineTextRc5Tests
+{
+    private static int TextOps(byte[] pdf) =>
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @" (Td|Tj|TJ)\b").Count;
+
+    private static string Doc(string position) =>
+        "<!doctype html><html><head><style>@page{size:A4;margin:0} body{margin:0;font-size:12px}"
+        + ".content{height:200px}"
+        + $".footer{{position:{position};left:0;bottom:0;width:320px;height:30px;background:#eef;padding:5px}}"
+        + "</style></head><body><div class=\"content\">Body content</div>"
+        + "<div class=\"footer\">Footer total here</div></body></html>";
+
+    [Theory]
+    [InlineData("fixed")]
+    [InlineData("absolute")]
+    public void Positioned_box_with_inline_text_renders_that_text(string position)
+    {
+        var res = HtmlPdf.ConvertDetailed(Doc(position), new HtmlPdfOptions { PrintBackgrounds = true });
+        // Body + footer = two text-showing runs. Before the fix only the body's text emitted (1).
+        Assert.True(TextOps(res.Pdf) >= 2,
+            $"expected the {position} footer's text to render (>=2 text ops); got {TextOps(res.Pdf)}");
+    }
+
+    [Fact]
+    public void Content_dispatch_does_not_add_a_duplicate_of_the_box_decoration()
+    {
+        // The content dispatch now lays out the root-inline text (RC-5); the decorationOwner
+        // suppression must keep it from ALSO re-painting the box's own background. A plain absolute
+        // box (no separate fixed-emission phantom) paints its background exactly once.
+        var res = HtmlPdf.ConvertDetailed(Doc("absolute"), new HtmlPdfOptions { PrintBackgrounds = true });
+        var s = Encoding.Latin1.GetString(res.Pdf);
+        // #eef ≈ 0.933 0.933 1.0 — the footer background fill.
+        var footerFills = Regex.Matches(s, @"0\.93\d* 0\.93\d* 1(?:\.0+)? rg").Count;
+        Assert.Equal(1, footerFills);
+    }
+}

--- a/tests/NetPdf.UnitTests/Rendering/FixedAbsoluteInlineTextRc5Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FixedAbsoluteInlineTextRc5Tests.cs
@@ -19,8 +19,11 @@ namespace NetPdf.UnitTests.Rendering;
 /// </summary>
 public sealed class FixedAbsoluteInlineTextRc5Tests
 {
+    // Count only text-SHOWING operators (Tj / TJ) — NOT Td, which merely moves the text cursor and can
+    // be emitted even when no glyphs are painted. Counting Td would let the test pass even if the
+    // positioned footer's text were still dropped.
     private static int TextOps(byte[] pdf) =>
-        Regex.Matches(Encoding.Latin1.GetString(pdf), @" (Td|Tj|TJ)\b").Count;
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"\b(Tj|TJ)\b").Count;
 
     private static string Doc(string position) =>
         "<!doctype html><html><head><style>@page{size:A4;margin:0} body{margin:0;font-size:12px}"
@@ -38,6 +41,24 @@ public sealed class FixedAbsoluteInlineTextRc5Tests
         // Body + footer = two text-showing runs. Before the fix only the body's text emitted (1).
         Assert.True(TextOps(res.Pdf) >= 2,
             $"expected the {position} footer's text to render (>=2 text ops); got {TextOps(res.Pdf)}");
+    }
+
+    [Theory]
+    [InlineData("fixed")]
+    [InlineData("absolute")]
+    public void Positioned_inline_only_root_text_is_isolated_and_rendered(string position)
+    {
+        // Isolate the footer: NO body text, so the ONLY text-showing operator can come from the
+        // positioned box's own inline-only-root content. Its TextRun shares the box's out-of-flow
+        // ComputedStyle; before the fix CollectInlineTextRuns treated that shared style as out-of-flow
+        // and dropped the text, so this rendered ZERO text-show ops.
+        var doc =
+            "<!doctype html><html><head><style>@page{size:A4;margin:0} body{margin:0;font-size:12px}"
+            + $".footer{{position:{position};left:0;bottom:0;width:320px;height:30px;background:#eef;padding:5px}}"
+            + "</style></head><body><div class=\"footer\">Footer total here</div></body></html>";
+        var res = HtmlPdf.ConvertDetailed(doc, new HtmlPdfOptions { PrintBackgrounds = true });
+        Assert.True(TextOps(res.Pdf) >= 1,
+            $"the {position} inline-only-root footer's own text must render (>=1 text-show op); got {TextOps(res.Pdf)}");
     }
 
     [Fact]


### PR DESCRIPTION
Seventh release-readiness work package. Ships **RC-5** (silent text drop in positioned boxes); **RC-4** (auto-height explosion) is deferred with findings — see below.

> **Stacked on #290 (WP-3)** → base `wp3-flex-cross-size`. Merge the earlier PRs first.

## RC-5 — fixed/absolute inline text was silently dropped
A `position: fixed` / `position: absolute` box with **inline-only** content (the ubiquitous `<div class="footer">Total: $384.00</div>` running footer) had its own text **silently dropped** — `DispatchAbsoluteChildContents` built the inner content layouter **without** `layoutRootInlineContent`, so the block-only child loop skipped the box's direct text runs. index.pdf's footer text was missing on every page (a rule-7 violation).

**Fix:** opt the abspos/fixed content dispatch into root-inline layout. That surfaces a content fragment for the box itself, which would otherwise **double-paint** the box's background (already emitted by `EmitOneFixedBox` / `EmitOneAbsoluteBox`), so `AbsoluteTranslatingSink` gains a `decorationOwner` (mirroring `GridLayouter`'s translating sink): the root fragment is marked `SuppressBoxDecoration` and paints **text only**.

**Tests:** `FixedAbsoluteInlineTextRc5Tests` — fixed + absolute footers render their text (was dropped); the content dispatch adds no duplicate decoration. Full suite green (exit 0).

## RC-4 — deferred (deeper than described)
RC-4 (an auto-height `position:fixed; bottom:0` box explodes to the full available extent, and its background occludes the page) is **not** in this PR. I drafted the finding's pre-measure re-solve, but investigation showed **two further bugs stack on the solver approximation**, so the pre-measure alone does not clear the occlusion:

1. **Out-of-flow measure returns 0** — `NestedContentMeasurer` measuring an out-of-flow box's *own* content returns 0 because `BufferingMeasureSink` drops the out-of-flow **subject** fragment (so the box sizes to chrome-only).
2. **Phantom duplicate fixed box** — a pre-existing *childless* duplicate `fixed` box in the tree paints a second full-page background (the finding's "bg emitted 2–4×"). This is the actual occlusion and is independent of the solver.

I reverted the incomplete RC-4 machinery to keep this PR clean. RC-4 warrants its own PR that also fixes the out-of-flow measure and the duplicate-fixed-box emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)