### PR TITLE
feat(table): honor explicit table width (F3 Step B); shrink-to-fit deferred

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -533,6 +533,20 @@ grepping the ID).
     `break-inside: avoid`; RTL writing modes / row reversal / caption
     inline-axis keyword routing; HTML5 colspan='0'/rowspan='0'
     remainder semantics; percentage column widths.
+  - **F3 used-table-width (partial).** An explicit `width` (px / %) on a
+    `display: table` / `inline-table` wrapper is now HONORED
+    (`BlockLayouter.ResolveInFlowBorderBoxInlineSize` includes the table
+    kinds — the declared border-box width sizes the wrapper + becomes the
+    grid's available width, floored at GRIDMIN by the column algorithm).
+    STILL DEFERRED: shrink-to-fit for `width: auto` tables (they still fill
+    the containing block, not max-content — CSS 2.2 §17.5.2 auto width);
+    percentage cell/column widths (drop to 0); the nested-table max-content
+    `1e6` probe poison; and the caption-width floor these need (narrowing an
+    auto wrapper to its grid collapses captions/0-content tables — the
+    caption/wrapper width derives from the grid, so shrink-to-fit must floor
+    the table width by the caption's content width). These land together as
+    a dedicated PR (they break the 23 auto-width table-contract tests as an
+    intended re-pin + need the caption floor to avoid regressions).
   - `src/NetPdf.Layout/Layouters/BlockLayouter.cs::PreMeasureTableIfNeeded`
     — now consumes the table's
     `MeasuredUsedInlineSize` to widen the wrapper's border-box

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -1784,6 +1784,21 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 }
             }
 
+            // F3 — a table wrapper's auto inline margins (`margin: 0 auto`) must distribute against
+            // its FINAL used width. The grid pre-measure above can WIDEN borderBoxInlineSize past the
+            // declared width when the column min-content overflows it, so re-resolve here — the
+            // earlier call (before the pre-measure) used the pre-widening width. ResolveAutoInlineMargins
+            // is idempotent when no widening happened (it recomputes the same leftover), so this is a
+            // no-op for the common fits-within case. InlineTable is excluded (inline-level, no block
+            // auto-margins); the pre-measure's cell offsets are relative + re-anchored at emit, so
+            // updating the margin after the pre-measure is safe.
+            if (child.Kind is BoxKind.Table)
+            {
+                ResolveAutoInlineMargins(
+                    child, borderBoxInlineSize, availInlineSize,
+                    ref marginInlineStart, ref marginInlineEnd);
+            }
+
             // Per Phase 3 Task 14 cycle 1 hardening (Findings 1 + 2) —
             // multicol container pre-measure. For multicol containers,
             // grow `borderBoxBlockSize` to fit the columnized content
@@ -5606,6 +5621,18 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     }
                 }
 
+                // F3 — re-distribute a table wrapper's auto inline margins (`margin: 0 auto`) against
+                // its FINAL used width: the grid pre-measure above may have widened
+                // childBorderBoxInlineSize past the declared width (min-content overflow), so the
+                // earlier call (5276, pre-measure) used the pre-widening width. Idempotent when no
+                // widening happened. Table only (InlineTable flows inline — no block auto-margins).
+                if (child.Kind is BoxKind.Table)
+                {
+                    ResolveAutoInlineMargins(
+                        child, childBorderBoxInlineSize, contentInlineSize,
+                        ref marginInlineStart, ref marginInlineEnd);
+                }
+
                 // RC-7 — break BEFORE a positionally-oversized nested table. Its repeated header+footer
                 // stack can't fit the remainder at this offset (so the emit pass's catastrophic branch
                 // would commit zero body rows + drop the body) but WOULD fit a fresh page, and the table
@@ -7722,8 +7749,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // FlexContainer / GridContainer included (PR #204 review [P2]) — `display: flex;
         // width: 200px; margin: 0 auto` centers the container, matching the explicit-width
         // gate in ResolveInFlowBorderBoxInlineSize (both sets must stay in lockstep).
+        // Table included (F3 used-table-width — `table { width: 150px; margin: 0 auto }` centers
+        // now that the wrapper has a definite used width). InlineTable is NOT — it is inline-level
+        // (atomic to line layout), so block-level auto-margin distribution does not apply.
         if (child.Kind is not (BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement
-            or BoxKind.FlexContainer or BoxKind.GridContainer)) return;
+            or BoxKind.FlexContainer or BoxKind.GridContainer or BoxKind.Table)) return;
         // EXPLICIT width (a tag test, so the legal `width: 0` / `0%` distributes too — post-PR-#164
         // review P3) OR an explicit `max-width` (a `width: auto` block that max-width clamps below the
         // range still has a definite used width, so `margin: 0 auto` centers it — CSS 2.2 §10.3.3 +

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -7638,9 +7638,13 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     ///   <item><see cref="BoxKind.AnonymousBlock"/> SHARES its parent's style object, so the
     ///   parent's explicit width would double-apply (plus re-add the parent's borders/padding);
     ///   per Display L3 §3.1 anonymous boxes take the initial <c>width: auto</c>.</item>
-    ///   <item><see cref="BoxKind.Table"/> / <see cref="BoxKind.InlineTable"/> wrappers track
-    ///   the MEASURED grid via the table-driven growth logic (Task 12 Finding 6) — the grid
-    ///   already consumes the css width itself.</item>
+    ///   <item><see cref="BoxKind.Table"/> / <see cref="BoxKind.InlineTable"/> wrappers now honor
+    ///   an explicit <c>width</c> (F3 used-table-width Step B, CSS 2.2 §17.5.2): the declared
+    ///   border-box width is the wrapper size and becomes the grid's available width (floored at
+    ///   GRIDMIN by the column algorithm). A <c>width: auto</c> table still FILLS the available range
+    ///   here — auto shrink-to-fit is the deferred remainder of F3 (see
+    ///   <c>docs/deferrals.md#table-auto-fixed-spans-borders</c>); the MEASURED grid only WIDENS the
+    ///   wrapper when it overflows (Task 12 Finding 6).</item>
     ///   <item><see cref="BoxKind.BlockReplacedElement"/> sizes like a plain block
     ///   (img-pipeline cycle): the sizing pre-pass writes the §10.3.2 used width/height into
     ///   the slots, so an explicit width here is the image's used size — filling would
@@ -7658,7 +7662,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         double marginInlineStart, double marginInlineEnd)
     {
         if (child.Kind is BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement
-            or BoxKind.FlexContainer or BoxKind.GridContainer)
+            or BoxKind.FlexContainer or BoxKind.GridContainer
+            or BoxKind.Table or BoxKind.InlineTable)
         {
             // Body % lengths (body-percent cycle): an explicit PERCENTAGE width resolves against
             // the CONTAINING block's inline size (CSS 2.2 §10.2 — not the float-adjusted available

--- a/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
@@ -27,16 +27,21 @@ public sealed class TableExplicitWidthTests
 {
     private static HtmlPdfOptions Opts() => new() { FontResolver = new SynthResolver(), PrintBackgrounds = true };
 
-    // Widths of the filled cell background rects (#ff0000 → `1 0 0 rg <x> <y> <w> <h> re`).
-    private static List<double> CellRectWidths(string tableAttrsAndStyle) =>
+    // Filled cell background rects (#ff0000 → `1 0 0 rg <x> <y> <w> <h> re`) as (x, width) pt pairs.
+    private static List<(double X, double W)> CellRects(string bodyInner, string extraTableCss = "") =>
         Regex.Matches(
                 Encoding.Latin1.GetString(HtmlPdf.Convert(
                     "<!DOCTYPE html><html><head><style>@page{size:A4;margin:0}*{box-sizing:border-box}"
-                    + "body{margin:0}table{border-collapse:collapse}td{background:#ff0000}</style></head>"
-                    + "<body>" + tableAttrsAndStyle + "</body></html>", Opts())),
-                @"\b1 0 0 rg\s+-?[\d.]+ -?[\d.]+ (-?[\d.]+) -?[\d.]+ re")
-            .Select(m => double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture))
+                    + "body{margin:0}table{border-collapse:collapse;" + extraTableCss + "}td{background:#ff0000}</style></head>"
+                    + "<body>" + bodyInner + "</body></html>", Opts())),
+                @"\b1 0 0 rg\s+(-?[\d.]+) -?[\d.]+ (-?[\d.]+) -?[\d.]+ re")
+            .Select(m => (
+                X: double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture),
+                W: double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture)))
             .ToList();
+
+    private static List<double> CellRectWidths(string tableAttrsAndStyle) =>
+        CellRects(tableAttrsAndStyle).Select(r => r.W).ToList();
 
     [Fact]
     public void Explicit_px_width_on_a_table_is_honored()
@@ -67,6 +72,47 @@ public sealed class TableExplicitWidthTests
         Assert.NotEmpty(widths);
         Assert.All(widths, w => Assert.True(w > 500,
             $"auto-width cell {w:0.##}pt — an auto table should still fill (~595pt) until shrink-to-fit lands."));
+    }
+
+    [Fact]
+    public void Explicit_width_table_with_auto_margins_is_centered()
+    {
+        // review [P2] — now that a table has a definite used width, `margin: 0 auto` must center it.
+        // A4 content width = 595.28pt; a 150px (112.5pt) table centers at x = (595.28−112.5)/2 ≈ 241.4pt.
+        var rects = CellRects("<table><tbody><tr><td>X</td></tr></tbody></table>", "width:150px;margin:0 auto");
+        Assert.NotEmpty(rects);
+        Assert.All(rects, r =>
+        {
+            Assert.True(System.Math.Abs(r.W - 112.5) < 1.0, $"width {r.W:0.##}pt (expected 112.5)");
+            Assert.True(System.Math.Abs(r.X - 241.39) < 2.0,
+                $"cell x {r.X:0.##}pt — a `margin: 0 auto` explicit-width table did not center (expected ≈241.4).");
+        });
+    }
+
+    [Fact]
+    public void Auto_margin_min_content_overflow_stays_on_page()
+    {
+        // review [P2] ordering / min-content case — a tiny declared width whose content can't fit
+        // (a long unbreakable word) overflows to the column min-content. `ResolveAutoInlineMargins`
+        // is re-run after the table-driven inline widening (both the outer + recursion dispatch
+        // paths) so the margins distribute against the FINAL used width when the pre-measure reports
+        // the overflow. RESIDUAL: for a single cell whose min-content only materializes at EMIT (not
+        // in the pre-measure), the wrapper isn't widened at the block level, so the table keeps its
+        // declared-width auto-margin — it is NOT recentered on the wider used width. Either way the
+        // safety invariant holds: the content renders and stays WITHIN the page (no off-right-edge
+        // clip). A4 content width (margin:0) = 595.28pt.
+        var rects = CellRects(
+            "<table><tbody><tr><td>Supercalifragilisticexpialidocious</td></tr></tbody></table>",
+            "width:20px;margin:0 auto");
+        Assert.NotEmpty(rects);
+        Assert.All(rects, r =>
+        {
+            Assert.True(r.W > 20 * 0.75 + 1,
+                $"cell width {r.W:0.##}pt — the content should have overflowed the 20px declared width.");
+            Assert.True(r.X >= -0.5 && r.X + r.W <= 595.28 + 0.5,
+                $"cell [{r.X:0.##}..{r.X + r.W:0.##}]pt escaped the page — an overflowing auto-margin table "
+                + "must stay within the page width.");
+        });
     }
 
     private sealed class SynthResolver : IFontResolver

--- a/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
@@ -1,0 +1,79 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using NetPdf;
+using NetPdf.Text.Fonts;
+using NetPdf.UnitTests.Text.Fonts.OpenType;
+using Xunit;
+
+namespace NetPdf.UnitTests.Layout;
+
+/// <summary>
+/// F3 used-table-width, Step B (CSS 2.2 §17.5.2): an explicit <c>width</c> on a table wrapper is now
+/// honored — previously the <c>display: table</c> wrapper kind was excluded from the explicit-width
+/// resolution in <c>BlockLayouter.ResolveInFlowBorderBoxInlineSize</c>, so a table ALWAYS filled its
+/// containing block
+/// and a declared <c>width</c> (px or %) had no effect (repro J of the F3 finding). A <c>width: auto</c>
+/// table still fills (shrink-to-fit is the deferred remainder of F3 — see the PR / deferrals).
+/// </summary>
+public sealed class TableExplicitWidthTests
+{
+    private static HtmlPdfOptions Opts() => new() { FontResolver = new SynthResolver(), PrintBackgrounds = true };
+
+    // Widths of the filled cell background rects (#ff0000 → `1 0 0 rg <x> <y> <w> <h> re`).
+    private static List<double> CellRectWidths(string tableAttrsAndStyle) =>
+        Regex.Matches(
+                Encoding.Latin1.GetString(HtmlPdf.Convert(
+                    "<!DOCTYPE html><html><head><style>@page{size:A4;margin:0}*{box-sizing:border-box}"
+                    + "body{margin:0}table{border-collapse:collapse}td{background:#ff0000}</style></head>"
+                    + "<body>" + tableAttrsAndStyle + "</body></html>", Opts())),
+                @"\b1 0 0 rg\s+-?[\d.]+ -?[\d.]+ (-?[\d.]+) -?[\d.]+ re")
+            .Select(m => double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture))
+            .ToList();
+
+    [Fact]
+    public void Explicit_px_width_on_a_table_is_honored()
+    {
+        // 150px = 112.5pt. Pre-fix the cell filled the full A4 content width (595.28pt).
+        var widths = CellRectWidths("<table style='width:150px'><tbody><tr><td>X</td></tr></tbody></table>");
+        Assert.NotEmpty(widths);
+        Assert.All(widths, w => Assert.True(System.Math.Abs(w - 112.5) < 1.0,
+            $"cell width {w:0.##}pt — expected 112.5pt (150px); explicit table width was ignored."));
+    }
+
+    [Fact]
+    public void Explicit_percent_width_on_a_table_is_honored()
+    {
+        // A4 content width = 595.28pt (margin:0); 50% = 297.64pt.
+        var widths = CellRectWidths("<table style='width:50%'><tbody><tr><td>X</td></tr></tbody></table>");
+        Assert.NotEmpty(widths);
+        Assert.All(widths, w => Assert.True(System.Math.Abs(w - 297.64) < 2.0,
+            $"cell width {w:0.##}pt — expected ~297.6pt (50% of A4); explicit % table width was ignored."));
+    }
+
+    [Fact]
+    public void Auto_width_table_still_fills_the_available_width()
+    {
+        // Regression guard: shrink-to-fit for auto tables is the DEFERRED remainder of F3, so a
+        // `width: auto` table must keep filling its containing block (current behavior, unchanged).
+        var widths = CellRectWidths("<table><tbody><tr><td>X</td></tr></tbody></table>");
+        Assert.NotEmpty(widths);
+        Assert.All(widths, w => Assert.True(w > 500,
+            $"auto-width cell {w:0.##}pt — an auto table should still fill (~595pt) until shrink-to-fit lands."));
+    }
+
+    private sealed class SynthResolver : IFontResolver
+    {
+        private static readonly byte[] FontBytes = SyntheticFont.Build();
+
+        public ValueTask<FontFaceData?> ResolveAsync(FontQuery query, CancellationToken ct)
+            => new(new FontFaceData { Bytes = FontBytes, Family = query.Family });
+    }
+}


### PR DESCRIPTION
## Summary

F3 (used-table-width) from the 2026-07-08 corpus QA plan. This PR ships the **safe, self-contained Step B** — honoring an explicit `width` on a table — and **defers the shrink-to-fit remainder (Steps A/C/D/E)** to a dedicated PR, for the reasons below.

## What's fixed — Step B (CSS 2.2 §17.5.2)

A `display: table` / `inline-table` wrapper was excluded from the explicit-width branch of `BlockLayouter.ResolveInFlowBorderBoxInlineSize`, so a table **always filled its containing block** and a declared `width` (px or %) was silently ignored (repro J of the finding). The stale doc even claimed "the grid already consumes the css width itself" — it doesn't; nothing in `TableLayouter` read the wrapper's width.

Adding `Table`/`InlineTable` to the kind gate makes the declared border-box width (box-sizing-mapped, min/max-width clamped, `%` against the containing block per §10.2) size the wrapper and become the grid's available width (floored at GRIDMIN by the column algorithm). `width: auto` tables keep the fill behavior.

**Verified:** `table{width:150px}` → a 112.5pt cell (was full-width ~595pt); `table{width:50%}` → ~297.6pt. Tests: `TableExplicitWidthTests` (px + % honored; auto still fills). Full unit suite green (**8590**); no golden re-pins (auto tables unchanged).

## Why the rest is deferred (Steps A / C / D / E)

I implemented shrink-to-fit locally to gauge it. It is a genuinely larger, interaction-heavy change than one PR should absorb:

- **23 table-contract unit tests re-pin** — the intended fill→max-content change (e.g. `Simple_2x2`: a `300pt` fill column → its `7.2pt` max-content). Each needs careful re-validation, not blind updating.
- **Captions collapse** — an uncovered interaction the finding didn't flag: a caption's inline size derives from `_measuredUsedInlineSize` (the grid width), so narrowing an auto wrapper to its shrunk grid drops the caption fragment entirely (and 0-content tables vanish). Fixing it needs a **caption-content floor** on the used table width (CSS Tables L3 §3.2).
- The actual index.html totals-card symptom additionally needs **Step E** (percentage cell/column distribution — the `w-full` spacer idiom) and **Step D** (percent-as-auto under the intrinsic probe, killing the nested-table `1e6` poison).

So the full fix = shrink-to-fit + caption floor + percent columns + the 23 re-pins + corpus re-validation — a focused follow-up PR. The finding itself sequences D "last, after the re-pins settle." **The index.html symptom (F3) is therefore not yet resolved by this PR; explicit-width tables (reproJ) are.** Documented in `docs/deferrals.md#table-auto-fixed-spans-borders`.

## Gate

Build 0-warn · 8590 unit / 3 skip. Determinism unaffected. (CI is red on the repo-wide GitHub Actions billing block — see the note below — verified locally per the established workflow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)