### PR TITLE
fix: table-cell vertical-align (§17.5.3 / F2) + column-flex %-height base (F4)

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -550,6 +550,41 @@ grepping the ID).
 
 
 
+## table-cell-vertical-align-baseline
+
+- **ID** — `table-cell-vertical-align-baseline`
+- **Status** — `approximated`. `top` / `middle` / `bottom` are exact; the
+  WHATWG `middle` default is applied; only the `baseline` distribution is
+  approximated.
+- **Behavior** — `TableLayouter.ResolveUsedCellVerticalAlign` +
+  `CellContentAlignmentShift` implement CSS 2.2 §17.5.3 by distributing a
+  cell's free block space: `top` → 0, `middle` → half, `bottom` → all. A cell
+  with no author `vertical-align` resolves to `middle` (the UA rule
+  `table, thead, tbody, tfoot, tr { vertical-align: middle }` + a code-side
+  walk cell → row → row-group → table). `baseline` — and the non-core
+  keywords `sub` / `super` / `text-top` / `text-bottom` and any length /
+  percentage — are all treated as the walk default (`middle`), so no cell
+  currently gets a true first-baseline-aligned distribution.
+- **Missing** — the §17.5.3 `baseline` mode: aligning each baseline-aligned
+  cell's first in-flow line-box baseline to the row's max baseline (and growing
+  the row for the resulting shifts). The table content sink
+  (`TableLayouter.MeasuringFragmentSink`) tracks only the content block extent,
+  not a `FirstBaselineFromOrigin`, so the per-cell first baseline needed for the
+  row-baseline max is not available. `vertical-align: baseline` explicitly set
+  on a cell is therefore rendered as `middle`, not baseline.
+- **Trigger** — a corpus/customer case where per-cell baseline alignment across
+  a mixed-font row is visibly required, or a conformance case asserting it.
+- **Owner files** — `src/NetPdf.Layout/Layouters/TableLayouter.cs`
+  (`MeasuringFragmentSink` needs first-baseline tracking mirroring
+  `BufferingMeasureSink.FirstBaselineFromOrigin`; `CellContentAlignmentShift`
+  gains a `baseline` branch that shifts by `rowBaseline − cellBaseline` and
+  grows the row height for it before offsets settle).
+- **Removal condition** — `baseline` cells align their first baselines to the
+  row baseline (with row growth) and a unit test asserts a smaller-font cell
+  shifts down so its first baseline coincides with a larger-font sibling's.
+
+
+
 ## multicol-balancing-pagination
 
 - **ID** — `multicol-balancing-pagination`

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -3466,6 +3466,16 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                     (mainSlot.Tag == ComputedSlotTag.Percentage
                      || item.Style.ReadFlexBasis().Kind == FlexBasisKind.Percentage)
                     && !double.IsFinite(containerDefiniteMainSize);
+                // Definite = an explicit length / definite flex-basis (resolvedItemMainSizes holds the
+                // §9.7-flexed used main size — an explicit `height` + `flex-grow` in a definite-height
+                // column grows correctly here). NOT content-determined items (flex-basis auto/content +
+                // auto height): their resolvedItemMainSizes is either still 0 (auto-height container —
+                // content-sizes AFTER this measure at :3465) or a page-sized hypothetical (their base
+                // size is measured at the page budget), so it is NOT a usable %-base here — keep the
+                // page budget. (Growing a `flex:1 1 auto` auto-height item to its DEFINITE-container
+                // flexed height as the %-base needs an auto-basis column base size that isn't page-
+                // sized — a separate flex base-sizing follow-up, review [P1].) Percentage main / basis
+                // against an indefinite container is auto → page budget.
                 var definiteMain = !IsMainSizeContentDetermined(item, mainSizeProperty)
                     && !mainIsPercentAgainstIndefinite;
                 if (isColumn && definiteMain)

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -1138,7 +1138,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         var (itemContentBuffers, itemDiagnosticBuffers) = MeasureFlexItemContents(
             lines, resolvedItemMainSizes, flexDirection, isColumn,
             mainSizeProperty, crossSizeProperty, containerCrossSize,
-            containerDefiniteCrossSize, isWrapping,
+            containerDefiniteCrossSize, containerDefiniteMainSize, isWrapping,
             fragmentainer, layout.WritingMode, layout.IsRtl,
             effectiveDiagnostics, contentMeasureBudget, cancellationToken);
 
@@ -3366,6 +3366,7 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         PropertyId crossSizeProperty,
         double containerCrossSize,
         double containerDefiniteCrossSize,
+        double containerDefiniteMainSize,
         bool isWrapping,
         FragmentainerContext fragmentainer,
         WritingMode writingMode,
@@ -3447,6 +3448,30 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
                     var crossBorderBox = item.Style.CrossBorderBoxSizePx(
                         crossSizeProperty, containerDefiniteCrossSize);
                     itemBlockBudget = Math.Max(0, crossBorderBox - item.Style.BlockBorderPaddingPx());
+                }
+                // F4 (10-event-ticket barcode) — the COLUMN analogue of the row fix above: a column
+                // item's BLOCK axis IS its MAIN axis. When the main size is DEFINITE the item's used
+                // main size is already resolved in resolvedItemMainSizes (§9.7 flexing + min/max
+                // clamping, a BORDER-box size), and it — not the page budget — is the percentage-height
+                // base for the item's children (CSS 2.2 §10.5; the flex item is their containing block).
+                // Pre-fix a definite-height column item (`.barcode { height: 58px }`) still handed its
+                // children the page/fragmentainer budget, so a `height: 100%` bar resolved against the
+                // A4 content box (751pt instead of 43.5pt). Definite = NOT content-determined
+                // (flex-basis auto/content with auto height content-sizes → resolvedItemMainSizes is
+                // stale 0 here, filled AFTER the measure at :3465–3475, so keep the page budget) AND
+                // NOT a percentage main size / flex-basis against an INDEFINITE container main (a %
+                // against indefinite is auto per css-sizing-3 §5.1.1 → keep the page budget).
+                var mainSlot = item.Style.Get(mainSizeProperty);
+                var mainIsPercentAgainstIndefinite =
+                    (mainSlot.Tag == ComputedSlotTag.Percentage
+                     || item.Style.ReadFlexBasis().Kind == FlexBasisKind.Percentage)
+                    && !double.IsFinite(containerDefiniteMainSize);
+                var definiteMain = !IsMainSizeContentDetermined(item, mainSizeProperty)
+                    && !mainIsPercentAgainstIndefinite;
+                if (isColumn && definiteMain)
+                {
+                    itemBlockBudget = Math.Max(
+                        0, resolvedItemMainSizes[itemIdx] - item.Style.BlockBorderPaddingPx());
                 }
 
                 var buffer = LayoutItemContentIntoBuffer(

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using NetPdf.Css.ComputedValues;
+using NetPdf.Css.ComputedValues.PropertyResolvers;
 using NetPdf.Css.Properties;
 using NetPdf.Layout.Boxes;
 using NetPdf.Layout.Inline;
@@ -2363,6 +2365,56 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         return LayoutAttemptResult.AllDone(cost: 0);
     }
 
+    /// <summary>CSS 2.2 §17.5.3 + WHATWG HTML Rendering "Tables" — the USED <c>vertical-align</c> of a
+    /// table cell as a <see cref="VerticalAlignResolver"/> keyword index. <c>vertical-align</c> is not
+    /// inherited in the cascade (and the CSS-wide <c>inherit</c> keyword is not plumbed for it), so the
+    /// WHATWG default is emulated by a code-side walk: return the FIRST explicit
+    /// <c>top</c>/<c>middle</c>/<c>bottom</c> found walking cell → row → row-group → table, else
+    /// <c>middle</c>. The UA rule <c>table, thead, tbody, tfoot, tr { vertical-align: middle }</c> puts a
+    /// <c>middle</c> on the row so an author <c>table { vertical-align: top }</c> is correctly shadowed at
+    /// the row (browser behavior), while an author <c>tr</c>/<c>td</c> value (higher origin) still wins.
+    /// The other §17.5.3 values (<c>baseline</c>, <c>sub</c>, <c>super</c>, <c>text-top</c>,
+    /// <c>text-bottom</c>, length/percentage) are all skipped → they fall to the walk default; a cell can
+    /// therefore not currently resolve to a true <c>baseline</c> distribution (indistinguishable from the
+    /// unset initial value at the slot level — a documented approximation, see
+    /// <c>docs/deferrals.md#table-cell-vertical-align-baseline</c>).</summary>
+    private static int ResolveUsedCellVerticalAlign(Box cell)
+    {
+        for (Box? b = cell; b is not null; b = b.Parent)
+        {
+            var slot = b.Style.Get(PropertyId.VerticalAlign);
+            if (slot.Tag == ComputedSlotTag.Keyword)
+            {
+                var k = slot.AsKeyword();
+                if (k is VerticalAlignResolver.Top or VerticalAlignResolver.Middle
+                    or VerticalAlignResolver.Bottom)
+                    return k;
+            }
+            if (b.Kind is BoxKind.Table or BoxKind.InlineTable) break;   // don't walk past the table
+        }
+        return VerticalAlignResolver.Middle;   // WHATWG default
+    }
+
+    /// <summary>CSS 2.2 §17.5.3 — the block-axis shift applied to a cell's buffered CONTENT so it aligns
+    /// within the cell's (possibly rowspan-) spanned border box of height <paramref name="cellSpanHeight"/>.
+    /// <c>top</c> — and <c>baseline</c>, APPROXIMATED as top because the table content sink tracks no
+    /// first-baseline (see <c>docs/deferrals.md#table-cell-vertical-align-baseline</c>) — yield 0;
+    /// <c>middle</c> half the free space; <c>bottom</c> all of it. Free space is the spanned height minus
+    /// the cell's natural border-box height (<see cref="CellPlacement.ContentBlockExtent"/>, which already
+    /// includes the cell's own border+padding). Only the CONTENT moves — the cell's border/background
+    /// fragment keeps the full spanned height (browser behavior: align content within the cell box, not the
+    /// box within the row), so <c>FragmentPainter</c> stays untouched. A uniform single-line row has
+    /// free == 0 for every cell → 0 shift → byte-identical.</summary>
+    private static double CellContentAlignmentShift(in CellPlacement placement, double cellSpanHeight)
+    {
+        var valign = ResolveUsedCellVerticalAlign(placement.Cell);
+        if (valign is not VerticalAlignResolver.Middle and not VerticalAlignResolver.Bottom)
+            return 0.0;   // top + baseline(≈top)
+        var free = cellSpanHeight - placement.ContentBlockExtent;
+        if (!(free > 0.0)) return 0.0;
+        return valign == VerticalAlignResolver.Middle ? free / 2.0 : free;
+    }
+
     /// <summary>Per Phase 3 Task 13 cycle 1 — emit the row + cell +
     /// content fragments for the row window
     /// <c>[windowStart, windowEndExclusive)</c>. Walks the three
@@ -2460,7 +2512,13 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             for (var i = 0; i < bucket.Count; i++)
             {
                 var placement = bucket[i];
-                placement.ContentBuffer.FlushTo(_sink, rowBlockOffsets[r]);
+                // CSS 2.2 §17.5.3 — shift the content down to align it within the cell's spanned
+                // border box (WHATWG default `middle`; author top/middle/bottom honored).
+                var cellSpanHeight =
+                    rowEndBlockOffset[placement.OriginRow + placement.RowSpan]
+                    - rowEndBlockOffset[placement.OriginRow];
+                var valignShift = CellContentAlignmentShift(placement, cellSpanHeight);
+                placement.ContentBuffer.FlushTo(_sink, rowBlockOffsets[r] + valignShift);
                 if (diagSink is not null)
                 {
                     placement.DiagnosticsBuffer?.FlushTo(diagSink);
@@ -2656,7 +2714,13 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             for (var i = 0; i < bucket.Count; i++)
             {
                 var placement = bucket[i];
-                placement.ContentBuffer.FlushKeepingBuffer(_sink, rowBlockOffsets[r]);
+                // CSS 2.2 §17.5.3 — repeated-header cell content aligns within its spanned box too.
+                // Match Phase B's RC-10 span-height (SUM of row heights, immune to resume shifts).
+                var cellSpanHeight = 0.0;
+                for (var rr = placement.OriginRow; rr < placement.OriginRow + placement.RowSpan; rr++)
+                    cellSpanHeight += rows[rr].RowHeight;
+                var valignShift = CellContentAlignmentShift(placement, cellSpanHeight);
+                placement.ContentBuffer.FlushKeepingBuffer(_sink, rowBlockOffsets[r] + valignShift);
                 if (shouldFlushDiagnostics)
                 {
                     placement.DiagnosticsBuffer?.FlushTo(flushDiagnostics!);
@@ -2744,7 +2808,12 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             for (var i = 0; i < bucket.Count; i++)
             {
                 var placement = bucket[i];
-                placement.ContentBuffer.FlushKeepingBuffer(_sink, rowBlockOffsets[r]);
+                // CSS 2.2 §17.5.3 — repeated-footer cell content aligns within its spanned box.
+                var cellSpanHeight =
+                    rowEndBlockOffset[placement.OriginRow + placement.RowSpan]
+                    - rowEndBlockOffset[placement.OriginRow];
+                var valignShift = CellContentAlignmentShift(placement, cellSpanHeight);
+                placement.ContentBuffer.FlushKeepingBuffer(_sink, rowBlockOffsets[r] + valignShift);
                 if (shouldFlushDiagnostics)
                 {
                     placement.DiagnosticsBuffer?.FlushTo(flushDiagnostics!);

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -779,16 +779,26 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             }
         }
         if (_measuredPlacements is null) return false;
+        // CSS 2.2 §17.5.3 — a short cell's content is shifted DOWN by its vertical-align free space
+        // (middle/bottom), so its block boundaries land at bufferOffset + shift. The cut must see
+        // the SHIFTED boundaries so the emit-time splitter (EmitSlicedRow, which flushes at the same
+        // shift) and this dry-run agree (review [P1]). The tall cell that drives the split has
+        // free == 0 → shift == 0, so its boundaries are unchanged. Split rows are RowSpan == 1
+        // (guarded below), so the row height is the cell's full spanned height.
+        var rowHeightForShift = _measuredRows is { } mr && rowIndex >= 0 && rowIndex < mr.Count
+            ? mr[rowIndex].RowHeight
+            : 0.0;
         var limit = priorCut + avail;
         for (var i = 0; i < _measuredPlacements.Count; i++)
         {
             var p = _measuredPlacements[i];
             if (p.OriginRow != rowIndex) continue;
             if (p.RowSpan > 1) return false;
+            var valignShift = CellContentAlignmentShift(p, rowHeightForShift);
             var buf = p.ContentBuffer.Buffered;
             for (var j = 0; j < buf.Count; j++)
             {
-                var bottom = buf[j].BlockOffset + buf[j].BlockSize;
+                var bottom = buf[j].BlockOffset + buf[j].BlockSize + valignShift;
                 if (bottom > priorCut && bottom <= limit && bottom > cut)
                 {
                     cut = bottom;
@@ -2397,19 +2407,21 @@ internal sealed class TableLayouter : ILayouter, IDisposable
 
     /// <summary>CSS 2.2 §17.5.3 — the block-axis shift applied to a cell's buffered CONTENT so it aligns
     /// within the cell's (possibly rowspan-) spanned border box of height <paramref name="cellSpanHeight"/>.
-    /// <c>top</c> — and <c>baseline</c>, APPROXIMATED as top because the table content sink tracks no
-    /// first-baseline (see <c>docs/deferrals.md#table-cell-vertical-align-baseline</c>) — yield 0;
-    /// <c>middle</c> half the free space; <c>bottom</c> all of it. Free space is the spanned height minus
-    /// the cell's natural border-box height (<see cref="CellPlacement.ContentBlockExtent"/>, which already
-    /// includes the cell's own border+padding). Only the CONTENT moves — the cell's border/background
-    /// fragment keeps the full spanned height (browser behavior: align content within the cell box, not the
-    /// box within the row), so <c>FragmentPainter</c> stays untouched. A uniform single-line row has
-    /// free == 0 for every cell → 0 shift → byte-identical.</summary>
+    /// <see cref="ResolveUsedCellVerticalAlign"/> only ever yields <c>top</c>/<c>middle</c>/<c>bottom</c>
+    /// (<c>baseline</c> and the non-core keywords are folded to the walk default <c>middle</c> — the table
+    /// content sink tracks no first-baseline, so a true <c>baseline</c> distribution is deferred, see
+    /// <c>docs/deferrals.md#table-cell-vertical-align-baseline</c>): <c>top</c> → 0, <c>middle</c> → half
+    /// the free space, <c>bottom</c> → all of it. Free space is the spanned height minus the cell's natural
+    /// border-box height (<see cref="CellPlacement.ContentBlockExtent"/>, which already includes the cell's
+    /// own border+padding). Only the CONTENT moves — the cell's border/background fragment keeps the full
+    /// spanned height (browser behavior: align content within the cell box, not the box within the row), so
+    /// <c>FragmentPainter</c> stays untouched. A uniform single-line row has free == 0 for every cell → 0
+    /// shift → byte-identical.</summary>
     private static double CellContentAlignmentShift(in CellPlacement placement, double cellSpanHeight)
     {
         var valign = ResolveUsedCellVerticalAlign(placement.Cell);
         if (valign is not VerticalAlignResolver.Middle and not VerticalAlignResolver.Bottom)
-            return 0.0;   // top + baseline(≈top)
+            return 0.0;   // top (baseline/others already folded to middle upstream)
         var free = cellSpanHeight - placement.ContentBlockExtent;
         if (!(free > 0.0)) return 0.0;
         return valign == VerticalAlignResolver.Middle ? free / 2.0 : free;
@@ -2592,12 +2604,22 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         }
 
         // Phase C — slice each cell's buffered content into the window.
+        // CSS 2.2 §17.5.3 — position a short cell's content by its vertical-align free-space shift
+        // (top → 0, middle → half, bottom → all) even across a page split (review [P1]). The shift
+        // is baked into the slice window: passing `[sliceStart − shift, sliceEnd − shift)` with
+        // `additionalBlockOffset = rowTop` makes FlushSlice include a fragment when
+        // `bufferOffset + shift ∈ [sliceStart, sliceEnd)` and emit it at `rowTop + (bufferOffset +
+        // shift − sliceStart)` — i.e. shifted down within its slice, landing on whichever page its
+        // shifted position falls in. Split rows are RowSpan == 1, so the row height is the full
+        // spanned height. The tall cell (free == 0) is unaffected → byte-identical.
         var sliceEnd = sliceStart + sliceHeight;
+        var rowHeightForShift = rows[rowIndex].RowHeight;
         var hasMore = false;
         for (var i = 0; i < bucket.Count; i++)
         {
+            var valignShift = CellContentAlignmentShift(bucket[i], rowHeightForShift);
             if (bucket[i].ContentBuffer.FlushSlice(
-                    _sink, rowTop, sliceStart, sliceEnd))
+                    _sink, rowTop, sliceStart - valignShift, sliceEnd - valignShift))
             {
                 hasMore = true;
             }

--- a/src/NetPdf/UserAgentStylesheet.cs
+++ b/src/NetPdf/UserAgentStylesheet.cs
@@ -59,6 +59,7 @@ internal static class UserAgentStylesheet
         caption { text-align: center; }
         th { font-weight: bold; text-align: center; }
         td, th { padding: 1px; }
+        table, thead, tbody, tfoot, tr { vertical-align: middle; }
         hr { border-width: 1px; border-style: solid; margin-top: 0.5em; margin-bottom: 0.5em; }
         """;
 

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -47,6 +47,7 @@ public sealed class DeferralsParityTests
         "inline-atomic-boxes",
         "inline-box-decoration-painting",
         "table-auto-fixed-spans-borders",
+        "table-cell-vertical-align-baseline",
         "multicol-balancing-pagination",
         "float-continuation-propagation",
         "flex-layouter-features",

--- a/tests/NetPdf.UnitTests/Layout/TableCellVerticalAlignTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableCellVerticalAlignTests.cs
@@ -1,0 +1,123 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using NetPdf;
+using NetPdf.Text.Fonts;
+using NetPdf.UnitTests.Text.Fonts.OpenType;
+using Xunit;
+
+namespace NetPdf.UnitTests.Layout;
+
+/// <summary>
+/// CSS 2.2 §17.5.3 table-cell <c>vertical-align</c> (F2, RC-F2b). Before this, cell content was pinned
+/// to the cell content-box top for every keyword, and there was no WHATWG <c>middle</c> default — so a
+/// short cell next to a taller sibling never centered the way browsers do. These render a two-column
+/// row whose FIRST (leftmost) cell is short and second is tall, then measure the short cell's text
+/// baseline (the glyph run with the smallest x) as the alignment keyword varies. The synthetic font
+/// keeps the geometry deterministic.
+/// </summary>
+public sealed class TableCellVerticalAlignTests
+{
+    private static HtmlPdfOptions Opts() => new() { FontResolver = new SynthResolver() };
+
+    // A tall right cell (3 lines) forces free space in the short left cell's row.
+    private static string Row(string cellCss) =>
+        "<!DOCTYPE html><html><head><style>@page{size:A4;margin:20mm}"
+        + "table{border-collapse:collapse}td{padding:0;font-size:12px;" + cellCss + "}</style></head>"
+        + "<body style='margin:0'><table><tr>"
+        + "<td class='short'>S</td>"
+        + "<td>Line one<br>Line two<br>Line three</td>"
+        + "</tr></table></body></html>";
+
+    // The short cell's text baseline y (the run with the smallest x = leftmost column). PDF is y-up,
+    // so a LARGER y is HIGHER on the page (closer to the row top).
+    private static double ShortCellY(string cellCss)
+    {
+        var pdf = Encoding.Latin1.GetString(HtmlPdf.Convert(Row(cellCss), Opts()));
+        var runs = Regex.Matches(pdf, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td\s+<[0-9A-Fa-f]*>\s+Tj")
+            .Select(m => (
+                X: double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture),
+                Y: double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture)))
+            .ToList();
+        Assert.NotEmpty(runs);
+        return runs.OrderBy(r => r.X).First().Y;   // leftmost run = the short cell.
+    }
+
+    [Fact]
+    public void Keywords_distribute_free_space_top_middle_bottom()
+    {
+        var top = ShortCellY("vertical-align:top");
+        var middle = ShortCellY("vertical-align:middle");
+        var bottom = ShortCellY("vertical-align:bottom");
+
+        // y-up: top is highest, bottom is lowest, middle strictly between.
+        Assert.True(top > middle + 1, $"top ({top:0.#}) should be higher than middle ({middle:0.#})");
+        Assert.True(middle > bottom + 1, $"middle ({middle:0.#}) should be higher than bottom ({bottom:0.#})");
+    }
+
+    [Fact]
+    public void Explicit_top_does_not_shift_the_content()
+    {
+        // invoice-12 declares `vertical-align: top` — content must stay at the cell content-box top,
+        // i.e. level with the tall cell's FIRST line (the topmost text run overall).
+        var pdf = Encoding.Latin1.GetString(HtmlPdf.Convert(Row("vertical-align:top"), Opts()));
+        var ys = Regex.Matches(pdf, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td\s+<[0-9A-Fa-f]*>\s+Tj")
+            .Select(m => double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture))
+            .ToList();
+        var topmost = ys.Max();
+        var shortY = ShortCellY("vertical-align:top");
+        Assert.True(System.Math.Abs(shortY - topmost) < 0.5,
+            $"top-aligned short cell (y={shortY:0.##}) is not level with the topmost line (y={topmost:0.##})");
+    }
+
+    [Fact]
+    public void Default_with_no_author_value_centers_like_the_whatwg_middle_default()
+    {
+        // No author vertical-align anywhere → WHATWG UA default is `middle`, so the short cell centers.
+        var none = ShortCellY(string.Empty);
+        var middle = ShortCellY("vertical-align:middle");
+        Assert.True(System.Math.Abs(none - middle) < 0.5,
+            $"default short-cell y ({none:0.##}) should equal explicit middle ({middle:0.##}) — the "
+            + "WHATWG `middle` default did not apply.");
+        // …and it is genuinely lower than top-aligned (i.e. the default is NOT top).
+        var top = ShortCellY("vertical-align:top");
+        Assert.True(top > none + 1, $"default ({none:0.#}) should sit below top ({top:0.#})");
+    }
+
+    [Fact]
+    public void Author_row_vertical_align_top_overrides_the_ua_middle_default()
+    {
+        // vertical-align on the <tr> must reach the cell (inheritance in the WHATWG model) and put the
+        // content back at the top — proving the default is not a hard `td, th { middle }` rule.
+        const string html = "<!DOCTYPE html><html><head><style>@page{size:A4;margin:20mm}"
+            + "table{border-collapse:collapse}td{padding:0;font-size:12px}tr{vertical-align:top}</style></head>"
+            + "<body style='margin:0'><table><tr><td>S</td>"
+            + "<td>Line one<br>Line two<br>Line three</td></tr></table></body></html>";
+        var pdf = Encoding.Latin1.GetString(HtmlPdf.Convert(html, Opts()));
+        var runs = Regex.Matches(pdf, @"(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s+Td\s+<[0-9A-Fa-f]*>\s+Tj")
+            .Select(m => (
+                X: double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture),
+                Y: double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture)))
+            .ToList();
+        var shortY = runs.OrderBy(r => r.X).First().Y;
+        var topmost = runs.Max(r => r.Y);
+        Assert.True(System.Math.Abs(shortY - topmost) < 0.5,
+            $"author `tr {{ vertical-align: top }}` did not reach the cell (short y={shortY:0.##}, "
+            + $"topmost={topmost:0.##}).");
+    }
+
+    private sealed class SynthResolver : IFontResolver
+    {
+        private static readonly byte[] FontBytes = SyntheticFont.Build();
+
+        public ValueTask<FontFaceData?> ResolveAsync(FontQuery query, CancellationToken ct)
+            => new(new FontFaceData { Bytes = FontBytes, Family = query.Family });
+    }
+}

--- a/tests/NetPdf.UnitTests/Layout/TableCellVerticalAlignTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableCellVerticalAlignTests.cs
@@ -92,6 +92,23 @@ public sealed class TableCellVerticalAlignTests
     }
 
     [Fact]
+    public void Explicit_baseline_is_approximated_as_middle_documented_deferral()
+    {
+        // review [P3] — locks the documented approximation
+        // (docs/deferrals.md#table-cell-vertical-align-baseline): the table content sink has no
+        // first-baseline, so an explicit `vertical-align: baseline` cell is NOT baseline-distributed
+        // — it folds to the walk default `middle`. Assert it renders identical to explicit middle
+        // (and NOT top). When true baseline support lands, this test changes with the deferral.
+        var baseline = ShortCellY("vertical-align:baseline");
+        var middle = ShortCellY("vertical-align:middle");
+        var top = ShortCellY("vertical-align:top");
+        Assert.True(System.Math.Abs(baseline - middle) < 0.5,
+            $"explicit baseline (y={baseline:0.##}) should currently match middle (y={middle:0.##}) "
+            + "per the documented approximation.");
+        Assert.True(top > baseline + 1, $"baseline ({baseline:0.#}) must not be top-aligned ({top:0.#})");
+    }
+
+    [Fact]
     public void Author_row_vertical_align_top_overrides_the_ua_middle_default()
     {
         // vertical-align on the <tr> must reach the cell (inheritance in the WHATWG model) and put the

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
@@ -655,6 +655,92 @@ public sealed class TableLayouterTests
     }
 
     [Fact]
+    public void IntraCell_split_row_bottom_aligned_short_cell_emits_once_and_shifts_down()
+    {
+        // review [P1] — CSS 2.2 §17.5.3 vertical-align must be honored ACROSS an intra-cell page
+        // split. A split row with a TALL left cell (6×200px) and a SHORT right cell (one 100px block)
+        // whose vertical-align is `bottom`: the short block must (a) emit EXACTLY once across the
+        // pages (the valign-shifted FlushSlice must not drop or duplicate it) and (b) be positioned
+        // by its bottom shift (free = 1200−100 = 1100), landing near the row bottom on a LATER page —
+        // NOT at the page-1 top (the pre-fix behavior).
+        var sink = new RecordingFragmentSink();
+        var diagSink = new RecordingDiagnosticsSink();
+        using var shaper = new SyntheticShaperResolver();
+
+        var root = Box.CreateRoot(MakeStyle());
+        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+        var grid = Box.Anonymous(BoxKind.TableGrid, MakeStyle());
+        var row = Box.ForElement(BoxKind.TableRow, MakeStyle(), MakeElement());
+
+        var tallCell = Box.ForElement(BoxKind.TableCell, MakeStyle(), MakeElement());
+        var tallAnon = Box.Anonymous(BoxKind.AnonymousBlock, MakeStyle());
+        for (var i = 0; i < 6; i++)
+        {
+            var s = MakeStyle();
+            SetLengthPx(s, PropertyId.Height, 200);
+            tallAnon.AppendChild(Box.ForElement(BoxKind.BlockContainer, s, MakeElement()));
+        }
+        tallCell.AppendChild(tallAnon);
+
+        var shortStyle = MakeStyle();
+        shortStyle.Set(PropertyId.VerticalAlign, ComputedSlot.FromKeyword(7));   // bottom
+        var shortCell = Box.ForElement(BoxKind.TableCell, shortStyle, MakeElement());
+        var shortBlockStyle = MakeStyle();
+        SetLengthPx(shortBlockStyle, PropertyId.Height, 100);
+        var shortBlock = Box.ForElement(BoxKind.BlockContainer, shortBlockStyle, MakeElement());
+        shortCell.AppendChild(shortBlock);
+
+        row.AppendChild(tallCell);
+        row.AppendChild(shortCell);
+        grid.AppendChild(row);
+        table.AppendChild(grid);
+        root.AppendChild(table);
+
+        var pages = 0;
+        TableContinuation? cont = null;
+        var done = false;
+        while (!done && pages < 8)
+        {
+            using var pl = new TableLayouter(
+                rootBox: table, sink: sink, incomingContinuation: cont,
+                diagnostics: diagSink, shaperResolver: shaper);
+            pl.ConfigureEmission(0, 0, 600);
+            var ctx = new FragmentainerContext(contentInlineSize: 600, blockSize: 800);
+            var lc = new LayoutContext(ctx) { Diagnostics = diagSink };
+            using var r = new BreakResolver();
+            var res = pl.AttemptLayout(ctx, ref lc, r, LayoutAttemptStrategy.LastResort);
+            pages++;
+            if (res.Outcome == LayoutAttemptOutcome.AllDone) done = true;
+            else
+            {
+                Assert.Equal(LayoutAttemptOutcome.PageComplete, res.Outcome);
+                cont = Assert.IsType<TableContinuation>(res.Continuation);
+            }
+        }
+        Assert.True(done, "the split table did not finish paginating");
+
+        // (a) The short cell's block emits EXACTLY once — no loss, no duplication.
+        double? shortBlockY = null;
+        var shortEmits = 0;
+        foreach (var f in sink.Fragments)
+        {
+            if (!ReferenceEquals(f.Box, shortBlock)) continue;
+            shortEmits++;
+            shortBlockY = f.BlockOffset;
+        }
+        Assert.Equal(1, shortEmits);
+
+        // (b) It is bottom-shifted (well below the page/row top), not emitted at the first-slice top.
+        Assert.NotNull(shortBlockY);
+        Assert.True(shortBlockY!.Value > 100,
+            $"bottom-aligned short cell emitted at y={shortBlockY:0.##} — the vertical-align shift was "
+            + "not applied across the split (pre-fix it lands at the page-1 top).");
+
+        Assert.DoesNotContain(diagSink.Diagnostics, d =>
+            d.Code == PaginateDiagnosticCodes.PaginationForcedOverflow001);
+    }
+
+    [Fact]
     public void IntraCell_split_row_taller_than_two_pages_paginates_three_pages()
     {
         // Per Phase 3 Task 17 cycle 5c.2d — a row taller than TWO pages

--- a/tests/NetPdf.UnitTests/Rendering/FlexColumnDefiniteMainPercentChildTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexColumnDefiniteMainPercentChildTests.cs
@@ -112,6 +112,28 @@ public sealed class FlexColumnDefiniteMainPercentChildTests
     }
 
     [Fact]
+    public void Explicit_height_flex_grow_item_uses_its_grown_height_as_the_percent_base()
+    {
+        // An EXPLICIT-height column item with flex-grow (definite basis) grows in §9.7 BEFORE the
+        // content measure, so resolvedItemMainSizes holds its grown height → a height:100% child
+        // resolves against that. Container 400px, item height:50px flex-grow:1 (only flexible item)
+        // + a fixed 100px sibling → the item grows to 300px (= 225pt). (An AUTO-basis `flex:1 1 auto`
+        // item is a separate flex base-sizing follow-up — see the Content_determined guard below.)
+        var heights = BarHeights(Doc(
+            "<div class='stub'><div class='fixed'></div>"
+            + "<div class='item'><div class='fill'></div></div></div>",
+            ".stub{display:flex;flex-direction:column;width:210px;height:400px}"
+            + ".fixed{height:100px}"
+            + ".item{height:50px;flex-grow:1}"
+            + ".fill{background:#1e1b2e;height:100%;width:40px}"));
+
+        Assert.NotEmpty(heights);
+        Assert.All(heights, h => Assert.True(h is > 180 and < 260,
+            $"fill height {h:0.##}pt — the flex-grown item height (400px−100px=300px=225pt) was not "
+            + "used as the %-height base."));
+    }
+
+    [Fact]
     public void Content_determined_auto_height_item_keeps_the_page_budget_for_content()
     {
         // Guard the IsMainSizeContentDetermined gate: an AUTO-height column item content-sizes; a

--- a/tests/NetPdf.UnitTests/Rendering/FlexColumnDefiniteMainPercentChildTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexColumnDefiniteMainPercentChildTests.cs
@@ -1,0 +1,129 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// Corpus-fidelity (10-event-ticket barcode, F4). A <c>height: 100%</c> child of a flex item that
+/// is a <b>column</b> flex item with a DEFINITE main size must resolve against the ITEM's height, not
+/// the page. PR #283 fixed this for ROW flex items (definite cross); the COLUMN branch — where the
+/// block axis IS the main axis — was left handing the page/fragmentainer budget to the nested content
+/// measure, so a <c>height:100%</c> bar resolved against the A4 content box (751pt) instead of the
+/// 58px barcode strip. These assert the barcode bars are their real height and the definite/indefinite
+/// distinction (css-sizing-3 §5.1.1) is preserved.
+/// </summary>
+public sealed class FlexColumnDefiniteMainPercentChildTests
+{
+    // The barcode fill color #1e1b2e → device-RGB `0.11765 0.10588 0.18039` (matches the corpus).
+    private const string BarFill = "0.11765 0.10588 0.18039";
+
+    private static List<double> BarHeights(string html)
+    {
+        var pdf = Encoding.Latin1.GetString(
+            HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        // `<r> <g> <b> rg <x> <y> <w> <h> re` — the filled bar's rect follows its fill color.
+        return Regex.Matches(pdf,
+                Regex.Escape(BarFill) + @" rg\s+-?[\d.]+ -?[\d.]+ -?[\d.]+ (-?[\d.]+) re")
+            .Select(m => double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture))
+            .ToList();
+    }
+
+    private static string Doc(string body, string css) =>
+        "<!DOCTYPE html><html><head><style>@page{size:A4;margin:16mm}*{box-sizing:border-box}"
+        + "body{margin:0}" + css + "</style></head><body>" + body + "</body></html>";
+
+    [Fact]
+    public void Barcode_bars_in_an_auto_height_column_flex_are_the_strip_height_not_the_page()
+    {
+        // repro3 — auto-height column flex → item .barcode { height:58px } (row flex) → height:100% bars.
+        var heights = BarHeights(Doc(
+            "<div class='stub'><p>top</p>"
+            + "<div class='barcode'><span></span><span></span><span></span></div>"
+            + "<p>bottom</p></div>",
+            ".stub{display:flex;flex-direction:column;width:210px}"
+            + ".barcode{display:flex;align-items:flex-end;height:58px;gap:2px}"
+            + ".barcode span{display:block;background:#1e1b2e;height:100%;width:4px}"));
+
+        Assert.NotEmpty(heights);
+        // 58px = 43.5pt. Pre-fix these were 751.18pt (the A4 content-box height).
+        Assert.All(heights, h => Assert.True(h is > 40 and < 50,
+            $"barcode bar height {h:0.##}pt — a height:100% bar in a definite-height column-flex item "
+            + "did not resolve against the 58px strip (page-budget leak)."));
+    }
+
+    [Fact]
+    public void Definite_height_column_container_still_resolves_bars_against_the_inner_strip()
+    {
+        // repro5 — the column container itself has a definite height (300px); the bars must still
+        // resolve against the 58px .barcode item, NOT the 300px container.
+        var heights = BarHeights(Doc(
+            "<div class='stub'><p>top</p>"
+            + "<div class='barcode'><span></span><span></span></div></div>",
+            ".stub{display:flex;flex-direction:column;width:210px;height:300px}"
+            + ".barcode{display:flex;align-items:flex-end;height:58px;gap:2px}"
+            + ".barcode span{display:block;background:#1e1b2e;height:100%;width:4px}"));
+
+        Assert.NotEmpty(heights);
+        Assert.All(heights, h => Assert.True(h is > 40 and < 50,
+            $"bar height {h:0.##}pt — resolved against the 300px container, not the 58px strip."));
+    }
+
+    [Fact]
+    public void Plain_block_item_with_definite_height_also_confines_percent_child()
+    {
+        // repro7 — NOT specific to a nested flex root: a plain BLOCK item height:58px with a
+        // height:100% BLOCK child must confine the child to 58px too.
+        var heights = BarHeights(Doc(
+            "<div class='stub'><div class='item'><div class='fill'></div></div></div>",
+            ".stub{display:flex;flex-direction:column;width:210px}"
+            + ".item{height:58px}"
+            + ".fill{background:#1e1b2e;height:100%;width:40px}"));
+
+        Assert.NotEmpty(heights);
+        Assert.All(heights, h => Assert.True(h is > 40 and < 50,
+            $"block child height {h:0.##}pt — a definite-height plain block item did not confine its "
+            + "height:100% child."));
+    }
+
+    [Fact]
+    public void Flexed_definite_item_uses_its_grown_height_as_the_percent_base()
+    {
+        // Definite-height column container (400px), single item height:50px flex-grow:1 → the item
+        // GROWS to fill 400px; a height:100% child resolves against the GROWN used size (not 50px,
+        // not the page). Locks in "read resolvedItemMainSizes, not the declared slot".
+        var heights = BarHeights(Doc(
+            "<div class='stub'><div class='item'><div class='fill'></div></div></div>",
+            ".stub{display:flex;flex-direction:column;width:210px;height:400px}"
+            + ".item{height:50px;flex-grow:1}"
+            + ".fill{background:#1e1b2e;height:100%;width:40px}"));
+
+        Assert.NotEmpty(heights);
+        // 400px = 300pt (the whole container is the single grown item). Not 50px (37.5pt), not page.
+        Assert.All(heights, h => Assert.True(h is > 250 and < 320,
+            $"fill height {h:0.##}pt — the child did not resolve against the item's GROWN (400px) height."));
+    }
+
+    [Fact]
+    public void Content_determined_auto_height_item_keeps_the_page_budget_for_content()
+    {
+        // Guard the IsMainSizeContentDetermined gate: an AUTO-height column item content-sizes; a
+        // height:50% child resolves as auto (indefinite base → 0). The item's TEXT must still render
+        // (the content measure must NOT be clipped to a stale 0 budget) — the paragraph is present.
+        var pdf = Encoding.Latin1.GetString(HtmlPdf.ConvertDetailed(Doc(
+            "<div class='stub'><div class='item'>visible text<div class='fill'></div></div></div>",
+            ".stub{display:flex;flex-direction:column;width:210px}"
+            + ".item{}"
+            + ".fill{background:#1e1b2e;height:50%;width:40px}"),
+            new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        // The text renders (a Tj glyph-show op is present) — content was not clipped to 0.
+        Assert.Matches(@"<[0-9A-Fa-f]+> *Tj", pdf);
+    }
+}


### PR DESCRIPTION
## Summary

Corpus QA round-2 continuation (plan: `NetPdf-tester/findings-2026-07-08/00-FIX-PLAN.md`). PR #299 landed **Defect A** (anonymous-block paint chrome — F1/F5/F2a). This PR lands the next two defects; **Defect D (F3 used-table-width) is deferred to its own PR** (see below).

## Defect B — CSS 2.2 §17.5.3 table-cell `vertical-align` (F2b)

Cell content was pinned to the cell content-box **top** for every keyword, and there was no WHATWG `middle` default — so a short cell next to a taller sibling never centered the way browsers do (F2's remaining half; the paint-side "bottom-hugging" was fixed in #299).

- `TableLayouter` now distributes each cell's free block space when draining its content buffer (body / repeated-header / repeated-footer flush): **top → 0, middle → half, bottom → all**, where `free = spanned border-box height − the cell's natural border-box height`. Only the **content** shifts; the cell border/background fragment keeps the full spanned height (browser behavior — align content *within* the cell box), so `FragmentPainter` is untouched.
- The used `vertical-align` is resolved by a code-side walk (cell → row → row-group → table; first explicit `top`/`middle`/`bottom`, else `middle`). The CSS-wide `inherit` keyword isn't plumbed for `vertical-align`, so the WHATWG `td,th { vertical-align: inherit }` rule can't be used; instead the UA sheet gets `table, thead, tbody, tfoot, tr { vertical-align: middle }` so an author `table { vertical-align: top }` is correctly *shadowed* at the row (browsers do this) while author `tr`/`td` values still win.
- `baseline` (and `sub`/`super`/`text-*`/length/percentage) fall to the `middle` default — a true first-baseline distribution needs first-baseline tracking the table content sink lacks. Documented: `docs/deferrals.md#table-cell-vertical-align-baseline`.

Uniform single-line rows have `free == 0` → 0 shift → **byte-identical**. Tests: `TableCellVerticalAlignTests` (keyword distribution, explicit-top = no shift, WHATWG middle default, author `tr` override). invoice-12 (`vertical-align: top`) stays top; invoice-04 (no author value) centers.

## Defect C — column-flex item is the %-height base for its children (F4)

PR #283 fixed the percentage-height measure budget for **row** flex items with a definite cross size; the **column** branch still handed the page/fragmentainer budget to the nested content measure. A column item's block axis IS its main axis, so a `height:100%` child of a definite-height column item (the 10-event-ticket barcode bars inside `.barcode { height:58px }`) resolved against the A4 content box (**751pt**) and painted a page-spanning black band.

Mirrored the row fix for the column branch of `MeasureFlexItemContents`: when the item is a column item with a **definite** main size, override its block budget to the used main size (`resolvedItemMainSizes[idx]` after §9.7 flexing/clamping) minus block chrome. Excludes content-determined items and percentages against an indefinite container main (auto per css-sizing-3 §5.1.1). #298 exposed this, it did not cause it.

Verified on 10-event-ticket: all 38 barcode bars **751.18pt → 43.5pt** (58px). Tests: `FlexColumnDefiniteMainPercentChildTests` (5 cases). Sibling #283/#298 suites stay green.

## Deferred — Defect D (F3 used-table-width)

Not in this PR, by design. It is the largest of the four (auto tables shrink-to-fit + honor explicit `width` + percent-column distribution). A local spike confirmed shrink-to-fit **breaks 23 table-contract unit tests** (the intended blast radius — each needs careful re-validation), surfaces an interaction the finding didn't cover (**caption width collapses** with the now-shrunk grid), and the actual index.html totals-card fix additionally needs Steps D+E (percent-as-auto under intrinsic probes + percent-column distribution) plus a caption-width floor. The plan itself sequences D "last, after the re-pins settle," so it lands as its own focused PR rather than jeopardizing the two clean fixes here.

## Verification / gate

Full solution green locally: build 0-warn · **8584** unit / 3 skip · 30 snapshot · 36 corpus · 105 real-doc · 6 W3C. No golden re-pins (uniform rows unaffected; barcode fix is `isColumn`-only). Determinism unaffected (no time/PRNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)