### PR TITLE
fix(layout): RC-1 — honor horizontal margin/border/padding on non-replaced inline boxes

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -3809,3 +3809,35 @@ grepping the ID).
   real glyphs paint + embed deterministically with a fixed font); the DEFAULT
   facade path still depends on platform fonts until the bundled fallback (5b)
   so the determinism contract for the default path remains open.
+
+
+## inline-box-decoration-painting
+
+- **ID** — `inline-box-decoration-painting`
+- **Status** — `approximated`. The horizontal SPACING of a non-replaced inline
+  box now ships (RC-1); its background / border PAINTING is the residual.
+- **Behavior** — A non-replaced inline element (`<span>` etc.) contributes its
+  horizontal box-model chrome (`margin` / `border` / `padding` left+right) as
+  advance around its content — `BlockLayouter.CollectInlineTextRuns` attaches the
+  open/close-edge advance to the wrapper's first/last leaf run and `LineBuilder`
+  folds it into the boundary glyphs (no new break opportunity). So a badge / pill
+  / label↔value span is spaced correctly. A visible inline BORDER additionally
+  emits `LAYOUT-INLINE-UNSUPPORTED-001` (Warning) once per layout so the missing
+  paint is not silent (rule 7).
+- **Missing** — The inline box's own background-color / border / background-image
+  is not PAINTED (it would need per-line inline decoration fragments with
+  box-decoration-break handling across wraps). Vertical padding/border on an
+  inline (which does not affect line box height per CSS 2.2 §10.6.1) is also not
+  painted. Background-only inlines (no border) are not diagnosed.
+- **Trigger** — inline decoration painting is implemented (inline fragments carry
+  a painted background/border rectangle per line box).
+- **Owner files**
+  - `src/NetPdf.Layout/Layouters/BlockLayouter.cs` (`CollectInlineTextRuns`
+    `BoxKind.InlineBox` case — chrome + the diagnostic).
+  - `src/NetPdf.Layout/Inline/TextRun.cs`
+    (`LeadingChromeAdvancePx` / `TrailingChromeAdvancePx`).
+  - `src/NetPdf.Layout/Inline/LineBuilder.cs` (`ApplyInlineChromeAdvance`).
+  - `src/NetPdf/Rendering/FragmentPainter.cs` (future inline decoration paint).
+- **Removal condition** — a bordered / backgrounded inline paints its decoration
+  per line box; the `LAYOUT-INLINE-UNSUPPORTED-001` inline-decoration warning is
+  removed.

--- a/src/NetPdf.Layout/Inline/LineBuilder.cs
+++ b/src/NetPdf.Layout/Inline/LineBuilder.cs
@@ -470,21 +470,26 @@ internal static class LineBuilder
 
         if (run.Utf16Start == srcStart && src.LeadingChromeAdvancePx != 0)
         {
-            var leading = (float)src.LeadingChromeAdvancePx;
             var g0 = glyphs[0];
             // Insert `leading` px of blank space before the first glyph: draw it `leading` to the right
             // (XOffset) AND move the pen past it (XAdvance) so every following glyph shifts right in step.
+            // A large NEGATIVE margin must not drive the glyph's XAdvance below 0 (Wrap asserts it), so
+            // clamp the applied amount to -XAdvance and apply that SAME amount to XOffset too — otherwise
+            // the glyph would shift left by the full (unclamped) negative while the pen stayed put,
+            // desynchronising its ink from the following glyphs' positions (Copilot review, #295).
+            var applied = Math.Max((float)src.LeadingChromeAdvancePx, -g0.XAdvance);
             glyphs[0] = g0 with
             {
-                XOffset = g0.XOffset + leading,
-                XAdvance = Math.Max(0f, g0.XAdvance + leading),   // clamp: a large negative margin can't make the run assert-tripping negative
+                XOffset = g0.XOffset + applied,
+                XAdvance = g0.XAdvance + applied,
             };
         }
         if (run.Utf16Start + run.Utf16Length == srcEnd && src.TrailingChromeAdvancePx != 0)
         {
-            var trailing = (float)src.TrailingChromeAdvancePx;
             var gl = glyphs[^1];
-            glyphs[^1] = gl with { XAdvance = Math.Max(0f, gl.XAdvance + trailing) };
+            // Same non-negative clamp (no XOffset on the trailing edge — it's pure pen advance).
+            var applied = Math.Max((float)src.TrailingChromeAdvancePx, -gl.XAdvance);
+            glyphs[^1] = gl with { XAdvance = gl.XAdvance + applied };
         }
     }
 

--- a/src/NetPdf.Layout/Inline/LineBuilder.cs
+++ b/src/NetPdf.Layout/Inline/LineBuilder.cs
@@ -346,9 +346,13 @@ internal static class LineBuilder
         // Rebuild the concat text. Cheap O(N); avoids needing
         // Itemize to plumb it back to the caller (which would break
         // the existing Itemize signature + tests).
+        // Per-source-run start offset in the concat buffer (RC-1 — used to place a wrapper's
+        // open/close-edge chrome on the FIRST/LAST itemized run covering that source leaf).
+        var sourceStart = new int[sourceTextRuns.Count];
         var concatTotal = 0;
         for (var i = 0; i < sourceTextRuns.Count; i++)
         {
+            sourceStart[i] = concatTotal;
             concatTotal += sourceTextRuns[i].Text.Length;
         }
         var concatBuf = new StringBuilder(concatTotal);
@@ -425,6 +429,11 @@ internal static class LineBuilder
                 direction, runScript, language,
                 cancellationToken);
 
+            // RC-1 — fold an enclosing non-replaced InlineBox's open/close-edge chrome
+            // (margin/border/padding-left/right, set by BlockLayouter.CollectInlineTextRuns) into this
+            // run's boundary glyphs BEFORE the advance sum, so the wrap/paint pen already carries it.
+            ApplyInlineChromeAdvance(glyphs, run, sourceTextRuns[run.SourceTextRunIndex], sourceStart);
+
             // Cycle 2 — sum XAdvance for fast wrap-pass measurement.
             // HarfBuzz XAdvance is in CSS px (HbShaper handles font-
             // units → pixels conversion at construction time).
@@ -437,6 +446,46 @@ internal static class LineBuilder
             output[runIdx] = new ShapedRun(run, glyphs, totalAdvance);
         }
         return output;
+    }
+
+    /// <summary>RC-1 — fold an enclosing non-replaced <c>InlineBox</c>'s horizontal box-model chrome into
+    /// a shaped run's boundary glyphs. <paramref name="src"/> carries the OPEN-edge advance
+    /// (<c>margin+border+padding-left</c>) on its <see cref="TextRun.LeadingChromeAdvancePx"/> and the
+    /// CLOSE-edge advance on <see cref="TextRun.TrailingChromeAdvancePx"/> (both accumulated across nested
+    /// wrappers by <c>BlockLayouter.CollectInlineTextRuns</c>). Leading lands only on the FIRST itemized
+    /// run covering the source leaf (its glyph 0 is shifted right by that much AND its advance grows, so
+    /// the following text is pushed right without a break opportunity); trailing lands only on the LAST
+    /// itemized run's last glyph. A source leaf that itemizes into ONE run (the common case) gets both.
+    /// <para>Scope: LTR runs only. RTL inline chrome is a documented deferral (it needs the visual-order
+    /// mirror — leading maps to the right edge); it is rare and would otherwise place the advance on the
+    /// wrong side, so an RTL run is left byte-identical for now.</para></summary>
+    private static void ApplyInlineChromeAdvance(
+        ShapedGlyph[] glyphs, ItemizedRun run, TextRun src, int[] sourceStart)
+    {
+        if (src.LeadingChromeAdvancePx == 0 && src.TrailingChromeAdvancePx == 0) return;
+        if (glyphs.Length == 0 || run.IsRtl) return;   // nothing to attach to / RTL deferred
+
+        var srcStart = sourceStart[run.SourceTextRunIndex];
+        var srcEnd = srcStart + src.Text.Length;
+
+        if (run.Utf16Start == srcStart && src.LeadingChromeAdvancePx != 0)
+        {
+            var leading = (float)src.LeadingChromeAdvancePx;
+            var g0 = glyphs[0];
+            // Insert `leading` px of blank space before the first glyph: draw it `leading` to the right
+            // (XOffset) AND move the pen past it (XAdvance) so every following glyph shifts right in step.
+            glyphs[0] = g0 with
+            {
+                XOffset = g0.XOffset + leading,
+                XAdvance = Math.Max(0f, g0.XAdvance + leading),   // clamp: a large negative margin can't make the run assert-tripping negative
+            };
+        }
+        if (run.Utf16Start + run.Utf16Length == srcEnd && src.TrailingChromeAdvancePx != 0)
+        {
+            var trailing = (float)src.TrailingChromeAdvancePx;
+            var gl = glyphs[^1];
+            glyphs[^1] = gl with { XAdvance = Math.Max(0f, gl.XAdvance + trailing) };
+        }
     }
 
     /// <summary>Per Phase 3 Task 9 cycle 3a — wrapping pass. Takes
@@ -2273,7 +2322,7 @@ internal static class LineBuilder
                 var normalized = NormalizeSegmentBreaks(raw);
                 preNormalized[i] = ReferenceEquals(raw, normalized)
                     ? runs[i]
-                    : new TextRun(normalized, runs[i].Style);
+                    : runs[i] with { Text = normalized };   // RC-1: preserve leading/trailing chrome + Atomic
             }
             return preNormalized;
         }
@@ -2299,9 +2348,10 @@ internal static class LineBuilder
                 inWs = false;
                 continue;
             }
-            output[r] = new TextRun(
-                CollapseStateful(runs[r].Text, preserveBreaks, ref inWs),
-                runs[r].Style);
+            output[r] = runs[r] with
+            {
+                Text = CollapseStateful(runs[r].Text, preserveBreaks, ref inWs),
+            };   // RC-1: preserve leading/trailing chrome + Atomic
         }
 
         if (output.Length > 0)
@@ -2310,8 +2360,7 @@ internal static class LineBuilder
             var t = output[last].Text;
             if (t.Length > 0 && t[t.Length - 1] == ' ')
             {
-                output[last] = new TextRun(t.Substring(0, t.Length - 1),
-                    output[last].Style);
+                output[last] = output[last] with { Text = t.Substring(0, t.Length - 1) };
             }
         }
 
@@ -2358,7 +2407,7 @@ internal static class LineBuilder
         };
         return string.Equals(transformed, run.Text, StringComparison.Ordinal)
             ? run
-            : new TextRun(transformed, run.Style);
+            : run with { Text = transformed };   // RC-1: preserve leading/trailing chrome + Atomic
     }
 
     /// <summary>CSS <c>text-transform: capitalize</c> — upper-case the first typographic letter of each
@@ -2526,7 +2575,7 @@ internal static class LineBuilder
                 var normalized = NormalizeSegmentBreaks(raw);
                 output[r] = ReferenceEquals(raw, normalized)
                     ? runs[r]
-                    : new TextRun(normalized, runs[r].Style);
+                    : runs[r] with { Text = normalized };   // RC-1: preserve chrome + Atomic
                 // Reset inWs for the next run — preserve content
                 // doesn't interact with collapse decisions either side.
                 inWs = false;
@@ -2535,9 +2584,10 @@ internal static class LineBuilder
             {
                 // Collapse mode (Normal / NoWrap / PreLine).
                 var preserveBreaks = mode == WhiteSpace.PreLine;
-                output[r] = new TextRun(
-                    CollapseStateful(runs[r].Text, preserveBreaks, ref inWs),
-                    runs[r].Style);
+                output[r] = runs[r] with
+                {
+                    Text = CollapseStateful(runs[r].Text, preserveBreaks, ref inWs),
+                };   // RC-1: preserve chrome + Atomic
             }
         }
 
@@ -2553,9 +2603,7 @@ internal static class LineBuilder
             var t = output[lastIdx].Text;
             if (t.Length > 0 && t[t.Length - 1] == ' ')
             {
-                output[lastIdx] = new TextRun(
-                    t.Substring(0, t.Length - 1),
-                    output[lastIdx].Style);
+                output[lastIdx] = output[lastIdx] with { Text = t.Substring(0, t.Length - 1) };
             }
         }
 

--- a/src/NetPdf.Layout/Inline/TextRun.cs
+++ b/src/NetPdf.Layout/Inline/TextRun.cs
@@ -44,4 +44,19 @@ namespace NetPdf.Layout.Inline;
 /// REPLACEMENT CHARACTER (so concat/index bookkeeping stays aligned); the shaper produces one synthetic
 /// glyph whose advance is <see cref="InlineAtomic.AdvancePx"/> instead of calling HarfBuzz. Null for
 /// ordinary text runs (the byte-identical default).</param>
-internal readonly record struct TextRun(string Text, ComputedStyle Style, InlineAtomic? Atomic = null);
+/// <param name="LeadingChromeAdvancePx">RC-1 — extra inline-START advance (px) contributed by an
+/// enclosing non-replaced <c>InlineBox</c>'s OPEN edge: <c>margin-left + border-left + padding-left</c>
+/// (CSS 2.2 §8.3/§8.4). Set by <c>BlockLayouter.CollectInlineTextRuns</c> on the FIRST leaf run of the
+/// wrapper's content; the shaper folds it into the first glyph's <c>XOffset</c> + <c>XAdvance</c> so the
+/// following text is pushed right by that much (no new break opportunity — unlike a U+FFFC atomic).
+/// Accumulates across nested wrappers. 0 for the byte-identical default.</param>
+/// <param name="TrailingChromeAdvancePx">RC-1 — extra inline-END advance (px) from the wrapper's CLOSE
+/// edge: <c>margin-right + border-right + padding-right</c>. Set on the LAST leaf run of the wrapper's
+/// content; the shaper folds it into the last glyph's <c>XAdvance</c>. Accumulates across nested wrappers.
+/// 0 for the byte-identical default.</param>
+internal readonly record struct TextRun(
+    string Text,
+    ComputedStyle Style,
+    InlineAtomic? Atomic = null,
+    double LeadingChromeAdvancePx = 0,
+    double TrailingChromeAdvancePx = 0);

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -369,6 +369,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// The opt-in keeps the blast radius to exactly the flex item case.</summary>
     private readonly bool _layoutRootInlineContent;
 
+    /// <summary>RC-1 — set once this layouter has emitted the "inline box border/background is not
+    /// painted" diagnostic, so a document with many bordered/backgrounded inlines surfaces the rule-7
+    /// signal exactly once per real layout rather than once per span (and never during a speculative
+    /// measure). Inline decoration PAINTING (as opposed to the now-honored horizontal spacing) is a
+    /// documented residual — see docs/deferrals.md.</summary>
+    private bool _inlineDecorationDropDiagnosed;
+
     /// <summary>Per Phase 3 Task 12 sub-cycle 5 hardening Finding 5 —
     /// when <see langword="true"/>, the inline-pass through
     /// <c>InlineLayouter.LayoutPerRun</c> downgrades
@@ -9612,12 +9619,75 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     }
                     break;
                 case BoxKind.InlineBox:
-                case BoxKind.AnonymousInline:
+                {
                     // Recurse — nested inline wrappers carry styled
                     // text leaves underneath. The TextRun's style is
                     // the LEAF's style (cascade-resolved), so the
                     // wrapper's own style doesn't need separate
                     // propagation at the LayoutPerRun seam.
+                    //
+                    // RC-1 — a non-replaced inline element ALSO contributes its horizontal box-model
+                    // chrome (margin/border/padding-left+right, CSS 2.2 §8.3/§8.4) as advance around its
+                    // content — previously dropped, so `<span style="margin-right:28px">` collapsed to
+                    // zero spacing. Attach the OPEN-edge advance to the FIRST leaf run the recursion adds
+                    // and the CLOSE-edge advance to the LAST; nested wrappers accumulate. LineBuilder folds
+                    // these into the boundary glyphs (no new break opportunity). Percentages resolve
+                    // against the containing inline size (availInlineContentSize). An empty wrapper (no
+                    // leaf run) contributes nothing — a documented residual.
+                    var firstRunIdx = textRuns.Count;
+                    skipCount += CollectInlineTextRuns(
+                        child, textRuns, parentBlockStyle, availInlineContentSize,
+                        atomicContents, cancellationToken);
+                    if (textRuns.Count > firstRunIdx)
+                    {
+                        var st = child.Style;
+                        var leading =
+                            st.ReadLengthOrPercentPx(PropertyId.MarginLeft, availInlineContentSize)
+                            + st.ReadLengthPxOrZero(PropertyId.BorderLeftWidth)
+                            + st.ReadLengthOrPercentPx(PropertyId.PaddingLeft, availInlineContentSize);
+                        var trailing =
+                            st.ReadLengthOrPercentPx(PropertyId.MarginRight, availInlineContentSize)
+                            + st.ReadLengthPxOrZero(PropertyId.BorderRightWidth)
+                            + st.ReadLengthOrPercentPx(PropertyId.PaddingRight, availInlineContentSize);
+                        if (leading != 0)
+                        {
+                            var f = textRuns[firstRunIdx];
+                            textRuns[firstRunIdx] =
+                                f with { LeadingChromeAdvancePx = f.LeadingChromeAdvancePx + leading };
+                        }
+                        if (trailing != 0)
+                        {
+                            var lastIdx = textRuns.Count - 1;
+                            var l = textRuns[lastIdx];
+                            textRuns[lastIdx] =
+                                l with { TrailingChromeAdvancePx = l.TrailingChromeAdvancePx + trailing };
+                        }
+                        // RC-1 (rule 7) — the wrapper's horizontal SPACING is now honored, but a
+                        // non-replaced inline's background / border is not yet PAINTED (a separate
+                        // line-fragment feature). Surface it once per real layout so a visible bordered
+                        // inline (a badge / pill) isn't dropped SILENTLY. Style-gated border-width read.
+                        if (!_inlineDecorationDropDiagnosed
+                            && _measurePurpose == MeasurePurpose.Layout
+                            && (st.ReadLengthPxOrZero(PropertyId.BorderTopWidth) > 0
+                                || st.ReadLengthPxOrZero(PropertyId.BorderRightWidth) > 0
+                                || st.ReadLengthPxOrZero(PropertyId.BorderBottomWidth) > 0
+                                || st.ReadLengthPxOrZero(PropertyId.BorderLeftWidth) > 0))
+                        {
+                            _inlineDecorationDropDiagnosed = true;
+                            OptimizingBreakResolver.SafeEmit(_diagnostics, new PaginateDiagnostic(
+                                PaginateDiagnosticCodes.LayoutInlineUnsupported001,
+                                "BlockLayouter: a non-replaced inline element's border/background is not "
+                                + "painted (its horizontal margin/border/padding spacing IS now honored). "
+                                + "Inline-box decoration painting is a documented residual "
+                                + "(docs/deferrals.md); wrap the content in a block/inline-block to paint it.",
+                                PaginateDiagnosticSeverity.Warning));
+                        }
+                    }
+                    break;
+                }
+                case BoxKind.AnonymousInline:
+                    // An anonymous inline wrapper reuses the parent's style by reference and paints
+                    // nothing, so it has NO author chrome to contribute — just recurse.
                     skipCount += CollectInlineTextRuns(
                         child, textRuns, parentBlockStyle, availInlineContentSize,
                         atomicContents, cancellationToken);

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -45,6 +45,7 @@ public sealed class DeferralsParityTests
         "phase-4-painter-wiring",
         "fuzzing-infrastructure",
         "inline-atomic-boxes",
+        "inline-box-decoration-painting",
         "table-auto-fixed-spans-borders",
         "multicol-balancing-pagination",
         "float-continuation-propagation",

--- a/tests/NetPdf.UnitTests/Rendering/InlineChromeRc1Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/InlineChromeRc1Tests.cs
@@ -1,0 +1,104 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-1 — horizontal margin/border/padding on a non-replaced inline element (`&lt;span&gt;`) was
+/// silently ignored, so badges/pills and label↔value gaps collapsed to zero spacing (invoice-05 p8
+/// "Amount due by &lt;date&gt;$&lt;amount&gt;" ran together). CollectInlineTextRuns dropped the
+/// wrapper's own box-model chrome. The fix folds the open/close-edge advance (margin+border+padding
+/// -left/right) into the wrapper's first/last leaf run at shaping time (no new break opportunity).
+/// <para>Measured via the x-position of the LAST text-position (Td) operator — the text AFTER the
+/// span. Comparing chrome-vs-control cancels the font specifics, so the delta is exactly the chrome
+/// (40px = 30pt). All content stays on one line.</para>
+/// </summary>
+public sealed class InlineChromeRc1Tests
+{
+    // x of the last `<x> <y> Td` (the slice furthest along the inline axis = text after the span).
+    private static double LastTdX(string html)
+    {
+        var doc = "<!doctype html><html><head><style>body{margin:0;font-size:20px}</style></head><body>"
+            + html + "</body></html>";
+        var s = Encoding.Latin1.GetString(HtmlPdf.Convert(doc));
+        var xs = new List<double>();
+        foreach (Match m in Regex.Matches(s, @"(-?\d+(?:\.\d+)?) (-?\d+(?:\.\d+)?) Td"))
+            xs.Add(double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture));
+        Assert.True(xs.Count > 0, "expected at least one text-position operator");
+        return xs.Max();
+    }
+
+    [Theory]
+    [InlineData("margin-right:40px")]
+    [InlineData("border-right:40px solid #000")]
+    [InlineData("padding-right:40px")]
+    public void End_edge_chrome_pushes_following_text_right_by_the_chrome(string css)
+    {
+        var control = LastTdX("<div>Xa<span>Yb</span>Zc</div>");
+        var withChrome = LastTdX($"<div>Xa<span style=\"{css}\">Yb</span>Zc</div>");
+        // 40px = 30pt. Before the fix the two were byte-identical (chrome ignored).
+        Assert.Equal(control + 30.0, withChrome, precision: 0);
+    }
+
+    [Theory]
+    [InlineData("padding-left:40px")]
+    [InlineData("border-left:40px solid #000")]
+    [InlineData("margin-left:40px")]
+    public void Start_edge_chrome_pushes_the_span_content_and_everything_after(string css)
+    {
+        // The start-edge advance lands before the span's own content, so BOTH the span text and the
+        // text after it shift right by the chrome.
+        var control = LastTdX("<div>Xa<span>Yb</span>Zc</div>");
+        var withChrome = LastTdX($"<div>Xa<span style=\"{css}\">Yb</span>Zc</div>");
+        Assert.Equal(control + 30.0, withChrome, precision: 0);
+    }
+
+    [Fact]
+    public void Chrome_accumulates_across_nested_inline_wrappers()
+    {
+        // margin-right:20px (15pt) on the outer + margin-right:16px (12pt) on the inner both trail the
+        // same last glyph → the following text shifts right by 27pt.
+        var control = LastTdX("<div>Xa<span><span>Yb</span></span>Zc</div>");
+        var nested = LastTdX(
+            "<div>Xa<span style=\"margin-right:20px\"><span style=\"margin-right:16px\">Yb</span></span>Zc</div>");
+        Assert.Equal(control + 27.0, nested, precision: 0);
+    }
+
+    [Fact]
+    public void Explicit_zero_chrome_adds_no_advance()
+    {
+        // A span whose margin/border/padding are all explicitly 0 must not shift anything — the advance
+        // addition is gated on non-zero chrome, so it matches a plain span exactly.
+        var plain = LastTdX("<div>Xa<span>Yb</span>Zc</div>");
+        var zeroed = LastTdX("<div>Xa<span style=\"margin:0;border:0;padding:0\">Yb</span>Zc</div>");
+        Assert.Equal(plain, zeroed, precision: 2);
+    }
+
+    [Fact]
+    public void Visible_inline_border_surfaces_a_rule7_diagnostic_exactly_once()
+    {
+        // Inline decoration PAINTING is a documented residual, but it must not be SILENT (rule 7). A
+        // bordered inline emits LAYOUT-INLINE-UNSUPPORTED-001 — once, even with several bordered spans.
+        var one = HtmlPdf.ConvertDetailed(
+            "<!doctype html><html><body><div>A<span style=\"border:2px solid red\">BB</span>C</div></body></html>");
+        Assert.Equal(1, one.Warnings.Count(w => w.Code == "LAYOUT-INLINE-UNSUPPORTED-001"));
+
+        var many = HtmlPdf.ConvertDetailed(
+            "<!doctype html><html><body><div>"
+            + "<span style=\"border:1px solid\">a</span><span style=\"border:1px solid\">b</span></div></body></html>");
+        Assert.Equal(1, many.Warnings.Count(w => w.Code == "LAYOUT-INLINE-UNSUPPORTED-001"));
+
+        // A spacing-only (margin/padding) inline is fully honored → no diagnostic.
+        var spacingOnly = HtmlPdf.ConvertDetailed(
+            "<!doctype html><html><body><div>A<span style=\"margin-right:20px\">BB</span>C</div></body></html>");
+        Assert.DoesNotContain(spacingOnly.Warnings, w => w.Code == "LAYOUT-INLINE-UNSUPPORTED-001");
+    }
+}


### PR DESCRIPTION
Implements **RC-1** (WP-3b) from the release findings: horizontal `margin` / `border` / `padding` on a non-replaced inline element was silently ignored, so badges/pills and label↔value gaps collapsed to zero spacing (invoice-05 p8 `Amount due by <date>$<amount>` ran together).

### Root cause
`BlockLayouter.CollectInlineTextRuns` recursed into an `InlineBox` wrapper collecting only its leaf `TextRun`s — the wrapper's own box-model chrome (CSS 2.2 §8.3/§8.4) never contributed any advance.

### Fix (the safer of the two vehicles the finding lists — no new break opportunity)
- `TextRun` gains `LeadingChromeAdvancePx` / `TrailingChromeAdvancePx`.
- The `InlineBox` case computes open-edge (`margin+border+padding-left`) and close-edge chrome (percentages against the containing inline size; border width style-gated) and attaches them to the **first / last** leaf run the recursion adds. Nested wrappers accumulate.
- `LineBuilder.ApplyInlineChromeAdvance` folds them into the run's boundary glyphs at shaping time (first glyph `XOffset`+`XAdvance`, last glyph `XAdvance`) so following text is pushed over without a wrap opportunity.
- The 7 whitespace/text-transform preprocessing reconstructions now use `with { Text = … }` so the new fields (and `Atomic`) survive preprocessing.

### Rule 7
Inline decoration **painting** (background/border) is a separate feature — documented as the `inline-box-decoration-painting` residual. A visible inline **border** now emits `LAYOUT-INLINE-UNSUPPORTED-001` once per layout instead of dropping silently.

### Scope
LTR runs. RTL inline chrome is a documented deferral (needs the visual-order mirror). Empty wrappers (no leaf run) contribute nothing.

### Verification
- `InlineChromeRc1Tests`: `margin/border/padding-left+right` deltas equal the chrome in pt, nested accumulation, explicit-zero-chrome no-op, and the rule-7 diagnostic (once, borders only).
- Full unit suite **8560 pass**; **LayoutSnapshots / PaginationGolden / RenderingCorpus / W3cConformance** all green — existing text byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
