### PR TITLE
test: count text-show ops (Tj/TJ) not Td in NestedRootDispatchTests

### DIFF
--- a/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
@@ -19,8 +19,13 @@ namespace NetPdf.UnitTests.Rendering;
 /// </summary>
 public sealed class NestedRootDispatchTests
 {
+    // Count text-SHOW operators (Tj / TJ), NOT Td. These tests render with the DEFAULT font resolver
+    // (a real embedded font), and a real font's binary contains the byte substring "Td" (e.g. in its
+    // name/OS-2 tables) — so counting " Td" would tally phantom matches from the font stream and pass
+    // even if NO glyphs were painted (the RC-5 false-positive class, WP-6/#291). Tj/TJ only appear where
+    // glyphs are actually shown.
     private static int TextRunCount(byte[] pdf) =>
-        Regex.Matches(Encoding.Latin1.GetString(pdf), @" Td\b").Count;
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"\b(Tj|TJ)\b").Count;
 
     private const string TableRows =
         "<table><tr><td>Subtotal</td><td>$100</td></tr>"

--- a/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/NestedRootDispatchTests.cs
@@ -22,10 +22,14 @@ public sealed class NestedRootDispatchTests
     // Count text-SHOW operators (Tj / TJ), NOT Td. These tests render with the DEFAULT font resolver
     // (a real embedded font), and a real font's binary contains the byte substring "Td" (e.g. in its
     // name/OS-2 tables) — so counting " Td" would tally phantom matches from the font stream and pass
-    // even if NO glyphs were painted (the RC-5 false-positive class, WP-6/#291). Tj/TJ only appear where
-    // glyphs are actually shown.
+    // even if NO glyphs were painted (the RC-5 false-positive class, WP-6/#291).
+    //
+    // Match the OPERAND-TERMINATED form — a PDF hex-string close `>` (or array close `]`) then the
+    // operator — not a bare `\bTj\b`. NetPdf emits `<glyph-hex> Tj` / `[...] TJ`, so this counts real
+    // show operators while a stray `Tj`/`TJ` byte pair inside the compressed FontFile2 stream can't match
+    // (it would need the exact `> Tj` / `] TJ` sequence) — Copilot review, #294.
     private static int TextRunCount(byte[] pdf) =>
-        Regex.Matches(Encoding.Latin1.GetString(pdf), @"\b(Tj|TJ)\b").Count;
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"(?:>|\]) T[jJ]\b").Count;
 
     private const string TableRows =
         "<table><tr><td>Subtotal</td><td>$100</td></tr>"


### PR DESCRIPTION
Applies the WP-6/#291 review lesson (count text-show operators, not `Td`) to the one remaining real-font text-presence assertion.

**Why:** `NestedRootDispatchTests` renders with the default font resolver (a real embedded font). A real font's binary contains the byte substring `Td` (in its name/OS-2 tables), so counting `" Td"` tallies phantom matches from the font stream — the assertion would pass even if no glyphs were painted (exactly the false-positive that masked the RC-5 bug in #291).

**Fix:** `TextRunCount` now counts `\b(Tj|TJ)\b` (text-show ops), which only appear where glyphs are actually shown. All 4 tests still pass, confirming the nested-root content genuinely renders.

The `HtmlPdfConvertTests` `Td` helpers are intentionally left as-is: they pair with `SyntheticFontResolver`, whose minimal binary contains no `" Td"`, so exact `Td` counts are reliable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
