### PR TITLE
fix(paginate): RC-7 — break before a positionally-oversized table instead of dropping its body

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -360,11 +360,18 @@ grepping the ID).
   `TableContinuation.RepeatHead` / `RepeatFoot` flags drive the
   resume page: when set, the resume layouter re-emits the
   header at the top + footer at the bottom of the body window.
-  The new `LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001` diagnostic
-  fires when header + footer combined exceed the fragmentainer
-  (no room for any body row alongside the repeat contract)
-  header + footer commit atomically + body is skipped to avoid
-  infinite continuation loops. The locked footer
+  The `LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001` diagnostic
+  fires (header + footer commit atomically + body is skipped)
+  ONLY when the header + footer stack exceeds a FRESH page's
+  budget — genuinely can't fit anywhere. RC-7 — when the stack
+  merely exceeds the CURRENT-page REMAINDER (the table was pushed
+  low by preceding content) but fits a fresh page, the dispatching
+  BlockLayouter now breaks BEFORE the table (dry-run
+  `TableLayouter.DryRunWontFitAtOffset`) so the whole table moves
+  to a fresh page + renders every row instead of dropping the
+  body. The break-before can't loop: the flag is set only when the
+  table is pushed below a fresh page's origin, so on the resume
+  page (table at the top) it clears. The locked footer
   position is IMMEDIATELY AFTER THE LAST BODY ROW on each page
   (not bottom-anchored to the fragmentainer); sub-+ may
   revisit bottom-anchoring.**— captions (`<caption>`) lay

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -2512,6 +2512,19 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 Math.Max(0, marginBoxBlockSizeForCursor),
                 visualBlockExtent);
 
+            // RC-7 — break BEFORE a positionally-oversized table. Its repeated header+footer stack alone
+            // exceeds the remainder at this offset (so the emit pass would drop the body via the
+            // catastrophic branch) but WOULD fit a fresh page. Present the resolver a chunk that cannot
+            // fit here, so it returns BreakHere → the table moves whole to a fresh page. The BreakHere
+            // handler's own top-of-page forward-progress guard force-overflows instead when there is
+            // nothing above to reclaim, so this can never spin. (The dry-run only flags this when the
+            // table is pushed down + fits fresh, so a fresh page won't re-trigger it — forward progress.)
+            if (pendingTableLayouter?.DryRunWontFitAtOffset == true)
+            {
+                var remainingBelowTable = fragmentainer.BlockSize - (fragmentainer.UsedBlockSize + topShift);
+                chunkForBreakCheck = Math.Max(chunkForBreakCheck, remainingBelowTable + 1.0);
+            }
+
             // Per PR #22 review fix #2 — capture a checkpoint at the
             // candidate-break boundary BEFORE consulting the resolver.
             // The resolver may return Rewind, naming this checkpoint
@@ -5581,6 +5594,21 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     {
                         childBorderBoxInlineSize = nestedTableDrivenInline;
                     }
+                }
+
+                // RC-7 — break BEFORE a positionally-oversized nested table. Its repeated header+footer
+                // stack can't fit the remainder at this offset (so the emit pass's catastrophic branch
+                // would commit zero body rows + drop the body) but WOULD fit a fresh page, and the table
+                // sits below a fresh page's origin. Defer the WHOLE table to a fresh page via the
+                // recursion's break-before mechanism (same as the child-boundary gate above). No loop:
+                // the wontFit flag is only set when the table is pushed down, so on the resume page (table
+                // at the page top) it clears — forward progress is guaranteed.
+                if (nestedPendingTable is { DryRunWontFitAtOffset: true })
+                {
+                    nestedPendingTable.Dispose();
+                    return new BlockContinuation(
+                        ResumeAtChild: childIdx,
+                        ConsumedBlockSize: 0);
                 }
             }
 

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -244,6 +244,18 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     private readonly IPaginateDiagnosticsSink? _diagnostics;
     private readonly IShaperResolver? _shaperResolver;
 
+    // RC-7 — set by the most recent DryRunCommittedBlockSize when the table is POSITIONALLY oversized at
+    // its current offset: its repeated header + footer stack alone exceeds the remaining space on THIS
+    // page (so zero body rows can commit + the catastrophic branch would drop the body) but WOULD fit a
+    // fresh page, and the table sits below a fresh page's origin (there is reclaimable space above). The
+    // dispatching BlockLayouter reads it right after PreMeasureTableIfNeeded to break BEFORE the table —
+    // moving the whole table to a fresh page — instead of force-overflowing / dropping the body.
+    private bool _dryRunWontFitAtOffset;
+
+    /// <summary>RC-7 — see <see cref="_dryRunWontFitAtOffset"/>. Reflects the LAST
+    /// <see cref="DryRunCommittedBlockSize"/> call on this instance.</summary>
+    internal bool DryRunWontFitAtOffset => _dryRunWontFitAtOffset;
+
     /// <summary>Construct a layouter for <paramref name="rootBox"/>'s
     /// inner table content. <paramref name="rootBox"/> MUST be a
     /// <see cref="BoxKind.Table"/> or <see cref="BoxKind.InlineTable"/>
@@ -722,6 +734,16 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     /// sizing simulation (<see cref="DryRunCommittedBlockSize"/>).</summary>
     private const double IntraCellRowSplitMinBudgetPx = 1.0;
 
+    /// <summary>RC-7 — the minimum reclaimable space (px, = how far the table sits below a fresh page's
+    /// origin) that makes a break-before-table worthwhile. Below it, breaking wouldn't meaningfully grow
+    /// the budget, so an oversized header+footer degrades in place instead (avoids a churny break).</summary>
+    private const double TableBreakBeforeMinReclaimPx = 1.0;
+
+    /// <summary>RC-7 — safety margin (px) subtracted from the fresh-page budget when deciding a table's
+    /// header+footer "fits a fresh page". Keeps a stack that only JUST fits from breaking before then
+    /// re-degrading on the fresh page.</summary>
+    private const double TableBreakBeforeSafetyPx = 0.5;
+
     /// <summary>Per Phase 3 Task 17 cycle 5c.2d (PR-#201 review P1) — derive the
     /// intra-cell row split cut from the cell content's actual BLOCK BOUNDARIES,
     /// not the raw page-budget edge. The <paramref name="cut"/> is the DEEPEST
@@ -818,6 +840,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     {
         needsSplitting = false;
         willForceOverflowOnSingleRow = false;
+        _dryRunWontFitAtOffset = false;   // RC-7 — reset; set below only for the positionally-oversized case
         if (!_measureDone || _measuredRows is null || _measuredRows.Count == 0)
         {
             // Degenerate paths (missing grid / zero rows / zero
@@ -864,6 +887,23 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             : fragmentainer.UsedBlockSize;
         var rowStackOriginInFragmentainer =
             pageStartOffset + topCaptionsBlock;
+
+        // RC-7 — flag the POSITIONALLY-oversized case for the dispatching BlockLayouter. The repeated
+        // header + footer stack alone exceeds the remainder at THIS offset (so the emit pass's
+        // catastrophic branch would commit zero body rows + drop the body), BUT the stack fits a fresh
+        // page and the table is pushed down (reclaimable space above) — so breaking BEFORE the table
+        // recovers all rows. When the table is at (or near) a fresh page's origin, or the stack won't fit
+        // even a fresh page, this stays false so the caller degrades in place (no churn / no loop).
+        var offsetRemainder = fragmentainer.BlockSize - rowStackOriginInFragmentainer;
+        var freshPageTopChrome = _measuredTopCaptionsTotal;
+        var headerFooterStack = headerStackHeight + footerStackHeight;
+        _dryRunWontFitAtOffset =
+            (headerCount > 0 || footerCount > 0)
+            && headerFooterStack > offsetRemainder
+            && headerFooterStack
+                <= fragmentainer.BlockSize - freshPageTopChrome - TableBreakBeforeSafetyPx
+            && rowStackOriginInFragmentainer > freshPageTopChrome + TableBreakBeforeMinReclaimPx;
+
         // Per cycle 2 — the body row window emits AFTER the header
         // stack + reserves footerStackHeight at the bottom of the
         // page. So the effective per-page body budget is

--- a/tests/NetPdf.UnitTests/Rendering/TableBreakBeforeRc7Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/TableBreakBeforeRc7Tests.cs
@@ -1,0 +1,90 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// RC-7 — a table pushed low on a page (by preceding content) whose repeated <c>&lt;thead&gt;</c> +
+/// <c>&lt;tfoot&gt;</c> stack exceeded the space REMAINING on that page was misclassified as
+/// "catastrophic": the layouter emitted the header + footer once, dropped ALL body rows, and let the
+/// footer overprint the page edge (02-travel-quote lost its 5 rows + clipped "Estimated Total"). The
+/// stack easily fits a FRESH page, so the fix breaks BEFORE the table — deferring the whole table to a
+/// fresh page where it renders completely. A stack that exceeds even a fresh page stays truly
+/// catastrophic (degrade + diagnostic), and the break-before can never loop.
+/// </summary>
+public sealed class TableBreakBeforeRc7Tests
+{
+    // Count text-position operators (coordinate-terminated `<x> <y> Td`) — a robust proxy for painted
+    // text runs that can't match stray bytes in the compressed font stream.
+    private static int TextRuns(byte[] pdf) =>
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"[\d.]+ [\d.]+ Td").Count;
+
+    private static PdfRenderResult Render(int cardHeightPx, int footerRows)
+    {
+        var foot = new StringBuilder();
+        for (var i = 0; i < footerRows; i++)
+            foot.Append("<tr><td>F").Append(i).Append("</td><td>T").Append(i).Append("</td></tr>");
+        var body = new StringBuilder();
+        for (var i = 0; i < 5; i++)
+            body.Append("<tr><td>R").Append(i).Append("</td><td>v").Append(i).Append("</td></tr>");
+        var cards = cardHeightPx > 0
+            ? "<div class=\"options\"><div class=\"card\">A</div><div class=\"card\">B</div></div>"
+            : string.Empty;
+        var html =
+            "<!doctype html><html><head><style>@page{size:A4;margin:20px}body{margin:0;font-size:12px}"
+            + ".options{display:flex}.card{height:" + cardHeightPx + "px;width:50%;background:#eef}"
+            + "table{width:100%;border-collapse:collapse}td,th{border:1px solid #333;padding:6px}"
+            + "thead th{height:38px}</style></head><body>"
+            + cards
+            + "<table><thead><tr><th>H1</th><th>H2</th></tr></thead><tfoot>" + foot + "</tfoot>"
+            + "<tbody>" + body + "</tbody></table></body></html>";
+        return HtmlPdf.ConvertDetailed(html);
+    }
+
+    [Fact]
+    public void Positionally_oversized_table_breaks_before_and_renders_every_row()
+    {
+        // thead + 9 tfoot rows exceed the ~180px remaining below 900px of flex cards, but fit a fresh
+        // A4 page. The whole table must move to a fresh page and render completely — NOT drop the body.
+        var pushed = Render(cardHeightPx: 900, footerRows: 9);
+        var control = Render(cardHeightPx: 0, footerRows: 9);   // same table, room to render in place
+
+        Assert.True(pushed.PageCount >= 2, "the pushed-down table should break onto a fresh page");
+        Assert.DoesNotContain(pushed.Warnings, w => w.Code == "LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001");
+        Assert.DoesNotContain(pushed.Warnings, w => w.Code == "PDF-CONTENT-OVERFLOW-TRUNCATED-001");
+        // The in-place control renders the full table; the pushed-down version renders it too (plus the
+        // two flex-card labels), so it must have AT LEAST as many text runs — no rows dropped.
+        Assert.True(TextRuns(pushed.Pdf) >= TextRuns(control.Pdf),
+            $"pushed-down table dropped rows: {TextRuns(pushed.Pdf)} runs < in-place {TextRuns(control.Pdf)}");
+    }
+
+    [Fact]
+    public void Table_that_fits_the_current_page_remainder_does_not_break()
+    {
+        // thead + 5 tfoot rows fit the ~380px below 700px of cards → no break, one page, no diagnostics.
+        var res = Render(cardHeightPx: 700, footerRows: 5);
+        Assert.Equal(1, res.PageCount);
+        Assert.Empty(res.Warnings);
+    }
+
+    [Fact]
+    public void Truly_oversized_header_footer_degrades_with_a_diagnostic_and_never_loops()
+    {
+        // 45 tfoot rows push the thead+tfoot stack past even a FRESH page's budget → genuinely can't
+        // fit. It must DEGRADE (emit LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001) and COMPLETE — the test
+        // returning at all is the infinite-loop guard (a break-before loop would hang the run).
+        var atTop = Render(cardHeightPx: 0, footerRows: 45);
+        Assert.Contains(atTop.Warnings, w => w.Code == "LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001");
+
+        // Same stack, but pushed down: it fits neither the remainder NOR a fresh page, so it must still
+        // degrade (NOT break-before, which would loop trying to find a page it fits on).
+        var pushed = Render(cardHeightPx: 900, footerRows: 45);
+        Assert.Contains(pushed.Warnings, w => w.Code == "LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001");
+    }
+}

--- a/tests/NetPdf.UnitTests/Rendering/TableBreakBeforeRc7Tests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/TableBreakBeforeRc7Tests.cs
@@ -1,7 +1,6 @@
 // Copyright 2026 Roland Aroche and NetPdf contributors.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
 
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using NetPdf;
@@ -23,7 +22,7 @@ public sealed class TableBreakBeforeRc7Tests
     // Count text-position operators (coordinate-terminated `<x> <y> Td`) — a robust proxy for painted
     // text runs that can't match stray bytes in the compressed font stream.
     private static int TextRuns(byte[] pdf) =>
-        Regex.Matches(Encoding.Latin1.GetString(pdf), @"[\d.]+ [\d.]+ Td").Count;
+        Regex.Matches(Encoding.Latin1.GetString(pdf), @"-?\d+(?:\.\d+)? -?\d+(?:\.\d+)? Td").Count;
 
     private static PdfRenderResult Render(int cardHeightPx, int footerRows)
     {


### PR DESCRIPTION
Implements **RC-7** (WP-5b) from the release findings — the last table-fragmentation blocker.

### Bug
A table pushed low on a page (by preceding content) whose repeated `<thead>`+`<tfoot>` stack exceeded the space **remaining on that page** was misclassified as catastrophic: it emitted the header+footer once, **dropped all body rows**, and let the footer overprint the page edge (02-travel-quote lost its 5 rows and clipped "Estimated Total"). The stack easily fits a **fresh** page.

### Fix (the finding's part-3 approach)
The emit-path-only variant the finding calls "minimal" isn't sufficient — the outer `BlockLayouter` doesn't resume a 0-commit table continuation. So the fix moves the decision to the dispatcher:
- `TableLayouter.DryRunCommittedBlockSize` sets `DryRunWontFitAtOffset` when the header+footer stack exceeds the remainder at the table's current offset **but fits a fresh page** and the table sits **below** a fresh page's origin (reclaimable space above).
- The dispatching `BlockLayouter` reads it right after `PreMeasureTableIfNeeded` and **breaks before the table** — deferring the whole table to a fresh page via the recursion's existing break-before continuation (plus the top-level loop's chunk-check for a root-level table). On the fresh page the table starts at the top, the flag clears, and it renders every row.

### No infinite loop
The flag is set **only** when the table is pushed down, so the resume page (table at the top) never re-triggers it. A stack that exceeds even a fresh page stays **truly catastrophic** — degrade + `LAYOUT-TABLE-HEADER-FOOTER-OVERSIZED-001`, exactly as before.

### Verification
- `TableBreakBeforeRc7Tests`: pushed-down table renders every row (no `OVERSIZED`/`TRUNCATED`); fits-in-place stays one page; truly-oversized degrades **and completes** (the test returning is the loop guard).
- Full unit **8560** + **798** table/pagination + LayoutSnapshots + PaginationGolden + RenderingCorpus + W3cConformance all green — existing output byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
