### PR TITLE
WP-7: RC-13 empty-value clobber (zebra via var) + RC-12 text-transform consumer

### DIFF
--- a/src/NetPdf.Css/Parser/CssParserAdapter.cs
+++ b/src/NetPdf.Css/Parser/CssParserAdapter.cs
@@ -1097,14 +1097,23 @@ internal static class CssParserAdapter
         foreach (var property in properties)
         {
             if (property is null || string.IsNullOrEmpty(property.Name)) continue;
-            // RC-13 — skip EMPTY-valued declarations. AngleSharp expands a shorthand whose value is a
-            // `var()` reference (e.g. `background: var(--tint)`) into its ~10 longhands with EMPTY-STRING
-            // values (it can't resolve the custom property at parse time). Forwarding those as real
-            // declarations let a later empty `background-color: ""` WIN the cascade over the
-            // preprocessor-recovered `background-color: var(--tint)`, painting the element transparent
-            // (the missing zebra stripes in 07/08). An empty declaration value is invalid CSS and must
-            // never enter the cascade; the recovery path carries the real `var()` value.
-            if (string.IsNullOrWhiteSpace(property.Value)) continue;
+            // RC-13 — skip EMPTY-valued declarations, but ONLY for standard properties. AngleSharp expands
+            // a shorthand whose value is a `var()` reference (e.g. `background: var(--tint)`) into its ~10
+            // longhands with EMPTY-STRING values (it can't resolve the custom property at parse time).
+            // Forwarding those as real declarations let a later empty `background-color: ""` WIN the cascade
+            // over the preprocessor-recovered `background-color: var(--tint)`, painting the element
+            // transparent (the missing zebra stripes in 07/08). An empty STANDARD declaration value is
+            // invalid CSS and must never enter the cascade; the recovery path carries the real `var()`
+            // value. A CUSTOM property (`--x`) is EXEMPT: an empty token stream (`--x: ;`) is VALID and
+            // meaningful — dropping it before VarResolver collects it would change `var(--x, fallback)`
+            // semantics (wrongly falling back / removing a theme token).
+            // Scope the empty-value drop to STANDARD properties. Today AngleSharp already omits an empty
+            // custom property (`--x: ;`) upstream, so this branch only ever sees the empty standard
+            // longhands the shorthand-var() expansion produces — but guarding it keeps the drop from ever
+            // removing an authored custom-property declaration (whose empty token stream is valid and must
+            // reach VarResolver) should that upstream behavior change.
+            var isCustomProperty = property.Name.StartsWith("--", StringComparison.Ordinal);
+            if (!isCustomProperty && string.IsNullOrWhiteSpace(property.Value)) continue;
             output.Add(new CssDeclaration(
                 Property: property.Name,
                 Value: new CssValue(property.Value ?? string.Empty),

--- a/src/NetPdf.Css/Parser/CssParserAdapter.cs
+++ b/src/NetPdf.Css/Parser/CssParserAdapter.cs
@@ -1097,6 +1097,14 @@ internal static class CssParserAdapter
         foreach (var property in properties)
         {
             if (property is null || string.IsNullOrEmpty(property.Name)) continue;
+            // RC-13 — skip EMPTY-valued declarations. AngleSharp expands a shorthand whose value is a
+            // `var()` reference (e.g. `background: var(--tint)`) into its ~10 longhands with EMPTY-STRING
+            // values (it can't resolve the custom property at parse time). Forwarding those as real
+            // declarations let a later empty `background-color: ""` WIN the cascade over the
+            // preprocessor-recovered `background-color: var(--tint)`, painting the element transparent
+            // (the missing zebra stripes in 07/08). An empty declaration value is invalid CSS and must
+            // never enter the cascade; the recovery path carries the real `var()` value.
+            if (string.IsNullOrWhiteSpace(property.Value)) continue;
             output.Add(new CssDeclaration(
                 Property: property.Name,
                 Value: new CssValue(property.Value ?? string.Empty),

--- a/src/NetPdf.Layout/Inline/LineBuilder.cs
+++ b/src/NetPdf.Layout/Inline/LineBuilder.cs
@@ -2370,6 +2370,14 @@ internal static class LineBuilder
         for (var i = 0; i < text.Length; i++)
         {
             var c = text[i];
+            // Apostrophes — straight ' (U+0027) and the typographic ' (U+2019) — are INTRA-word in
+            // contractions / possessives (don't, Roland's) per CSS Text L3 §2.1.1 (a "word" is a UAX #29
+            // word). Treat them as TRANSPARENT: neither starting a new word (so "don't" → "Don't", not
+            // "Don'T") nor consuming a pending word-start (so a leading "'twas" still yields "'Twas").
+            if (c is '\u0027' or '\u2019')
+            {
+                continue;
+            }
             if (char.IsWhiteSpace(c) || char.IsPunctuation(c) || char.IsSeparator(c) || char.IsSymbol(c))
             {
                 atWordStart = true;

--- a/src/NetPdf.Layout/Inline/LineBuilder.cs
+++ b/src/NetPdf.Layout/Inline/LineBuilder.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using NetPdf.Css.Properties;
+using NetPdf.Layout.Layouters;
 using NetPdf.Text.Bidi;
 using NetPdf.Text.Hyphenation;
 using NetPdf.Text.LineBreaking;
@@ -2258,6 +2260,9 @@ internal static class LineBuilder
     {
         ArgumentNullException.ThrowIfNull(runs);
         if (runs.Count == 0) return runs;
+        // RC-12 — apply `text-transform` per run BEFORE white-space processing + shaping. `text-transform`
+        // was registered but consumed NOWHERE, so `uppercase` etc. rendered as the original case.
+        runs = ApplyTextTransforms(runs);
 
         if (mode is WhiteSpace.Pre or WhiteSpace.PreWrap or WhiteSpace.BreakSpaces)
         {
@@ -2311,6 +2316,77 @@ internal static class LineBuilder
         }
 
         return output;
+    }
+
+    /// <summary>RC-12 — apply each run's <c>text-transform</c> (CSS Text L3 §2.1) to its text before
+    /// white-space processing + shaping. Returns the SAME list when no run is transformed (the common
+    /// case, byte-identical). Atomic runs (U+FFFC) and whitespace pass through unchanged. <c>capitalize</c>
+    /// detects word starts WITHIN a run; a word straddling a run boundary is a documented residual
+    /// (deferrals.md). Casing is invariant-culture — locale-tailored casing is a documented residual.</summary>
+    private static IReadOnlyList<TextRun> ApplyTextTransforms(IReadOnlyList<TextRun> runs)
+    {
+        TextRun[]? copy = null;
+        for (var i = 0; i < runs.Count; i++)
+        {
+            var transformed = ApplyTextTransform(runs[i]);
+            if (!string.Equals(transformed.Text, runs[i].Text, StringComparison.Ordinal))
+            {
+                if (copy is null)
+                {
+                    copy = new TextRun[runs.Count];
+                    for (var j = 0; j < runs.Count; j++) copy[j] = runs[j];
+                }
+                copy[i] = transformed;
+            }
+        }
+        return copy ?? runs;
+    }
+
+    private static TextRun ApplyTextTransform(TextRun run)
+    {
+        // Atomic (U+FFFC) runs are opaque; empty text has nothing to transform.
+        if (run.Atomic is not null || run.Text.Length == 0) return run;
+        // Keyword contract (KeywordResolver): none=0, capitalize=1, uppercase=2, lowercase=3;
+        // full-width=4 / full-size-kana=5 are deferred (pass through).
+        var tt = run.Style.ReadKeywordOrDefault(PropertyId.TextTransform, defaultIndex: 0);
+        var transformed = tt switch
+        {
+            1 => Capitalize(run.Text),
+            2 => run.Text.ToUpperInvariant(),
+            3 => run.Text.ToLowerInvariant(),
+            _ => run.Text,
+        };
+        return string.Equals(transformed, run.Text, StringComparison.Ordinal)
+            ? run
+            : new TextRun(transformed, run.Style);
+    }
+
+    /// <summary>CSS <c>text-transform: capitalize</c> — upper-case the first typographic letter of each
+    /// WORD (a letter after whitespace / punctuation / separator / symbol, or the run start).</summary>
+    private static string Capitalize(string text)
+    {
+        char[]? chars = null;
+        var atWordStart = true;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (char.IsWhiteSpace(c) || char.IsPunctuation(c) || char.IsSeparator(c) || char.IsSymbol(c))
+            {
+                atWordStart = true;
+                continue;
+            }
+            if (atWordStart)
+            {
+                var up = char.ToUpperInvariant(c);
+                if (up != c)
+                {
+                    chars ??= text.ToCharArray();
+                    chars[i] = up;
+                }
+            }
+            atWordStart = false;
+        }
+        return chars is null ? text : new string(chars);
     }
 
     /// <summary>Per Phase 3 Task 10 cycle 3d sub-cycle 1 — per-source-
@@ -2407,6 +2483,9 @@ internal static class LineBuilder
         // Per cycle 3d sub-cycle 1 review Rec #4 — pre-cancelled
         // tokens fast-path out before any allocation.
         cancellationToken.ThrowIfCancellationRequested();
+
+        // RC-12 — apply `text-transform` per run BEFORE white-space processing + shaping.
+        runs = ApplyTextTransforms(runs);
 
         var output = new TextRun[runs.Count];
         // Initial `inWs = true` strips document-leading whitespace

--- a/tests/NetPdf.UnitTests/Css/Cascade/VarResolverTests.cs
+++ b/tests/NetPdf.UnitTests/Css/Cascade/VarResolverTests.cs
@@ -174,28 +174,25 @@ public sealed class VarResolverTests
     [Fact]
     public async Task Multiple_vars_in_single_value_all_resolve()
     {
-        // Test against a longhand property so AngleSharp preserves the var()-bearing value.
+        // Test against a genuine LONGHAND (transform) so AngleSharp preserves the var()-bearing value as
+        // a single pending-substitution value with MULTIPLE var() refs — a var()-in-shorthand (e.g.
+        // padding) is expanded to EMPTY longhands AngleSharp can't resolve, and those empty declarations
+        // are (correctly, RC-13) dropped before the cascade rather than falsely "resolving" to nothing.
         var doc = await ParseHtml("<p>x</p>");
         var sheet = await ParseSheet(
-            "p { --w: 2px; --c: red; padding: var(--w) var(--w) var(--w) var(--c) }");
+            "p { --a: 5px; --b: 10px; transform: translate(var(--a), var(--b)) }");
         var cascade = CascadeResolver.Resolve(doc, ImmutableArray.Create(sheet),
             CssMediaContext.DefaultPrint);
         var resolved = VarResolver.Resolve(cascade, doc);
 
         var styles = resolved.TryGetStylesFor(Q(doc, "p"));
         Assert.NotNull(styles);
-        // At least one padding-* longhand should hold the substituted value.
-        bool foundSubstitution = false;
-        foreach (var name in styles!.Properties)
-        {
-            if (!name.StartsWith("padding", System.StringComparison.Ordinal)) continue;
-            var winner = styles.GetWinner(name);
-            if (winner is null) continue;
-            // After var() substitution, neither var( nor --w/--c remain in the resolved text.
-            Assert.DoesNotContain("var(", winner.ResolvedValue);
-            foundSubstitution = true;
-        }
-        Assert.True(foundSubstitution, "expected at least one padding-* longhand with substitution");
+        var transform = styles!.GetWinner("transform");
+        Assert.NotNull(transform);
+        // BOTH var()s substituted: neither var( nor the custom-property names remain.
+        Assert.DoesNotContain("var(", transform!.ResolvedValue);
+        Assert.Contains("5px", transform.ResolvedValue);
+        Assert.Contains("10px", transform.ResolvedValue);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Rendering/CssPipelineWp7Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/CssPipelineWp7Tests.cs
@@ -68,4 +68,15 @@ public sealed class CssPipelineWp7Tests
     {
         Assert.True(Para("text-transform:capitalize", "hello world").SequenceEqual(Para("", "Hello World")));
     }
+
+    [Fact]
+    public void Text_transform_capitalize_keeps_apostrophe_words_intact()
+    {
+        // Apostrophes are intra-word (CSS Text L3 §2.1.1): "don't" → "Don't", NOT "Don'T"; and a
+        // possessive "roland's" → "Roland's". Before the fix the apostrophe reset the word-start flag
+        // so the letter after it was wrongly capitalized.
+        Assert.True(Para("text-transform:capitalize", "don't worry").SequenceEqual(Para("", "Don't Worry")));
+        Assert.False(Para("text-transform:capitalize", "don't worry").SequenceEqual(Para("", "Don'T Worry")));
+        Assert.True(Para("text-transform:capitalize", "roland's cat").SequenceEqual(Para("", "Roland's Cat")));
+    }
 }

--- a/tests/NetPdf.UnitTests/Rendering/CssPipelineWp7Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/CssPipelineWp7Tests.cs
@@ -1,0 +1,71 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// WP-7 — two CSS-pipeline defects. RC-13: AngleSharp expands a shorthand with a <c>var()</c> value
+/// (e.g. <c>background: var(--tint)</c>) into ~10 EMPTY-valued longhands; forwarding those let a later
+/// empty <c>background-color</c> win the cascade over the preprocessor-recovered value, painting the
+/// element transparent (missing zebra stripes). RC-12: <c>text-transform</c> was registered but consumed
+/// nowhere, so <c>uppercase</c>/<c>lowercase</c>/<c>capitalize</c> rendered the original case.
+/// </summary>
+public sealed class CssPipelineWp7Tests
+{
+    private static int BgFills(string html, string colorRegex)
+    {
+        var res = HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true });
+        return Regex.Matches(Encoding.Latin1.GetString(res.Pdf), colorRegex).Count;
+    }
+
+    // ---- RC-13: background via var() paints (was clobbered by empty longhands) ----
+
+    [Fact]
+    public void Background_via_var_is_not_clobbered_by_empty_longhands()
+    {
+        // #ffeeee ≈ 1 0.933 0.933. Two even rows → two zebra fills, same as a literal color.
+        const string tail =
+            "table{border-collapse:collapse}td{padding:4px}tbody tr:nth-child(even){background:%BG%}"
+            + "</style></head><body><table><tbody>"
+            + "<tr><td>1</td></tr><tr><td>2</td></tr><tr><td>3</td></tr><tr><td>4</td></tr>"
+            + "</tbody></table></body></html>";
+        var viaVar = "<!doctype html><html><head><style>:root{--tint:#ffeeee}" + tail.Replace("%BG%", "var(--tint)");
+        var viaLiteral = "<!doctype html><html><head><style>" + tail.Replace("%BG%", "#ffeeee");
+
+        var literalFills = BgFills(viaLiteral, @"1 0\.93\d* 0\.93\d* rg");
+        Assert.Equal(2, literalFills);                       // control
+        Assert.Equal(literalFills, BgFills(viaVar, @"1 0\.93\d* 0\.93\d* rg"));
+    }
+
+    // ---- RC-12: text-transform ----
+
+    private static byte[] Para(string css, string text) =>
+        HtmlPdf.Convert($"<!doctype html><html><head><style>p{{{css}}}</style></head><body><p>{text}</p></body></html>");
+
+    [Fact]
+    public void Text_transform_uppercase_renders_like_literal_upper_case()
+    {
+        // uppercase("hello world") must produce the same bytes as the literal "HELLO WORLD".
+        Assert.True(Para("text-transform:uppercase", "hello world").SequenceEqual(Para("", "HELLO WORLD")));
+        // ...and must NOT equal the untransformed lower-case rendering.
+        Assert.False(Para("text-transform:uppercase", "hello world").SequenceEqual(Para("", "hello world")));
+    }
+
+    [Fact]
+    public void Text_transform_lowercase_renders_like_literal_lower_case()
+    {
+        Assert.True(Para("text-transform:lowercase", "HELLO WORLD").SequenceEqual(Para("", "hello world")));
+    }
+
+    [Fact]
+    public void Text_transform_capitalize_upper_cases_each_word_start()
+    {
+        Assert.True(Para("text-transform:capitalize", "hello world").SequenceEqual(Para("", "Hello World")));
+    }
+}


### PR DESCRIPTION
Eighth release-readiness work package (CSS pipeline). Two independent defects.

> **Stacked on #291 (WP-6)** → base `wp6-abspos-fixed`. Merge the earlier PRs first.

## RC-13 — `background: var()` painted transparent (missing zebra stripes)
AngleSharp expands a shorthand whose value is a `var()` reference into its ~10 longhands with **empty-string** values (it can't resolve the custom property at parse time). `CssParserAdapter.AdaptProperties` forwarded those empty declarations, so a later empty `background-color: ""` **won the cascade** over the preprocessor-recovered `background-color: var(--tint)` → transparent (the missing zebra stripes in 07/08).

**Fix:** skip empty/whitespace-valued declarations in `AdaptProperties` — an empty declaration value is invalid CSS and must never enter the cascade; the recovery path carries the real `var()` value.

**Proof:** zebra via `var()` `0 → 2` fills, matching a literal color.

## RC-12 — `text-transform` was a no-op
`text-transform` was registered but consumed **nowhere**, so `uppercase` / `lowercase` / `capitalize` rendered the original case. Now applied per run in `LineBuilder.PreprocessTextRuns[PerRun]` before white-space processing + shaping. uppercase/lowercase are invariant-culture maps; `capitalize` upper-cases each within-run word start.

**Proof:** `uppercase("hello")` is **byte-identical** to the literal `HELLO`; `capitalize("hello world") == "Hello World"`.

## Tests & verification
- `CssPipelineWp7Tests` — var() background not clobbered; uppercase/lowercase/capitalize render like their literal-case equivalents.
- Updated `VarResolverTests.Multiple_vars_in_single_value_all_resolve`: it used a `var()`-in-**shorthand** (`padding`) that expands to empty longhands and only "passed" because the empties trivially contained no `var(`. It now exercises a real longhand (`transform`) with two `var()` refs that actually substitute.
- **Full suite green** (`dotnet test NetPdf.slnx -c Release`, exit 0).

## Deferred follow-ups
- RC-13 part (1) — `SelectorTextEquivalent` `an+b` (even↔2n) canonicalization (a cursor-desync that duplicates rules wholesale, a cascade-order hazard beyond `var()`; the reported zebra is fixed by the empty-value drop alone).
- Register `font-variant` + an unsupported-feature diagnostic (small-caps).
- `text-transform` residuals: capitalize word-starts across a run boundary; locale-tailored casing; full-width / full-size-kana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)