### PR TITLE
fix(flex): auto-height column flex is content-sized — no flex-grow/percent pagination runaway

### DIFF
--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -10993,9 +10993,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         var intrinsicBaseSizes = FlexLayouter.BuildRowIntrinsicMainBaseSizes(
             lineItems, _shaperResolver, cancellationToken);
         var resolvedMain = lineItems.Count > 0
+            // This is the ROW-flex pre-measure (main axis = inline), which is always DEFINITE for a
+            // block-level flex container — so the definite main size equals flexContentInlineSize.
             ? FlexLayouter.ResolveFlexLineMainSizes(
                 lineItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth,
-                flexContentInlineSize, mainGap, cancellationToken, intrinsicBaseSizes)
+                flexContentInlineSize, flexContentInlineSize, mainGap, cancellationToken, intrinsicBaseSizes)
             : System.Array.Empty<double>();
 
         // Flex baseline-alignment cycle [P1] — when the container uses align-items /

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -699,6 +699,14 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         // a `%` cross size stays 0 (auto against an indefinite parent, so auto-height flex stays
         // byte-identical).
         var containerDefiniteCrossSize = isColumn ? _contentInlineSize : blockGapBase;
+        // Corpus-fidelity (10-event-ticket runaway) — the DEFINITE main-axis size for resolving a flex
+        // item's PERCENTAGE main size (e.g. `height: 100%` in a COLUMN flex). Column main = block: definite
+        // only when the container height isn't auto (same indefinite-reference rule as blockGapBase); a
+        // column flex with AUTO height has an INDEFINITE main size, so a `%` main size must compute to auto
+        // (0 / content) per CSS 2.2 §10.5 — NOT resolve against `containerMainSize`, which during a nested
+        // MEASURE is the ~1,000,000px unbounded budget (→ a 1M-tall item → thousands of blank pages). Row
+        // main = inline: always definite for a block-level flex container.
+        var containerDefiniteMainSize = isColumn ? blockGapBase : _contentInlineSize;
         var mainGap = _rootBox.Style.ReadFlexGridGapOrZero(
             isColumn ? PropertyId.RowGap : PropertyId.ColumnGap,
             isColumn ? blockGapBase : inlineGapBase);
@@ -1096,7 +1104,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         var (minSizeProperty, maxSizeProperty) = GetMinMaxMainAxisProperties(flexDirection);
         var resolvedItemMainSizes = ResolveFlexibleMainSizes(
             lines, mainSizeProperty, minSizeProperty, maxSizeProperty,
-            containerMainSize, mainGap, cancellationToken, intrinsicBaseSizes);
+            containerMainSize, containerDefiniteMainSize, mainGap, cancellationToken, intrinsicBaseSizes);
 
         // Non-block-pagination arc (flex item CONTENT layout) — lay out each
         // flex item's INNER content (text / nested blocks) via a nested
@@ -2185,6 +2193,10 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId minSizeProperty,
         PropertyId maxSizeProperty,
         double containerMainSize,
+        // RC — the DEFINITE main size (NaN when the container's main axis is indefinite, e.g. an auto-height
+        // COLUMN flex). Used ONLY to resolve a PERCENTAGE main / min / max-size (which computes to auto
+        // against an indefinite reference); the flex free-space algorithm keeps the numeric containerMainSize.
+        double containerDefiniteMainSize,
         double mainGap,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<Box, double>? precomputedIntrinsicBaseSizes = null)
@@ -2197,7 +2209,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             ResolveLineWithMinMaxClamping(
                 line, resolved, mainSizeProperty,
                 minSizeProperty, maxSizeProperty,
-                containerMainSize, mainGap, cancellationToken,
+                containerMainSize, containerDefiniteMainSize, mainGap, cancellationToken,
                 precomputedIntrinsicBaseSizes);
         }
 
@@ -2250,6 +2262,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId minSizeProperty,
         PropertyId maxSizeProperty,
         double containerMainSize,
+        double containerDefiniteMainSize,
         double mainGap,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<Box, double>? precomputedIntrinsicBaseSizes = null)
@@ -2262,7 +2275,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             lineItems[i] = _rootBox.Children[_sortedFlexChildIndices[line.FirstItemIndex + i]];
         var lineResolved = ResolveFlexLineMainSizes(
             lineItems, mainSizeProperty, minSizeProperty, maxSizeProperty,
-            containerMainSize, mainGap, cancellationToken, precomputedIntrinsicBaseSizes);
+            containerMainSize, containerDefiniteMainSize, mainGap, cancellationToken, precomputedIntrinsicBaseSizes);
         for (var i = 0; i < count; i++)
             resolved[_sortedFlexChildIndices[line.FirstItemIndex + i]] = lineResolved[i];
     }
@@ -2284,6 +2297,11 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId minSizeProperty,
         PropertyId maxSizeProperty,
         double containerMainSize,
+        // RC — the DEFINITE main size (NaN when the container's main axis is indefinite, e.g. an auto-height
+        // COLUMN flex) for resolving a PERCENTAGE main / min / max-size to auto against an indefinite
+        // reference. Defaults to containerMainSize so existing callers that pass a definite size are
+        // unchanged; the auto-height column case passes NaN.
+        double containerDefiniteMainSize,
         double mainGap,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<Box, double>? precomputedIntrinsicBaseSizes = null)
@@ -2320,15 +2338,16 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             var item = lineItems[i];
 
             var hypothetical = ResolveHypotheticalMainSize(
-                item, mainSizeProperty, containerMainSize, precomputedIntrinsicBaseSizes);
+                item, mainSizeProperty, containerDefiniteMainSize, precomputedIntrinsicBaseSizes);
             hypotheticals[i] = hypothetical;
             resolved[i] = hypothetical;
 
-            // Pass the container main size so a PERCENTAGE main min/max-* resolves
-            // against it (mirrors the hypothetical main-size resolution above, which
-            // already threads containerMainSize for percentage flex-basis / main size).
+            // Pass the DEFINITE container main size so a PERCENTAGE main min/max-* resolves against it —
+            // and computes to auto (0) against an INDEFINITE reference (auto-height column flex), mirroring
+            // the hypothetical main-size resolution above. The numeric containerMainSize is still used for
+            // the free-space distribution below.
             var (min, max) = item.ResolveFlexItemMinMaxMainSize(
-                minSizeProperty, maxSizeProperty, containerMainSize);
+                minSizeProperty, maxSizeProperty, containerDefiniteMainSize);
             mins[i] = min;
             maxs[i] = max;
         }
@@ -2368,7 +2387,16 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                 }
             }
 
-            var remainingFreeSpace = containerMainSize - mainGutterTotal - sumFrozenResolved - sumUnfrozenHypothetical;
+            // CSS Flexbox L1 §9.7 — flex-grow/shrink distribute the container's FREE SPACE, which only
+            // exists when the container's main size is DEFINITE. For an INDEFINITE main size (an
+            // auto-height COLUMN flex — content-sized), there is no free space to distribute: the used main
+            // size IS the sum of the items, so free space = 0 and the items stay at their hypothetical
+            // (base) sizes. Without this gate, a `flex-grow` item in an auto-height column flex that is
+            // being MEASURED (as a row-flex item, at the ~1,000,000px unbounded budget) grows to fill the
+            // budget → a ~1M-tall item → thousands of blank pages (10-event-ticket / 02-travel-quote).
+            var remainingFreeSpace = double.IsFinite(containerDefiniteMainSize)
+                ? containerMainSize - mainGutterTotal - sumFrozenResolved - sumUnfrozenHypothetical
+                : 0.0;
 
             // Distribute remainingFreeSpace among unfrozen items.
             if (remainingFreeSpace > 0 && sumFlexGrow > 0)

--- a/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/FlexLayouterTests.cs
@@ -5881,7 +5881,7 @@ public sealed class FlexLayouterTests
             Box.ForElement(BoxKind.BlockContainer, growing, MakeElement()),
         };
         var resolvedAB = FlexLayouter.ResolveFlexLineMainSizes(
-            itemsAB, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            itemsAB, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, containerDefiniteMainSize: 300,
             mainGap: 0, cancellationToken: default);
         Assert.Equal(100.0, resolvedAB[0], precision: 3);
         Assert.Equal(200.0, resolvedAB[1], precision: 3);
@@ -5896,7 +5896,7 @@ public sealed class FlexLayouterTests
             thirds[i] = Box.ForElement(BoxKind.BlockContainer, s, MakeElement());
         }
         var resolvedThirds = FlexLayouter.ResolveFlexLineMainSizes(
-            thirds, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            thirds, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, containerDefiniteMainSize: 300,
             mainGap: 0, cancellationToken: default);
         Assert.All(resolvedThirds, w => Assert.Equal(100.0, w, precision: 3));
     }
@@ -5924,7 +5924,7 @@ public sealed class FlexLayouterTests
             Box.ForElement(BoxKind.BlockContainer, growB, MakeElement()),
         };
         var grown = FlexLayouter.ResolveFlexLineMainSizes(
-            growItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            growItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, containerDefiniteMainSize: 300,
             mainGap: 20, cancellationToken: default);
         Assert.Equal(140.0, grown[0], precision: 3);
         Assert.Equal(140.0, grown[1], precision: 3);
@@ -5945,7 +5945,7 @@ public sealed class FlexLayouterTests
             Box.ForElement(BoxKind.BlockContainer, shrinkB, MakeElement()),
         };
         var shrunk = FlexLayouter.ResolveFlexLineMainSizes(
-            shrinkItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            shrinkItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, containerDefiniteMainSize: 300,
             mainGap: 20, cancellationToken: default);
         Assert.Equal(140.0, shrunk[0], precision: 3);
         Assert.Equal(140.0, shrunk[1], precision: 3);
@@ -5967,7 +5967,7 @@ public sealed class FlexLayouterTests
         maxStyle.Set(PropertyId.MaxWidth, ComputedSlot.FromPercentage(50));
         var maxItems = new[] { Box.ForElement(BoxKind.BlockContainer, maxStyle, MakeElement()) };
         var maxResolved = FlexLayouter.ResolveFlexLineMainSizes(
-            maxItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            maxItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, containerDefiniteMainSize: 300,
             mainGap: 0, cancellationToken: default);
         Assert.Equal(150.0, maxResolved[0], precision: 3);
 
@@ -5979,7 +5979,7 @@ public sealed class FlexLayouterTests
         minStyle.Set(PropertyId.MinWidth, ComputedSlot.FromPercentage(50));
         var minItems = new[] { Box.ForElement(BoxKind.BlockContainer, minStyle, MakeElement()) };
         var minResolved = FlexLayouter.ResolveFlexLineMainSizes(
-            minItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300,
+            minItems, PropertyId.Width, PropertyId.MinWidth, PropertyId.MaxWidth, 300, containerDefiniteMainSize: 300,
             mainGap: 0, cancellationToken: default);
         Assert.Equal(150.0, minResolved[0], precision: 3);
     }

--- a/tests/NetPdf.UnitTests/Rendering/FlexIndefiniteMainSizeTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexIndefiniteMainSizeTests.cs
@@ -1,0 +1,57 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// A flex item's main size is resolved against the flex container's main size ONLY when that size is
+/// DEFINITE (CSS Flexbox L1 §9.7 / CSS 2.2 §10.5). An auto-height COLUMN flex has an INDEFINITE main
+/// (block) size — it is content-sized. When such a column flex is a flex ITEM of a row flex, it is
+/// MEASURED at the ~1,000,000px unbounded intra-item budget; before the fix a `flex-grow` item (or a
+/// `height: 100%` item) resolved against that budget → a ~1M-tall item → thousands of blank pages
+/// (10-event-ticket rendered 2003 pages, 02-travel-quote 1001). Now the indefinite main size makes
+/// flex-grow contribute no free space and a `%` main size compute to auto, so the column sizes to
+/// content.
+/// </summary>
+public sealed class FlexIndefiniteMainSizeTests
+{
+    private static int Pages(string body) =>
+        HtmlPdf.ConvertDetailed(
+            "<!doctype html><html><head><style>@page{size:A4;margin:20px}body{margin:0}</style></head><body>"
+            + body + "</body></html>").PageCount;
+
+    [Fact]
+    public void FlexGrow_item_in_an_auto_height_column_flex_item_does_not_run_away()
+    {
+        // row flex > auto-height column flex (its main = block, indefinite) > flex-grow item. The column is
+        // measured at the unbounded budget; flex-grow must NOT fill it. Before the fix: 924 pages.
+        Assert.True(Pages(
+            "<div style=\"display:flex\"><div style=\"display:flex;flex-direction:column\">"
+            + "<div style=\"flex:1 1 auto\">content</div></div></div>") <= 2);
+    }
+
+    [Fact]
+    public void Percent_height_item_in_an_auto_height_column_flex_item_does_not_run_away()
+    {
+        // Same shape, but the runaway is a `height: 100%` item — a percentage against the indefinite main
+        // size must compute to auto (0 / content), not resolve against the 1M budget.
+        Assert.True(Pages(
+            "<div style=\"display:flex\"><div style=\"display:flex;flex-direction:column\">"
+            + "<span style=\"height:100%\">bar</span></div></div>") <= 2);
+    }
+
+    [Fact]
+    public void FlexGrow_still_fills_a_definite_height_column_flex()
+    {
+        // Regression guard: when the column flex height IS definite, flex-grow must still distribute the
+        // real free space. A 400px column with one flex-grow child + one 100px child grows the child to
+        // ~300px — so the two together fill the container on ONE page (no overflow, no extra page).
+        Assert.Equal(1, Pages(
+            "<div style=\"display:flex;flex-direction:column;height:400px\">"
+            + "<div style=\"flex:1 1 auto;background:#eee\">grows</div>"
+            + "<div style=\"height:100px;background:#ccc\">fixed</div></div>"));
+    }
+}


### PR DESCRIPTION
Fixes the pagination **runaway** found while regenerating the tester corpus: `10-event-ticket` rendered **2003 pages** (70s) and `02-travel-quote` **1001 pages** (33s).

### Root cause
A flex item's main size resolves against the flex container's main size **only when that size is definite** (CSS Flexbox L1 §9.7 / CSS 2.2 §10.5). An **auto-height column flex** has an **indefinite** main (block) size — it is content-sized. When such a column flex is itself a flex **item of a row flex**, it's measured at the ~1,000,000px unbounded intra-item budget. Before the fix:
- a `flex: 1 1 auto` item **grew to fill** that 1M budget, and
- a `height: 100%` item resolved to 100% of it,

→ a ~1M-tall item → thousands of blank pages.

### Fix
`FlexLayouter` derives `containerDefiniteMainSize` (NaN for an auto-height column, mirroring the existing `containerDefiniteCrossSize`) and threads it through `ResolveFlexibleMainSizes → ResolveLineWithMinMaxClamping → ResolveFlexLineMainSizes`, using it for:
- the hypothetical/declared main size + min/max (a `%` against an indefinite reference → 0), and
- the §9.7 **free space** (indefinite main → free space 0, so flex-grow/shrink don't apply; the container sizes to the sum of its items).

The numeric `containerMainSize` still drives justify-content / line packing. The row-flex pre-measure passes the always-definite inline size.

### Result
- `10-event-ticket`: 2003 → **1 page** (0.4s)
- `02-travel-quote`: 1001 → **2 pages** (0.2s)
- Full unit **8566** + LayoutSnapshots + PaginationGolden + RenderingCorpus + W3cConformance all green — existing flex output byte-identical.

Tests: `FlexIndefiniteMainSizeTests` (flex-grow + percent-height no runaway; a definite-height column still grows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
