### PR TITLE
RC-4: auto-height fixed/absolute boxes are content-sized, not page-sized (WP-6 follow-up)

### DIFF
--- a/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
@@ -347,6 +347,21 @@ internal static class AbsoluteLayouter
             + ReadPxOrPct(st, PropertyId.PaddingRight, cbInlineSize);
         return System.Math.Max(0, borderBoxInlineSize - chrome);
     }
+
+    /// <summary>The box's BLOCK-axis border + padding sum (top + bottom). Percentage padding resolves
+    /// against <paramref name="cbInlineSize"/> — the SAME base <see cref="ResolvePlacement"/>'s block
+    /// <c>SolveAxis</c> uses (CSS 2.1 §8.4). Callers that measured a box's BORDER-box block extent (an
+    /// inline-only ROOT's own-box fragment) subtract this to obtain the CONTENT-box height that
+    /// <c>ResolvePlacement(measuredBlockContentSize:)</c> expects — it re-adds the chrome internally, so
+    /// passing the border-box extent would double-count border + padding (#293 review).</summary>
+    public static double BlockAxisChrome(Box box, double cbInlineSize)
+    {
+        var st = box.Style;
+        return st.ReadLengthPxOrZero(PropertyId.BorderTopWidth)
+            + st.ReadLengthPxOrZero(PropertyId.BorderBottomWidth)
+            + ReadPxOrPct(st, PropertyId.PaddingTop, cbInlineSize)
+            + ReadPxOrPct(st, PropertyId.PaddingBottom, cbInlineSize);
+    }
 }
 
 /// <summary>Per Phase 3 Task 19 — the containing block for an

--- a/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/AbsoluteLayouter.cs
@@ -52,7 +52,10 @@ internal static class AbsoluteLayouter
     /// longer produced here — the <c>BlockLayouter</c>'s null-containing-
     /// block path is the drop site.</summary>
     public static AbsolutePlacement ResolvePlacement(
-        Box box, AbsoluteContainingBlock cb)
+        Box box, AbsoluteContainingBlock cb,
+        // RC-4 — the CONTENT block extent for an auto-height box, pre-measured by the caller at the
+        // resolved content-inline size. NaN = not supplied → the legacy available-extent approximation.
+        double measuredBlockContentSize = double.NaN)
     {
         var style = box.Style;
 
@@ -89,7 +92,8 @@ internal static class AbsoluteLayouter
             paddingEnd: ReadPxOrPct(style, PropertyId.PaddingBottom, cb.InlineSize),
             borderEnd: style.ReadLengthPxOrZero(PropertyId.BorderBottomWidth),
             cbExtent: cb.BlockSize,
-            isInlineAxis: false);
+            isInlineAxis: false,
+            measuredContentSize: measuredBlockContentSize);
 
         // SolveAxis already clamps a negative resolved content size to
         // 0 (CSS clamps used width/height to >= 0), so inlineSize /
@@ -114,7 +118,7 @@ internal static class AbsoluteLayouter
         double? insetStart, double? insetEnd, double? size,
         double? marginStart, double? marginEnd,
         double borderStart, double paddingStart, double paddingEnd, double borderEnd,
-        double cbExtent, bool isInlineAxis)
+        double cbExtent, bool isInlineAxis, double measuredContentSize = double.NaN)
     {
         var chrome = borderStart + paddingStart + paddingEnd + borderEnd;
         var startAuto = insetStart is null;
@@ -190,9 +194,13 @@ internal static class AbsoluteLayouter
 
         if (sizeAuto)
         {
-            // Size auto → shrink-to-fit (inline) / content height
-            // (block), approximated as the AVAILABLE extent. EXACT when
-            // both insets pin it (fill).
+            // Size auto → shrink-to-fit (inline) / content height (block). RC-4 — for the BLOCK axis a
+            // caller-supplied `measuredContentSize` (the box's pre-measured content height) is the CSS
+            // 2.1 §10.6.4 used height for a SINGLE-anchored box; without it the legacy approximation used
+            // the AVAILABLE extent, so a `position:fixed; bottom:0; height:auto` footer's height (and its
+            // background) exploded to the FULL page and painted over everything. The `fill` case (both
+            // insets) genuinely fills, so it never uses the measured size.
+            var useMeasured = !isInlineAxis && !double.IsNaN(measuredContentSize);
             if (!startAuto && !endAuto)
             {
                 // Fill: both insets given → size = remaining space.
@@ -202,26 +210,30 @@ internal static class AbsoluteLayouter
             }
             else if (!startAuto)
             {
-                // start given, end auto → available from start to CB end.
+                // start given, end auto → content height (block); available extent otherwise.
                 usedStart = insetStart!.Value;
-                usedSize = cbExtent - insetStart.Value - marS - marE - chrome;
+                usedSize = useMeasured
+                    ? measuredContentSize
+                    : cbExtent - insetStart.Value - marS - marE - chrome;
             }
             else if (!endAuto)
             {
-                // end given, start auto → END-anchored. Size fills from
-                // the CB start to the end inset; the box's end edge stays
-                // pinned at the end inset. usedStart is recomputed from
-                // that anchor AFTER the clamp (below) so a clamped-to-
-                // zero size still honors the end inset.
-                usedSize = cbExtent - insetEnd!.Value - marS - marE - chrome;
+                // end given, start auto → END-anchored. Size = content height (block); the box's end edge
+                // stays pinned at the end inset. usedStart is recomputed post-clamp so a clamped-to-zero
+                // size still honors the end inset.
+                usedSize = useMeasured
+                    ? measuredContentSize
+                    : cbExtent - insetEnd!.Value - marS - marE - chrome;
                 usedStart = StaticPosition;  // provisional; recomputed post-clamp
                 endAnchored = true;
             }
             else
             {
-                // all auto → start = static position; size = available.
+                // all auto → start = static position; size = content height (block) or available.
                 usedStart = StaticPosition;
-                usedSize = cbExtent - StaticPosition - marS - marE - chrome;
+                usedSize = useMeasured
+                    ? measuredContentSize
+                    : cbExtent - StaticPosition - marS - marE - chrome;
             }
         }
         else
@@ -311,6 +323,29 @@ internal static class AbsoluteLayouter
             ComputedSlotTag.Percentage => slot.AsPercentage() / 100.0 * pctBase,
             _ => 0.0,
         };
+    }
+
+    private static bool IsDefinite(ComputedStyle style, PropertyId id) =>
+        style.Get(id).Tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
+
+    /// <summary>RC-4 — true when the box has an AUTO block size NOT pinned by BOTH top and bottom
+    /// (single-anchored or all-auto). Only these need a content-height pre-measure.</summary>
+    public static bool NeedsAutoBlockContentMeasure(Box box)
+    {
+        if (IsDefinite(box.Style, PropertyId.Height)) return false;
+        return !(IsDefinite(box.Style, PropertyId.Top) && IsDefinite(box.Style, PropertyId.Bottom));
+    }
+
+    /// <summary>The box's CONTENT-box inline size given its resolved border-box inline size (subtract the
+    /// inline padding + border; percentages resolve against <paramref name="cbInlineSize"/>).</summary>
+    public static double ContentInlineSize(Box box, double borderBoxInlineSize, double cbInlineSize)
+    {
+        var st = box.Style;
+        var chrome = st.ReadLengthPxOrZero(PropertyId.BorderLeftWidth)
+            + st.ReadLengthPxOrZero(PropertyId.BorderRightWidth)
+            + ReadPxOrPct(st, PropertyId.PaddingLeft, cbInlineSize)
+            + ReadPxOrPct(st, PropertyId.PaddingRight, cbInlineSize);
+        return System.Math.Max(0, borderBoxInlineSize - chrome);
     }
 }
 

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -4321,6 +4321,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             return;
         }
 
+        placement = RemeasureAutoHeightPlacement(child, containingBlock.Value, placement, ref layout, cancellationToken);
+
         // Emit the border-box fragment at the resolved position.
         _sink.Emit(new BoxFragment(
             Box: child,
@@ -4424,7 +4426,15 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         foreach (var child in box.Children)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (child.Style.IsFixedPositioned())
+            // Only a GENUINE positioned box (an element whose OWN style is position:fixed) is emitted.
+            // `position` does not inherit, so a real child ELEMENT of a fixed box is static — but a
+            // TextRun / anonymous box REUSES its parent's whole ComputedStyle by reference (CSS 2.1
+            // §9.2.1.1), so the text node inside a fixed box spuriously reports IsFixedPositioned and,
+            // emitted, re-paints the box's background as a SECOND full-page rect (RC-4's "bg emitted
+            // 2-4x" occlusion). Mirror the abspos pass's guard (EmitAbsolutelyPositionedDescendants):
+            // a real fixed box is never a TextRun or an anonymous block.
+            if (child.Style.IsFixedPositioned()
+                && child.Kind is not (BoxKind.TextRun or BoxKind.AnonymousBlock))
             {
                 // Emit + dispatch this fixed box's own content...
                 EmitOneFixedBox(child, pageCb, ref layout, cancellationToken);
@@ -4467,6 +4477,7 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         CancellationToken cancellationToken)
     {
         var placement = AbsoluteLayouter.ResolvePlacement(child, pageCb);
+        placement = RemeasureAutoHeightPlacement(child, pageCb, placement, ref layout, cancellationToken);
         _sink.Emit(new BoxFragment(
             Box: child,
             InlineOffset: placement.InlineOffset,
@@ -4523,6 +4534,30 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// paginated) rather than being clipped. The abspos caller passes
     /// <c>noPaginate: false</c> (it paginates + discards the result —
     /// a separate pre-existing item).</para></summary>
+    /// <summary>RC-4 — for an AUTO-block-size single-anchored abspos / fixed box, re-solve its placement
+    /// using the box's MEASURED content height instead of the available-extent approximation, so the box
+    /// (and its background) is content-sized rather than page-sized. A no-op for a definite height, a
+    /// top+bottom-pinned (fill) box, or a box with no content / no inline extent.</summary>
+    private AbsolutePlacement RemeasureAutoHeightPlacement(
+        Box box, AbsoluteContainingBlock cb, AbsolutePlacement placement,
+        ref LayoutContext layout, CancellationToken cancellationToken)
+    {
+        if (!AbsoluteLayouter.NeedsAutoBlockContentMeasure(box)
+            || box.Children.Count == 0 || placement.InlineSize <= 0)
+        {
+            return placement;
+        }
+        var contentInline = AbsoluteLayouter.ContentInlineSize(box, placement.InlineSize, cb.InlineSize);
+        if (contentInline <= 0) return placement;
+        var measured = NestedContentMeasurer.Measure(
+            box, contentInline, NestedContentMeasurer.EffectivelyUnboundedBlockBudgetPx,
+            _shaperResolver, layout.WritingMode, layout.IsRtl, cancellationToken,
+            diagnostics: _diagnostics,
+            purpose: MeasurePurpose.DefiniteWidthExtent).ContentBlockExtent;
+        if (double.IsNaN(measured) || measured < 0) return placement;
+        return AbsoluteLayouter.ResolvePlacement(box, cb, measuredBlockContentSize: measured);
+    }
+
     private void DispatchAbsoluteChildContents(
         Box box,
         double inlineOrigin,
@@ -9540,21 +9575,22 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             cancellationToken.ThrowIfCancellationRequested();
             var child = parent.Children[i];
             // PR-#182 Copilot review — an out-of-flow (position: absolute /
-            // fixed) inline-level descendant does NOT participate in inline
+            // fixed) inline-level descendant ELEMENT does NOT participate in inline
             // flow (CSS 2.2 §9.3 — it's removed from the normal flow). Skip it
             // (and don't recurse into its subtree) so its text never contributes
             // to the line layout / measurement here; the abspos / fixed passes
             // emit + anchor it. Without this an inline-only block (incl. the
             // nested-content root) would render the positioned text inline AND
             // at its positioned offset (duplicate + wrong sizing).
-            // RC-5 — a child whose ComputedStyle is the SAME reference as its parent's is anonymous /
-            // shared-style content (a raw TextRun, or an anonymous inline wrapper): it is the parent's
-            // OWN text, not an independently positioned box, and `position` does not apply to it. Only
-            // skip a child that is genuinely out of flow — i.e. it carries its OWN (distinct) style. A
-            // positioned inline element (`<span style="position:absolute">`) has a distinct style and is
-            // still skipped (and anchored by the abspos/fixed pass); but the direct text of an out-of-flow
-            // inline-only ROOT (a `position:absolute/fixed` footer) shares the root's out-of-flow style —
-            // without this guard it was skipped here, silently dropping the positioned box's own text.
+            // RC-5 / RC-4 — a child whose ComputedStyle is the SAME reference as its parent's is
+            // anonymous / shared-style content (a raw TextRun, or an anonymous inline wrapper): it is the
+            // parent's OWN text, not an independently positioned box, and `position` does not apply to it
+            // (position doesn't inherit). Only skip a child that is genuinely out of flow — i.e. it carries
+            // its OWN (distinct) style. A positioned inline element (`<span style="position:absolute">`)
+            // has a distinct style and is still skipped (and anchored by the abspos/fixed pass); but the
+            // direct text of an out-of-flow inline-only ROOT (a `position:absolute/fixed` footer) shares
+            // the root's out-of-flow style — without this guard it was skipped here, silently dropping the
+            // positioned box's own text (which also made an auto-height box measure 0 content → chrome-only).
             if (child.Style.IsOutOfFlow() && !ReferenceEquals(child.Style, parent.Style)) continue;
             switch (child.Kind)
             {

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -4549,12 +4549,22 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         }
         var contentInline = AbsoluteLayouter.ContentInlineSize(box, placement.InlineSize, cb.InlineSize);
         if (contentInline <= 0) return placement;
-        var measured = NestedContentMeasurer.Measure(
+        var measureSink = NestedContentMeasurer.Measure(
             box, contentInline, NestedContentMeasurer.EffectivelyUnboundedBlockBudgetPx,
             _shaperResolver, layout.WritingMode, layout.IsRtl, cancellationToken,
             diagnostics: _diagnostics,
-            purpose: MeasurePurpose.DefiniteWidthExtent).ContentBlockExtent;
+            purpose: MeasurePurpose.DefiniteWidthExtent);
+        var measured = measureSink.ContentBlockExtent;
         if (double.IsNaN(measured) || measured < 0) return placement;
+        // #293 review — when the box laid out as an INLINE-ONLY ROOT, its own-box fragment IS the box's
+        // BORDER box, so ContentBlockExtent already includes the box's block border + padding. But
+        // ResolvePlacement treats measuredBlockContentSize as a CONTENT-box size and adds that chrome
+        // itself, so pass the content-box extent — otherwise border + padding is double-counted and the
+        // auto-height box (and its background) is too tall. Block-CHILD buffers are already content-box.
+        if (measureSink.ContainsDecorationOwnerFragment)
+        {
+            measured = System.Math.Max(0, measured - AbsoluteLayouter.BlockAxisChrome(box, cb.InlineSize));
+        }
         return AbsoluteLayouter.ResolvePlacement(box, cb, measuredBlockContentSize: measured);
     }
 

--- a/src/NetPdf.Layout/Layouters/BufferingMeasureSink.cs
+++ b/src/NetPdf.Layout/Layouters/BufferingMeasureSink.cs
@@ -143,7 +143,15 @@ internal sealed class BufferingMeasureSink : IBlockFragmentSink
         // abspos / fixed passes run AFTER the in-flow child loop that captures
         // cursors + issues UpdateFragmentBlockSize, so no in-flow cursor target
         // is shifted by a skipped out-of-flow emission.
-        if (fragment.Box.Style.IsOutOfFlow()) return;
+        // RC-4 — but when the MEASUREMENT SUBJECT itself is out-of-flow (measuring an abspos/fixed box's
+        // OWN content so its root fragment carries the content extent = decorationOwner), COUNT it, else
+        // the content-height pre-measure returns 0 and the box sizes to chrome-only. Out-of-flow
+        // DESCENDANTS (box != the subject) are still dropped.
+        if (fragment.Box.Style.IsOutOfFlow()
+            && !(_decorationOwner is not null && ReferenceEquals(fragment.Box, _decorationOwner)))
+        {
+            return;
+        }
 
         // The inline-only-root content fragment (box == the item) paints text
         // only — its decoration is the item's flex / grid geometry fragment's

--- a/tests/NetPdf.UnitTests/Rendering/AbsPosAutoHeightRc4Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/AbsPosAutoHeightRc4Tests.cs
@@ -59,6 +59,28 @@ public sealed class AbsPosAutoHeightRc4Tests
     }
 
     [Fact]
+    public void Auto_height_positioned_box_does_not_double_count_border_and_padding()
+    {
+        // #293 review — an inline-only-ROOT positioned box's measured content extent IS its BORDER box
+        // (it includes the box's own block border + padding); ResolvePlacement then adds that chrome
+        // again. With a large border + padding the auto-height ABSOLUTE box must resolve to the SAME
+        // border-box height as the equivalent STATIC box, not taller by 2x the chrome.
+        static byte[] Render(string position) => HtmlPdf.Convert(
+            "<!doctype html><html><head><style>@page{size:A4;margin:0}body{margin:0;font-size:12px}"
+            + ".b{" + position + "width:200px;background:#eef;border:20px solid #000;padding:20px}"
+            + "</style></head><body><div class=\"b\">Hi</div></body></html>",
+            new HtmlPdfOptions { PrintBackgrounds = true });
+
+        var abs = FooterRectHeights(Render("position:absolute;top:0;left:0;"));
+        var stat = FooterRectHeights(Render(string.Empty));
+        Assert.NotEmpty(abs);
+        Assert.NotEmpty(stat);
+        // Border-box height = the tallest rect. Equal to the static control; before the fix the absolute
+        // box was ~60pt taller (2x the 20px border + 20px padding, minus the once-counted chrome).
+        Assert.Equal(stat.Max(), abs.Max(), precision: 0);
+    }
+
+    [Fact]
     public void Fixed_footer_background_is_painted_exactly_once()
     {
         // The box's own TextRun spuriously inherits `position:fixed` by style reference; the fixed pass

--- a/tests/NetPdf.UnitTests/Rendering/AbsPosAutoHeightRc4Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/AbsPosAutoHeightRc4Tests.cs
@@ -1,0 +1,69 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-4 — an auto-height single-anchored fixed/absolute box (the ubiquitous `position:fixed;
+/// bottom:0; height:auto` footer) resolved its height to the FULL available extent instead of its
+/// content height, so its background painted as a full-page rect over everything (index.pdf's
+/// illegible total row + blank tinted page). Two further bugs stacked on the solver approximation:
+/// (a) the fixed pass emitted the box's own TextRun (which spuriously inherits `fixed` by style
+/// reference) as a SECOND full-page box; (b) measuring an out-of-flow box's own content returned 0
+/// (the inline text run was dropped as "out of flow", and the subject fragment was dropped by the
+/// measure sink). Fixed by pre-measuring content height + guarding both.
+/// </summary>
+public sealed class AbsPosAutoHeightRc4Tests
+{
+    private static string Doc(string position, string anchor) =>
+        "<!doctype html><html><head><style>@page{size:A4;margin:0} body{margin:0;font-size:12px}"
+        + ".content{height:200px}"
+        + $".footer{{position:{position};left:0;{anchor};width:300px;height:auto;background:#eef;padding:10px}}"
+        + "</style></head><body><div class=\"content\">Body content</div>"
+        + "<div class=\"footer\">Footer total here</div></body></html>";
+
+    // Heights of the footer-colored (#eef) background rectangles.
+    private static List<double> FooterRectHeights(byte[] pdf)
+    {
+        var s = Encoding.Latin1.GetString(pdf);
+        return Regex.Matches(s, @"[\d.-]+ [\d.-]+ [\d.-]+ ([\d.]+) re")
+            .Select(m => double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture))
+            .Where(h => h > 5)   // ignore hairline separators
+            .ToList();
+    }
+
+    private static int FooterBgFills(byte[] pdf) =>
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"0\.93\d* 0\.93\d* 1(?:\.0+)? rg").Count;
+
+    [Theory]
+    [InlineData("fixed", "bottom:0")]
+    [InlineData("absolute", "bottom:0")]
+    [InlineData("fixed", "top:0")]
+    public void Auto_height_positioned_box_is_content_sized_not_page_sized(string position, string anchor)
+    {
+        var pdf = HtmlPdf.ConvertDetailed(Doc(position, anchor), new HtmlPdfOptions { PrintBackgrounds = true }).Pdf;
+        var heights = FooterRectHeights(pdf);
+        Assert.NotEmpty(heights);
+        // A4 content height is ~842pt; a content-sized footer (one line + 20px padding) is well under
+        // 100pt. Before the fix the background rect was the full page (~842pt).
+        Assert.All(heights, h => Assert.True(h < 100,
+            $"footer background height {h:F1}pt should be content-sized (< 100pt), not page-sized"));
+    }
+
+    [Fact]
+    public void Fixed_footer_background_is_painted_exactly_once()
+    {
+        // The box's own TextRun spuriously inherits `position:fixed` by style reference; the fixed pass
+        // must not emit it as a second full-page box. Exactly one footer background fill.
+        var pdf = HtmlPdf.ConvertDetailed(Doc("fixed", "bottom:0"), new HtmlPdfOptions { PrintBackgrounds = true }).Pdf;
+        Assert.Equal(1, FooterBgFills(pdf));
+    }
+}


### PR DESCRIPTION
The **RC-4** follow-up deferred out of WP-6 (#291). Fixes the index.pdf occlusion BLOCKER — an auto-height `position:fixed; bottom:0` footer whose background filled the whole page and painted over the total row + separators.

> **Stacked on #292 (WP-7)** → base `wp7-css-pipeline`. Merge the earlier PRs first.

## RC-4 was three stacked bugs
1. **Solver approximation** (`AbsoluteLayouter.SolveAxis`) — an auto **block** size that is single-anchored (top XOR bottom) used the *available extent*, not the content height. Now the caller **pre-measures** the content height and passes it as the §10.6.4 used height (`RemeasureAutoHeightPlacement` → `ResolvePlacement`'s new `measuredBlockContentSize`). The fill case (both insets) still fills.
2. **Phantom duplicate** (`EmitFixedPositionedDescendants`) — the box's own `TextRun` **reuses its parent's ComputedStyle by reference**, so it spuriously reported `IsFixedPositioned` and the fixed pass emitted it as a *second* full-page box (the finding's "bg emitted 2–4×"). Mirror the abspos pass's guard — skip `TextRun`/`AnonymousBlock`.
3. **Content measured 0** (so the box sized to chrome only) — (a) `CollectInlineTextRuns` dropped the box's *own* inline text because that text run inherits the box's out-of-flow style by reference (now only out-of-flow **element** descendants are skipped); (b) `BufferingMeasureSink` dropped the measurement **subject**'s own out-of-flow fragment (now the `decorationOwner` is counted).

## Results (repro)
| case | before | after |
|---|---|---|
| fixed `bottom:0` footer bg height | ~842pt (full page) | **~41pt** (content) |
| absolute `bottom:0` footer bg height | ~842pt | **~41pt** |
| footer background fills | 2 (duplicate) | **1** |

## Tests & verification
- `AbsPosAutoHeightRc4Tests` — auto-height positioned box is content-sized (< 100pt) for fixed/absolute + top/bottom; painted exactly once.
- **Full suite green** (exit 0) — no regressions across `CollectInlineTextRuns` / `BufferingMeasureSink` / the abspos + fixed passes.

Also fixes the 05-payment rotated PAID stamp's giant outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)