### PR TITLE
feat(diag): WP-9 — emit FONT-MISSING-GLYPH-001 for tofu instead of dropping silently

### DIFF
--- a/src/NetPdf.Layout/Inline/LineBuilder.cs
+++ b/src/NetPdf.Layout/Inline/LineBuilder.cs
@@ -438,12 +438,32 @@ internal static class LineBuilder
             // HarfBuzz XAdvance is in CSS px (HbShaper handles font-
             // units → pixels conversion at construction time).
             double totalAdvance = 0;
+            var hasVisibleMissingGlyph = false;
             for (var g = 0; g < glyphs.Length; g++)
             {
                 totalAdvance += glyphs[g].XAdvance;
+                // WP-9 (rule 7) — a .notdef (glyph 0) whose SOURCE character is a real (non-whitespace,
+                // non-format) codepoint is visible "tofu": the font couldn't map it. The glyph's Cluster
+                // is the offset into the concat buffer (HbShaper's hb_buffer_add_utf16 contract), so read
+                // the source char there. Whitespace / control chars that shape to .notdef paint nothing,
+                // so they are NOT flagged (avoids a false "missing glyph" for an unmapped space).
+                if (glyphs[g].GlyphId == 0)
+                {
+                    var cluster = glyphs[g].Cluster;
+                    if ((uint)cluster < (uint)concatText.Length)
+                    {
+                        var srcChar = concatText[cluster];
+                        if (!char.IsWhiteSpace(srcChar) && !char.IsControl(srcChar)
+                            && srcChar is not ('\u00AD' or '\uFFFC'))   // soft hyphen / object-replacement
+                        {
+                            hasVisibleMissingGlyph = true;
+                        }
+                    }
+                }
             }
 
-            output[runIdx] = new ShapedRun(run, glyphs, totalAdvance);
+            output[runIdx] = new ShapedRun(
+                run, glyphs, totalAdvance, HasVisibleMissingGlyph: hasVisibleMissingGlyph);
         }
         return output;
     }

--- a/src/NetPdf.Layout/Inline/ShapedRun.cs
+++ b/src/NetPdf.Layout/Inline/ShapedRun.cs
@@ -48,8 +48,15 @@ namespace NetPdf.Layout.Inline;
 /// <see cref="TotalAdvance"/> equals that width. The painter skips the synthetic glyph — the atomic's
 /// box is painted from its own emitted fragment — but still advances the line cursor by it. Null for
 /// ordinary text runs.</param>
+/// <param name="HasVisibleMissingGlyph">WP-9 (rule 7) — <see langword="true"/> when at least one glyph
+/// in this run is the <c>.notdef</c> ("tofu") glyph AND its source character is NOT whitespace / a
+/// format control (which legitimately paint nothing). Computed at shape time, where the source codepoint
+/// is available; the paint pass reads it to emit <c>FONT-MISSING-GLYPH-001</c> once so a character the
+/// font + fallback chain couldn't map isn't dropped silently. <see langword="false"/> for fully-mapped
+/// runs (the byte-identical default).</param>
 internal readonly record struct ShapedRun(
     ItemizedRun Source,
     ShapedGlyph[] Glyphs,
     double TotalAdvance,
-    InlineAtomic? Atomic = null);
+    InlineAtomic? Atomic = null,
+    bool HasVisibleMissingGlyph = false);

--- a/src/NetPdf/Diagnostics/DiagnosticCodes.cs
+++ b/src/NetPdf/Diagnostics/DiagnosticCodes.cs
@@ -1050,6 +1050,16 @@ internal static class DiagnosticCodes
     public const string PaintTextFontUnresolved001 = "PAINT-TEXT-FONT-UNRESOLVED-001";
 
     /// <summary>
+    /// A character was rendered as <c>.notdef</c> ("tofu") because the resolved font — and every font in
+    /// its fallback chain — lacks a glyph for that codepoint. The rest of the text still paints; only the
+    /// unmapped character shows the font's missing-glyph box. Surfaced (Info) rather than dropped silently
+    /// per the diagnostics-not-silent-corruption rule. Deduplicated within a conversion. Extending the
+    /// fallback chain to a bundled symbol font is a tracked follow-up.
+    /// Severity: <see cref="DiagnosticSeverity.Info"/>.
+    /// </summary>
+    public const string FontMissingGlyph001 = "FONT-MISSING-GLYPH-001";
+
+    /// <summary>
     /// Per Phase 3 Task 23 — a page margin box's laid-out content is TALLER than its content area: the box
     /// was clamped to the page-margin band but its content block-height exceeds the available height. The
     /// common case is a vertical (left/right) EDGE box whose shrink-to-fit height hit the band limit, or a

--- a/src/NetPdf/Rendering/TextPainter.cs
+++ b/src/NetPdf/Rendering/TextPainter.cs
@@ -523,6 +523,19 @@ internal static class TextPainter
                     originalIds[g] = gid;
                     fc.Used.Add(gid);
                 }
+                // FONT-MISSING-GLYPH-001 (rule 7) — the shaper flagged this run as containing a VISIBLE
+                // .notdef (a non-whitespace character the font + fallback chain couldn't map — "tofu").
+                // Surface it once per conversion (Info). Whitespace/format .notdefs are excluded at shape
+                // time (they paint nothing), so a real document isn't flagged for an unmapped space.
+                if (run.HasVisibleMissingGlyph && diagnosed.Add("\0font-missing-glyph"))
+                {
+                    diagnostics?.Emit(new Diagnostic(
+                        DiagnosticCodes.FontMissingGlyph001,
+                        "A character was rendered as .notdef (tofu) — the resolved font and its fallback "
+                        + "chain lack a glyph for it. The rest of the text still paints; extend the font "
+                        + "fallback chain to cover the missing codepoint(s).",
+                        DiagnosticSeverity.Info));
+                }
 
                 // Baseline: centre the run font's em box in the line box (half-leading), then
                 // drop to the baseline by the ascent. Metrics from the run's parsed font. When the line

--- a/tests/NetPdf.UnitTests/Rendering/MissingGlyphDiagnosticTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/MissingGlyphDiagnosticTests.cs
@@ -1,0 +1,59 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NetPdf;
+using NetPdf.UnitTests.Text.Fonts.OpenType;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// WP-9 — a character the resolved font (and its fallback chain) can't map renders as <c>.notdef</c>
+/// ("tofu"). Previously this was SILENT (rule-7 violation). The paint pass now emits
+/// <c>FONT-MISSING-GLYPH-001</c> (Info) once per conversion when it draws a visible <c>.notdef</c>
+/// box. Driven with <c>SyntheticFont</c> (glyphs only for 'A'/'B'), so any other letter is guaranteed
+/// tofu deterministically.
+/// </summary>
+public sealed class MissingGlyphDiagnosticTests
+{
+    // Resolves every query to the in-repo SyntheticFont (glyphs for 'A'/'B' only); synchronous.
+    private sealed class SyntheticFontResolver : IFontResolver
+    {
+        public ValueTask<FontFaceData?> ResolveAsync(FontQuery query, CancellationToken ct)
+            => new(new FontFaceData { Bytes = SyntheticFont.Build(), Family = query.Family });
+    }
+
+    private static PdfRenderResult Render(string text) =>
+        HtmlPdf.ConvertDetailed(
+            "<!doctype html><html><body><p>" + text + "</p></body></html>",
+            new HtmlPdfOptions { FontResolver = new SyntheticFontResolver() });
+
+    [Fact]
+    public void Text_fully_covered_by_the_font_emits_no_missing_glyph_diagnostic()
+    {
+        // 'A' and 'B' are the only glyphs SyntheticFont carries — no tofu, no diagnostic.
+        var res = Render("AB BA AB");
+        Assert.DoesNotContain(res.Warnings, w => w.Code == "FONT-MISSING-GLYPH-001");
+    }
+
+    [Fact]
+    public void An_unmapped_character_surfaces_a_missing_glyph_diagnostic()
+    {
+        // 'C' is not in SyntheticFont → drawn as a visible .notdef box → rule-7 diagnostic (Info).
+        var res = Render("ABC");
+        var missing = res.Warnings.Where(w => w.Code == "FONT-MISSING-GLYPH-001").ToList();
+        Assert.Single(missing);
+        Assert.Equal(DiagnosticSeverity.Info, missing[0].Severity);
+    }
+
+    [Fact]
+    public void Many_unmapped_characters_are_diagnosed_exactly_once()
+    {
+        // Dedup: a document full of tofu surfaces ONE diagnostic, not one per character.
+        var res = Render("CDEFGH IJKL");
+        Assert.Equal(1, res.Warnings.Count(w => w.Code == "FONT-MISSING-GLYPH-001"));
+    }
+}


### PR DESCRIPTION
Implements the **WP-9** rule-7 item: font-fallback tofu (`✔ ⇄ ★` etc.) was dropped **silently**. The `FONT-MISSING-GLYPH-001` code was documented but never emitted.

### Fix
- The shaper flags a run (`ShapedRun.HasVisibleMissingGlyph`) when it contains a `.notdef` glyph whose **source character** is a real, non-whitespace codepoint. Detection happens at **shape time**, where the source char is available — so an unmapped whitespace/format char (a space in a font without a space glyph, a soft hyphen, U+FFFC) is **not** flagged (those paint nothing).
- The paint pass emits `FONT-MISSING-GLYPH-001` (Info) **once per conversion** when it draws such a run.

Purely additive — PDF bytes are unchanged (goldens byte-identical). Extending the fallback chain to a bundled symbol font remains a tracked follow-up.

### Tests
`MissingGlyphDiagnosticTests` (driven by `SyntheticFont`, which has glyphs for `A`/`B` only, so any other letter is guaranteed tofu):
- an unmapped letter surfaces exactly one Info diagnostic;
- fully-mapped text **including spaces** (which map to `.notdef` in the minimal font) emits none — the whitespace-exclusion guard;
- many missing chars dedup to one.

Full unit **8563** + LayoutSnapshots + PaginationGolden + RenderingCorpus + W3cConformance all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
