### PR TITLE
feat(table): auto-table shrink-to-fit + percent columns (F3 Steps A–E)

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -540,10 +540,12 @@ grepping the ID).
     `ComputeColumnWidthsAuto` + the measured grid narrows the wrapper in both
     BlockLayouter dispatch paths); `table { margin: 0 auto }` centers; a
     `width: N%` NESTED table behaves as auto under the intrinsic max-content
-    probe (Step D — kills the `1e6` poison); and percentage columns absorb
-    the saturated-path surplus so the `<td width:100%>` spacer idiom pushes a
+    probe (Step D — kills the `1e6` poison); and percentage columns (from a
+    cell OR a `<col>`/`<colgroup>`, CSS or the HTML `width="N%"` attribute)
+    absorb the saturated-path surplus so the `width:100%` spacer idiom pushes a
     following content cell to the right edge (Step E — `DistributeSaturatedExtra`,
-    §3.5.3). A table with NO max-content (all-empty cells, `sumMax == 0`) keeps
+    §3.5.3); a `width: auto` shrink-to-fit table also centers under
+    `margin: 0 auto`. A table with NO max-content (all-empty cells, `sumMax == 0`) keeps
     the fill (a 0-width wrapper is degenerate — its emit + caption are dropped).
     RESIDUAL: the DEEP-NESTED spacer idiom (index.html's totals card = items
     table → colspan cell → `w-full` wrapper → auto cell → totals table, 3

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -533,20 +533,25 @@ grepping the ID).
     `break-inside: avoid`; RTL writing modes / row reversal / caption
     inline-axis keyword routing; HTML5 colspan='0'/rowspan='0'
     remainder semantics; percentage column widths.
-  - **F3 used-table-width (partial).** An explicit `width` (px / %) on a
-    `display: table` / `inline-table` wrapper is now HONORED
-    (`BlockLayouter.ResolveInFlowBorderBoxInlineSize` includes the table
-    kinds — the declared border-box width sizes the wrapper + becomes the
-    grid's available width, floored at GRIDMIN by the column algorithm).
-    STILL DEFERRED: shrink-to-fit for `width: auto` tables (they still fill
-    the containing block, not max-content — CSS 2.2 §17.5.2 auto width);
-    percentage cell/column widths (drop to 0); the nested-table max-content
-    `1e6` probe poison; and the caption-width floor these need (narrowing an
-    auto wrapper to its grid collapses captions/0-content tables — the
-    caption/wrapper width derives from the grid, so shrink-to-fit must floor
-    the table width by the caption's content width). These land together as
-    a dedicated PR (they break the 23 auto-width table-contract tests as an
-    intended re-pin + need the caption floor to avoid regressions).
+  - **F3 used-table-width (LANDED — one residual).** Auto-table
+    shrink-to-fit now works (CSS 2.2 §17.5.2 / CSS Tables L3 §3): an explicit
+    `width` (px/%) is honored (Step B); a `width: auto` table shrinks its
+    columns to max-content (Steps A+C — `usedTableWidth` in
+    `ComputeColumnWidthsAuto` + the measured grid narrows the wrapper in both
+    BlockLayouter dispatch paths); `table { margin: 0 auto }` centers; a
+    `width: N%` NESTED table behaves as auto under the intrinsic max-content
+    probe (Step D — kills the `1e6` poison); and percentage columns absorb
+    the saturated-path surplus so the `<td width:100%>` spacer idiom pushes a
+    following content cell to the right edge (Step E — `DistributeSaturatedExtra`,
+    §3.5.3). A table with NO max-content (all-empty cells, `sumMax == 0`) keeps
+    the fill (a 0-width wrapper is degenerate — its emit + caption are dropped).
+    RESIDUAL: the DEEP-NESTED spacer idiom (index.html's totals card = items
+    table → colspan cell → `w-full` wrapper → auto cell → totals table, 3
+    levels) still splits its label/value to opposite edges — the percentage
+    does not propagate through that many nested intrinsic measures (the direct
+    2-cell spacer works; see `TableShrinkToFitTests`). Pickup: trace the
+    percent-column / max-content propagation through the nested cell-content
+    measures for the 3-level case.
   - `src/NetPdf.Layout/Layouters/BlockLayouter.cs::PreMeasureTableIfNeeded`
     — now consumes the table's
     `MeasuredUsedInlineSize` to widen the wrapper's border-box

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -1777,7 +1777,17 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                         + wrapperPaddingInlineStart + wrapperPaddingInlineEnd;
                     var tableDrivenBorderBoxInline =
                         tableMeasuredUsedInlineSize + wrapperBorderPaddingInline;
-                    if (tableDrivenBorderBoxInline > borderBoxInlineSize)
+                    // F3 used-table-width Step C — a `width: auto` table shrinks-to-fit: adopt the
+                    // MEASURED grid width even when it is NARROWER than the fill (previously
+                    // widen-only, so an auto table always kept the full available width). An
+                    // explicit-width wrapper must NOT narrow — its declared width wins (§17.5.2), so
+                    // keep the widen-only behavior there (a grid wider than the declared width still
+                    // overflows the wrapper, matching the fixed-layout overflow contract). Also require
+                    // a POSITIVE measured grid width to narrow: a table with no measurable content
+                    // (all-empty cells → grid 0) keeps the available width — a 0-width wrapper is
+                    // degenerate (BlockLayouter drops its emit, taking any caption with it).
+                    if (tableDrivenBorderBoxInline > borderBoxInlineSize
+                        || (!HasExplicitWidth(child) && tableMeasuredUsedInlineSize > 0))
                     {
                         borderBoxInlineSize = tableDrivenBorderBoxInline;
                     }
@@ -5615,7 +5625,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                         + nestedPaddingInlineStart + nestedPaddingInlineEnd;
                     var nestedTableDrivenInline =
                         nestedMeasuredUsedInline + nestedBorderPaddingInline;
-                    if (nestedTableDrivenInline > childBorderBoxInlineSize)
+                    // F3 used-table-width Step C (recursion-path mirror) — an auto-width nested table
+                    // shrinks-to-fit; adopt the measured grid width even when narrower than the fill.
+                    // An explicit-width wrapper stays widen-only (declared width wins). A 0-measured
+                    // grid keeps the available width (degenerate 0-width wrapper — see the outer path).
+                    if (nestedTableDrivenInline > childBorderBoxInlineSize
+                        || (!HasExplicitWidth(child) && nestedMeasuredUsedInline > 0))
                     {
                         childBorderBoxInlineSize = nestedTableDrivenInline;
                     }

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -1641,7 +1641,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // block. Per the body-explicit-width gap fix — an explicit
             // `width` on a plain block container overrides the fill.
             var borderBoxInlineSize = ResolveInFlowBorderBoxInlineSize(
-                child, availInlineSize, fragmentainer.ContentInlineSize, marginInlineStart, marginInlineEnd);
+                child, availInlineSize, fragmentainer.ContentInlineSize, marginInlineStart, marginInlineEnd,
+                isIntrinsicProbe: _measurePurpose == MeasurePurpose.IntrinsicContribution);
             // §10.3.3 auto margins (auto-margins cycle): `margin: 0 auto` centres an explicit-width
             // block — must run before any inline-offset consumption below. The distribution range
             // is the FLOAT-ADJUSTED available range (the same range placement uses — review P1).
@@ -5282,7 +5283,8 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // block container overrides the fill), so a nested div
             // sizes identically to a top-level one.
             var childBorderBoxInlineSize = ResolveInFlowBorderBoxInlineSize(
-                child, contentInlineSize, contentInlineSize, marginInlineStart, marginInlineEnd);
+                child, contentInlineSize, contentInlineSize, marginInlineStart, marginInlineEnd,
+                isIntrinsicProbe: _measurePurpose == MeasurePurpose.IntrinsicContribution);
             ResolveAutoInlineMargins(
                 child, childBorderBoxInlineSize, contentInlineSize,
                 ref marginInlineStart, ref marginInlineEnd);   // §10.3.3 — auto-margins cycle.
@@ -7701,18 +7703,27 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     /// <see cref="ResolveAutoInlineMargins"/> (the caller applies it right after this).</summary>
     private static double ResolveInFlowBorderBoxInlineSize(
         Box child, double availableInlineSize, double containingInlinePx,
-        double marginInlineStart, double marginInlineEnd)
+        double marginInlineStart, double marginInlineEnd,
+        bool isIntrinsicProbe = false)
     {
         if (child.Kind is BoxKind.BlockContainer or BoxKind.ListItem or BoxKind.BlockReplacedElement
             or BoxKind.FlexContainer or BoxKind.GridContainer
             or BoxKind.Table or BoxKind.InlineTable)
         {
+            // F3 Step D — under an intrinsic (max-content) probe a PERCENTAGE width on a TABLE behaves
+            // as AUTO (CSS Sizing L3 §5.2.4 — cyclic percentage sizes), so a `width: 100%` nested table
+            // shrinks-to-fit its OWN content instead of resolving 100% against the ~1e6 probe width (the
+            // nested-table max-content poison that made the containing cell measure ~1e6). Scope-limited
+            // to table kinds so plain blocks under probes keep today's behavior.
+            var percentTableUnderProbe = isIntrinsicProbe
+                && child.Kind is BoxKind.Table or BoxKind.InlineTable
+                && child.Style.Get(PropertyId.Width).Tag == ComputedSlotTag.Percentage;
             // Body % lengths (body-percent cycle): an explicit PERCENTAGE width resolves against
             // the CONTAINING block's inline size (CSS 2.2 §10.2 — not the float-adjusted available
             // range), as do the padding percentages (§8.4). Explicitness is a TAG test, so the
             // legal `width: 0` / `0%` sizes a zero-content border box instead of filling
             // (post-PR-#164 review P3).
-            if (HasExplicitWidth(child))
+            if (HasExplicitWidth(child) && !percentTableUnderProbe)
             {
                 var declaredWidth = child.Style.ReadLengthOrPercentPx(PropertyId.Width, containingInlinePx);
                 var inlineInsets = child.Style.ReadLengthPxOrZero(PropertyId.BorderLeftWidth)

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -1795,19 +1795,23 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 }
             }
 
-            // F3 — a table wrapper's auto inline margins (`margin: 0 auto`) must distribute against
-            // its FINAL used width. The grid pre-measure above can WIDEN borderBoxInlineSize past the
-            // declared width when the column min-content overflows it, so re-resolve here — the
-            // earlier call (before the pre-measure) used the pre-widening width. ResolveAutoInlineMargins
-            // is idempotent when no widening happened (it recomputes the same leftover), so this is a
-            // no-op for the common fits-within case. InlineTable is excluded (inline-level, no block
-            // auto-margins); the pre-measure's cell offsets are relative + re-anchored at emit, so
-            // updating the margin after the pre-measure is safe.
+            // F3 — a table wrapper's auto inline margins (`margin: 0 auto`) must distribute against its
+            // FINAL used width: the grid pre-measure above SHRINKS an auto table (or WIDENS a declared
+            // table on min-content overflow), so the earlier call (before the pre-measure) used the
+            // pre-shrink/pre-widen width. Re-resolve here against the final borderBoxInlineSize, then —
+            // since PreMeasureTableIfNeeded already ConfigureEmission'd the table at the PRE-centering
+            // inline offset — shift the table's configured inline offset by the margin DELTA so the emit
+            // lands centered (offset-only; block offset + measured heights/widths are unchanged, so no
+            // re-measure is needed). InlineTable is excluded (inline-level, no block auto-margins).
             if (child.Kind is BoxKind.Table)
             {
+                var marginBeforeReResolve = marginInlineStart;
                 ResolveAutoInlineMargins(
                     child, borderBoxInlineSize, availInlineSize,
                     ref marginInlineStart, ref marginInlineEnd);
+                var marginDelta = marginInlineStart - marginBeforeReResolve;
+                if (marginDelta != 0.0)
+                    pendingTableLayouter?.ShiftContentInlineOffset(marginDelta);
             }
 
             // Per Phase 3 Task 14 cycle 1 hardening (Findings 1 + 2) —
@@ -5638,16 +5642,21 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     }
                 }
 
-                // F3 — re-distribute a table wrapper's auto inline margins (`margin: 0 auto`) against
-                // its FINAL used width: the grid pre-measure above may have widened
-                // childBorderBoxInlineSize past the declared width (min-content overflow), so the
-                // earlier call (5276, pre-measure) used the pre-widening width. Idempotent when no
-                // widening happened. Table only (InlineTable flows inline — no block auto-margins).
+                // F3 — re-distribute a table wrapper's auto inline margins (`margin: 0 auto`) against its
+                // FINAL used width (the grid pre-measure above SHRINKS an auto table / WIDENS a declared
+                // one), then shift the already-configured table inline offset by the margin DELTA so the
+                // emit lands centered (the pre-measure ConfigureEmission'd it at the pre-centering
+                // offset). Offset-only — heights/widths are unchanged. Table only (InlineTable flows
+                // inline — no block auto-margins).
                 if (child.Kind is BoxKind.Table)
                 {
+                    var marginBeforeReResolve = marginInlineStart;
                     ResolveAutoInlineMargins(
                         child, childBorderBoxInlineSize, contentInlineSize,
                         ref marginInlineStart, ref marginInlineEnd);
+                    var marginDelta = marginInlineStart - marginBeforeReResolve;
+                    if (marginDelta != 0.0)
+                        nestedPendingTable?.ShiftContentInlineOffset(marginDelta);
                 }
 
                 // RC-7 — break BEFORE a positionally-oversized nested table. Its repeated header+footer
@@ -7682,13 +7691,12 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
     ///   <item><see cref="BoxKind.AnonymousBlock"/> SHARES its parent's style object, so the
     ///   parent's explicit width would double-apply (plus re-add the parent's borders/padding);
     ///   per Display L3 §3.1 anonymous boxes take the initial <c>width: auto</c>.</item>
-    ///   <item><see cref="BoxKind.Table"/> / <see cref="BoxKind.InlineTable"/> wrappers now honor
-    ///   an explicit <c>width</c> (F3 used-table-width Step B, CSS 2.2 §17.5.2): the declared
-    ///   border-box width is the wrapper size and becomes the grid's available width (floored at
-    ///   GRIDMIN by the column algorithm). A <c>width: auto</c> table still FILLS the available range
-    ///   here — auto shrink-to-fit is the deferred remainder of F3 (see
-    ///   <c>docs/deferrals.md#table-auto-fixed-spans-borders</c>); the MEASURED grid only WIDENS the
-    ///   wrapper when it overflows (Task 12 Finding 6).</item>
+    ///   <item><see cref="BoxKind.Table"/> / <see cref="BoxKind.InlineTable"/> wrappers honor an
+    ///   explicit <c>width</c> (F3 used-table-width, CSS 2.2 §17.5.2): the declared border-box width
+    ///   is the wrapper size and becomes the grid's available width (floored at GRIDMIN). A
+    ///   <c>width: auto</c> table fills the available range HERE, then the caller NARROWS the wrapper
+    ///   to the MEASURED grid's shrink-to-fit width (Step C — the table-driven feedback below);
+    ///   `margin: 0 auto` centers the resulting definite-width table.</item>
     ///   <item><see cref="BoxKind.BlockReplacedElement"/> sizes like a plain block
     ///   (img-pipeline cycle): the sizing pre-pass writes the §10.3.2 used width/height into
     ///   the slots, so an explicit width here is the image's used size — filling would
@@ -7741,8 +7749,9 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
             // (minus margins); §10.4 — min-width/max-width then clamp that USED
             // width (e.g. `max-width: 600px` on an auto-width content column).
             // No-op when neither is set, so the fill path stays byte-identical
-            // (PR #203 review [P2]). Gated to plain block kinds — anonymous / flex
-            // / grid / table fill is unchanged (they own their width logic).
+            // (PR #203 review [P2]). A `width: auto` TABLE also fills HERE, but its caller then
+            // narrows the wrapper to the measured grid's shrink-to-fit width (F3 Step C) — the fill
+            // is just the "available width" input to the column algorithm's shrink clamp.
             var autoFillWidth = Math.Max(0,
                 availableInlineSize - marginInlineStart - marginInlineEnd);
             return child.ClampBorderBoxToMinMax(
@@ -7786,7 +7795,11 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
         // §10.4; the `borderBoxInlineSize` passed in is already the max-width-clamped used width, so the
         // leftover below is 0 when max-width doesn't actually clamp → byte-identical for the fill case).
         // A plain auto-width box with no max-width keeps the fill behavior (auto margins read 0).
-        if (!HasExplicitWidth(child) && !HasExplicitMaxWidth(child)) return;
+        // F3 — a Table ALWAYS has a definite used width (explicit OR the measured shrink-to-fit width),
+        // so `table { margin: 0 auto }` centers even without an explicit `width`. The caller passes the
+        // FINAL (post-shrink) borderBoxInlineSize, so the leftover is real. (Non-table auto boxes still
+        // need an explicit width / max-width to have a definite width to center.)
+        if (child.Kind is not BoxKind.Table && !HasExplicitWidth(child) && !HasExplicitMaxWidth(child)) return;
         var leftAuto = child.Style.Get(PropertyId.MarginLeft).Tag == ComputedSlotTag.Keyword;
         var rightAuto = child.Style.Get(PropertyId.MarginRight).Tag == ComputedSlotTag.Keyword;
         if (!leftAuto && !rightAuto) return;

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -4608,6 +4608,19 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             placements, declaredWidths, columnHasDeclared, columnCount,
             cancellationToken);
 
+        // F3 Step E — per-column PERCENTAGE widths (from the first row's single-column cells: the
+        // `<td class="w-full">` spacer idiom). Collected so the saturated path can route the surplus
+        // to percentage columns before the equal split (CSS Tables L3 §3.5.3). Colspan>1 percent
+        // cells are not distributed here (rare; the equal split still applies).
+        var columnPercents = new double[columnCount];
+        for (var i = 0; i < placements.Count; i++)
+        {
+            var p = placements[i];
+            if (p.OriginRow != 0 || p.ColSpan != 1 || p.OriginCol >= columnCount) continue;
+            var pct = ReadColumnWidthPercent(p.Cell);
+            if (pct > columnPercents[p.OriginCol]) columnPercents[p.OriginCol] = pct;
+        }
+
         // ============================================================
         //  Step 1 — per-cell intrinsic widths via speculative layouts.
         // ============================================================
@@ -4823,8 +4836,8 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             var extra = usedTableWidth - sumMax;
             if (extra > Tolerance)
             {
-                var perColumn = extra / columnCount;
-                for (var c = 0; c < columnCount; c++) widths[c] += perColumn;
+                DistributeSaturatedExtra(
+                    widths, columnPercents, usedTableWidth, extra, columnCount, Tolerance);
             }
             return widths;
         }
@@ -5235,6 +5248,73 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         }
         if (n < 0) return 0;
         return ColumnBorderBoxWidth(box, n);
+    }
+
+    /// <summary>F3 used-table-width Step E — the RAW percentage of a cell's / col's declared
+    /// <c>width: N%</c> (e.g. 100 for <c>width: 100%</c>), or 0 for a non-percentage width. Used to
+    /// route the auto-layout saturated path's surplus to percentage columns before the equal split
+    /// (CSS Tables L3 §3.5.3) so the <c>&lt;td class="w-full"&gt;</c> spacer idiom absorbs the extra.</summary>
+    private static double ReadColumnWidthPercent(Box box)
+    {
+        var slot = box.Style.Get(PropertyId.Width);
+        if (slot.Tag == ComputedSlotTag.Percentage) return slot.AsPercentage();
+        // HTML `width="N%"` attribute (the px path drops it to 0 at ReadColumnWidthPx:5223).
+        var raw = box.SourceElement?.GetAttribute("width");
+        if (!string.IsNullOrEmpty(raw) && raw.EndsWith('%')
+            && double.TryParse(raw.AsSpan(0, raw.Length - 1),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var pct) && pct > 0)
+        {
+            return pct;
+        }
+        return 0;
+    }
+
+    /// <summary>F3 Step E — distribute the saturated-path SURPLUS (usedTableWidth − sumMax) across
+    /// columns. Percentage columns (CSS Tables L3 §3.5.3) get priority: each percent column's TARGET is
+    /// <c>pct/100 × usedTableWidth</c> (normalized when Σpct &gt; 100), and the surplus fills those
+    /// targets first (proportional, capped at the target above the column's max-content) so a
+    /// <c>width: 100%</c> spacer absorbs the leftover and non-percent columns stay at their max-content;
+    /// any remainder splits equally across all columns (the pre-E behavior — byte-identical when no
+    /// column declares a percent).</summary>
+    private static void DistributeSaturatedExtra(
+        double[] widths, double[] columnPercents, double usedTableWidth,
+        double extra, int columnCount, double tolerance)
+    {
+        var sumPct = 0.0;
+        for (var c = 0; c < columnCount; c++) sumPct += columnPercents[c];
+        var scale = sumPct > 100.0 ? 100.0 / sumPct : 1.0;   // §3.5.3 — normalize when Σpct > 100.
+
+        var targets = new double[columnCount];
+        var sumTargets = 0.0;
+        for (var c = 0; c < columnCount; c++)
+        {
+            if (columnPercents[c] <= 0) continue;
+            var growth = columnPercents[c] * scale / 100.0 * usedTableWidth - widths[c];
+            if (growth > tolerance)
+            {
+                targets[c] = growth;
+                sumTargets += growth;
+            }
+        }
+
+        var remaining = extra;
+        if (sumTargets > tolerance)
+        {
+            var give = Math.Min(extra, sumTargets);
+            for (var c = 0; c < columnCount; c++)
+            {
+                if (targets[c] <= 0) continue;
+                widths[c] += give * (targets[c] / sumTargets);
+            }
+            remaining = extra - give;
+        }
+
+        if (remaining > tolerance && columnCount > 0)
+        {
+            var perColumn = remaining / columnCount;
+            for (var c = 0; c < columnCount; c++) widths[c] += perColumn;
+        }
     }
 
     /// <summary>Box-sizing audit (CSS Basic UI 4 §10) — map a cell's DECLARED width to

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -414,6 +414,18 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         _emissionConfigured = true;
     }
 
+    /// <summary>F3 — shift the configured content inline-start by <paramref name="delta"/> after the
+    /// pre-measure. A `width: auto` table's auto inline margins (`margin: 0 auto`) can only be resolved
+    /// once its shrink-to-fit width is measured, which happens AFTER <see cref="ConfigureEmission"/> was
+    /// called with the pre-centering offset. Centering changes only the inline START (by the margin
+    /// delta) — the block offset + measured row heights + column widths are unaffected — so the emit
+    /// re-anchors correctly without a re-measure. Cell inline offsets derive from
+    /// <see cref="_contentInlineOffset"/>, so shifting it moves the whole grid uniformly.</summary>
+    public void ShiftContentInlineOffset(double delta)
+    {
+        _contentInlineOffset += delta;
+    }
+
     private double _contentInlineOffset;
     private double _contentBlockOffset;
     private double _contentInlineSize;
@@ -4441,8 +4453,10 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             // <colgroup> as siblings of <tr> in the source HTML, which
             // BoxBuilder slots under the synthesized TableGrid.
             var colCursor = 0;
+            // Fixed layout (table-layout: fixed) doesn't use the auto-layout percent-column surplus
+            // distribution — pass a throwaway percents array (collected but unread here).
             CollectColumnsFromGridLevel(
-                wrapper, columnCount, widths, hasDeclared, ref colCursor,
+                wrapper, columnCount, widths, hasDeclared, new double[columnCount], ref colCursor,
                 cancellationToken);
 
             // Pass B — walk first-row placements. Sub-cycle 4 hardening
@@ -4600,19 +4614,19 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         // — see docs/deferrals.md#table-auto-fixed-spans-borders.
         var declaredWidths = new double[columnCount];
         var columnHasDeclared = new bool[columnCount];
+        // F3 Step E — per-column PERCENTAGE widths so the saturated path can route the surplus to
+        // percentage columns before the equal split (CSS Tables L3 §3.5.3 — the `width: 100%` spacer
+        // idiom). Sourced from BOTH `<col>`/`<colgroup>` declarations (in the grid-level walk, span-
+        // distributed) AND the first row's single-column cells (`<td class="w-full">`), taking the max.
+        var columnPercents = new double[columnCount];
         var colCursor = 0;
         CollectColumnsFromGridLevel(
-            wrapper, columnCount, declaredWidths, columnHasDeclared,
+            wrapper, columnCount, declaredWidths, columnHasDeclared, columnPercents,
             ref colCursor, cancellationToken);
         ApplyFirstRowCellWidths(
             placements, declaredWidths, columnHasDeclared, columnCount,
             cancellationToken);
 
-        // F3 Step E — per-column PERCENTAGE widths (from the first row's single-column cells: the
-        // `<td class="w-full">` spacer idiom). Collected so the saturated path can route the surplus
-        // to percentage columns before the equal split (CSS Tables L3 §3.5.3). Colspan>1 percent
-        // cells are not distributed here (rare; the equal split still applies).
-        var columnPercents = new double[columnCount];
         for (var i = 0; i < placements.Count; i++)
         {
             var p = placements[i];
@@ -5051,7 +5065,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     /// declarations are silently ignored per CSS Tables L3 §11.1).</para>
     /// </summary>
     private static void CollectColumnsFromGridLevel(
-        Box wrapper, int columnCount, double[] widths, bool[] hasDeclared,
+        Box wrapper, int columnCount, double[] widths, bool[] hasDeclared, double[] columnPercents,
         ref int colCursor, CancellationToken cancellationToken)
     {
         // Wrapper-level children first (rare but valid per Display 3 if
@@ -5061,7 +5075,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
             VisitColumnishChild(
-                wrapper.Children[i], columnCount, widths, hasDeclared,
+                wrapper.Children[i], columnCount, widths, hasDeclared, columnPercents,
                 ref colCursor, cancellationToken);
         }
 
@@ -5072,9 +5086,18 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
             VisitColumnishChild(
-                grid.Children[i], columnCount, widths, hasDeclared,
+                grid.Children[i], columnCount, widths, hasDeclared, columnPercents,
                 ref colCursor, cancellationToken);
         }
+    }
+
+    /// <summary>F3 Step E — record a <c>&lt;col&gt;</c>/<c>&lt;colgroup&gt;</c> percentage width across
+    /// the <c>[start, end)</c> columns it just claimed (max-wins, mirroring the cell collection).</summary>
+    private static void ApplyPercentToColumns(double pct, int start, int end, double[] columnPercents)
+    {
+        if (!(pct > 0)) return;
+        for (var c = start; c < end && c < columnPercents.Length; c++)
+            if (pct > columnPercents[c]) columnPercents[c] = pct;
     }
 
     /// <summary>Per Phase 3 Task 12 sub-cycle 4 — visit one direct
@@ -5088,7 +5111,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     /// <c>span</c> consecutive columns.
     /// </summary>
     private static void VisitColumnishChild(
-        Box child, int columnCount, double[] widths, bool[] hasDeclared,
+        Box child, int columnCount, double[] widths, bool[] hasDeclared, double[] columnPercents,
         ref int colCursor, CancellationToken cancellationToken)
     {
         switch (child.Kind)
@@ -5097,9 +5120,11 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             {
                 var span = ParseColumnSpan(child);
                 var width = ReadColumnWidthPx(child);
+                var colStart = colCursor;
                 ApplyDeclaredWidthToColumns(
                     width, span, columnCount, widths, hasDeclared,
                     ref colCursor, cancellationToken);
+                ApplyPercentToColumns(ReadColumnWidthPercent(child), colStart, colCursor, columnPercents);
                 break;
             }
             case BoxKind.TableColumnGroup:
@@ -5125,18 +5150,23 @@ internal sealed class TableLayouter : ILayouter, IDisposable
                         if (inner.Kind != BoxKind.TableColumn) continue;
                         var span = ParseColumnSpan(inner);
                         var width = ReadColumnWidthPx(inner);
+                        var colStart = colCursor;
                         ApplyDeclaredWidthToColumns(
                             width, span, columnCount, widths, hasDeclared,
                             ref colCursor, cancellationToken);
+                        ApplyPercentToColumns(
+                            ReadColumnWidthPercent(inner), colStart, colCursor, columnPercents);
                     }
                 }
                 else
                 {
                     var span = ParseColumnSpan(child);
                     var width = ReadColumnWidthPx(child);
+                    var colStart = colCursor;
                     ApplyDeclaredWidthToColumns(
                         width, span, columnCount, widths, hasDeclared,
                         ref colCursor, cancellationToken);
+                    ApplyPercentToColumns(ReadColumnWidthPercent(child), colStart, colCursor, columnPercents);
                 }
                 break;
             }
@@ -5192,15 +5222,15 @@ internal sealed class TableLayouter : ILayouter, IDisposable
     ///     attribute is parsed as a non-negative integer in CSS px;
     ///     non-integer / negative values are ignored.</item>
     /// </list>
-    /// Returns 0 when both are absent / invalid. Percentage column
-    /// widths (e.g. <c>20%</c>) are NOT supported — sub-cycle 5+ work,
-    /// see <c>docs/deferrals.md#table-auto-fixed-spans-borders</c>.
+    /// Returns 0 when both are absent / invalid. A PERCENTAGE column width (e.g. <c>20%</c>) does not
+    /// contribute a fixed px min/max here (it maps to 0), but F3 Step E reads it SEPARATELY via
+    /// <see cref="ReadColumnWidthPercent"/> to route the auto-layout saturated-path surplus to that
+    /// column (CSS Tables L3 §3.5.3 — the <c>width: 100%</c> spacer idiom).
     /// </summary>
     private static double ReadColumnWidthPx(Box box)
     {
-        // CSS width (resolved-px). Percentages + auto map to 0 per
-        // ReadLengthPxOrZero's contract — that's the documented sub-
-        // cycle-4 simplification.
+        // CSS width (resolved-px). Percentages + auto map to 0 per ReadLengthPxOrZero's contract — a
+        // percent doesn't set a fixed px column width; F3 Step E's ReadColumnWidthPercent handles it.
         var cssWidth = box.Style.ReadLengthPxOrZero(PropertyId.Width);
         if (cssWidth > 0) return ColumnBorderBoxWidth(box, cssWidth);
 

--- a/src/NetPdf.Layout/Layouters/TableLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/TableLayouter.cs
@@ -4771,10 +4771,24 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             sumMax += colMax[c];
         }
 
-        // tableWidth = clamp(contentInlineSize, sumMin, sumMax).
-        var tableWidth = contentInlineSize;
-        if (tableWidth < sumMin) tableWidth = sumMin;
-        else if (tableWidth > sumMax) tableWidth = sumMax;
+        // F3 used-table-width (CSS 2.2 §17.5.2 / CSS Tables L3 §3.2). An AUTO-width table
+        // shrinks-to-fit: clamp(contentInlineSize, sumMin, sumMax). An EXPLICIT-width table (its
+        // declared width was already resolved into `contentInlineSize` by
+        // BlockLayouter.ResolveInFlowBorderBoxInlineSize — Step B) uses that width, floored at
+        // GRIDMIN (sumMin) per §17.5.2 — it may exceed sumMax, in which case the saturated path
+        // distributes the surplus. Pre-F3 the saturated + interpolation paths spent
+        // `contentInlineSize` (the fill/available width) directly, so every auto table filled its
+        // containing block instead of shrinking.
+        var wrapperHasExplicitWidth =
+            wrapper.Style.Get(PropertyId.Width).Tag is ComputedSlotTag.LengthPx or ComputedSlotTag.Percentage;
+        var usedTableWidth = wrapperHasExplicitWidth
+            ? Math.Max(contentInlineSize, sumMin)
+            // A table with NO max-content (sumMax == 0 — all cells empty) keeps the fill instead of
+            // shrinking to 0: a 0-width auto table is degenerate (its wrapper emit is dropped, taking
+            // any caption/structure with it). Real tables have content (sumMax > 0) and shrink-to-fit.
+            : sumMax > 0
+                ? Math.Clamp(contentInlineSize, sumMin, sumMax)
+                : contentInlineSize;
 
         // ============================================================
         //  Step 4 — distribute width to columns.
@@ -4796,16 +4810,17 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             return widths;
         }
 
-        if (contentInlineSize + Tolerance >= sumMax)
+        if (usedTableWidth + Tolerance >= sumMax)
         {
-            // Saturated path: contentInlineSize >= sumMax — every
-            // column reaches its max-content; the extra space is
-            // distributed equally across all columns (per the §3 spec
-            // step "if the table-width is greater than the
-            // max-content-table-width, the difference [...] is
-            // distributed equally between all columns").
+            // Saturated path: the USED table width >= sumMax — every column reaches its
+            // max-content; the extra space (only non-zero for an explicit width wider than sumMax)
+            // is distributed equally across all columns (per the §3 spec step "if the table-width is
+            // greater than the max-content-table-width, the difference [...] is distributed equally
+            // between all columns"). For an AUTO table usedTableWidth == sumMax here → extra == 0 →
+            // columns are exactly their max-content = shrink-to-fit (F3). Step E may instead route the
+            // extra to percentage columns before the equal split.
             for (var c = 0; c < columnCount; c++) widths[c] = colMax[c];
-            var extra = contentInlineSize - sumMax;
+            var extra = usedTableWidth - sumMax;
             if (extra > Tolerance)
             {
                 var perColumn = extra / columnCount;
@@ -4829,7 +4844,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
         if (range <= Tolerance)
         {
             for (var c = 0; c < columnCount; c++) widths[c] = colMin[c];
-            var extra = contentInlineSize - sumMin;
+            var extra = usedTableWidth - sumMin;
             if (extra > Tolerance && columnCount > 0)
             {
                 var perColumn = extra / columnCount;
@@ -4838,7 +4853,7 @@ internal sealed class TableLayouter : ILayouter, IDisposable
             return widths;
         }
 
-        var available = tableWidth - sumMin;
+        var available = usedTableWidth - sumMin;
         for (var c = 0; c < columnCount; c++)
         {
             widths[c] = colMin[c] + available * (colMax[c] - colMin[c]) / range;

--- a/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
@@ -64,14 +64,14 @@ public sealed class TableExplicitWidthTests
     }
 
     [Fact]
-    public void Auto_width_table_still_fills_the_available_width()
+    public void Auto_width_table_shrinks_to_fit_its_content()
     {
-        // Regression guard: shrink-to-fit for auto tables is the DEFERRED remainder of F3, so a
-        // `width: auto` table must keep filling its containing block (current behavior, unchanged).
+        // F3 used-table-width — a `width: auto` table now SHRINKS-TO-FIT (CSS 2.2 §17.5.2): a single
+        // cell of "X" collapses to that cell's max-content, far narrower than the ~595pt fill.
         var widths = CellRectWidths("<table><tbody><tr><td>X</td></tr></tbody></table>");
         Assert.NotEmpty(widths);
-        Assert.All(widths, w => Assert.True(w > 500,
-            $"auto-width cell {w:0.##}pt — an auto table should still fill (~595pt) until shrink-to-fit lands."));
+        Assert.All(widths, w => Assert.True(w < 50,
+            $"auto-width cell {w:0.##}pt — an auto table should shrink to its content, not fill (~595pt)."));
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableExplicitWidthTests.cs
@@ -90,6 +90,21 @@ public sealed class TableExplicitWidthTests
     }
 
     [Fact]
+    public void Auto_width_shrink_to_fit_table_with_auto_margins_is_centered()
+    {
+        // review [P2] — a `width: auto` table now has a definite (shrink-to-fit) used width, so
+        // `margin: 0 auto` centers it. "Total" ≈ 26pt in a 595.28pt page → centered at x ≈ 284.6.
+        var rects = CellRects("<table><tbody><tr><td>Total</td></tr></tbody></table>", "margin:0 auto");
+        Assert.NotEmpty(rects);
+        Assert.All(rects, r =>
+        {
+            Assert.True(r.W < 40, $"width {r.W:0.##}pt should be shrunk max-content.");
+            Assert.True(System.Math.Abs(r.X - (595.28 - r.W) / 2) < 1.5,
+                $"cell x {r.X:0.##}pt — a shrink-to-fit `margin:0 auto` table did not center.");
+        });
+    }
+
+    [Fact]
     public void Auto_margin_min_content_overflow_stays_on_page()
     {
         // review [P2] ordering / min-content case — a tiny declared width whose content can't fit

--- a/tests/NetPdf.UnitTests/Layout/TableShrinkToFitTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableShrinkToFitTests.cs
@@ -1,0 +1,100 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using NetPdf;
+using NetPdf.Text.Fonts;
+using NetPdf.UnitTests.Text.Fonts.OpenType;
+using Xunit;
+
+namespace NetPdf.UnitTests.Layout;
+
+/// <summary>
+/// F3 used-table-width — auto-table SHRINK-TO-FIT (CSS 2.2 §17.5.2 / CSS Tables L3 §3) and the
+/// percentage-column distribution (Step E, §3.5.3). A <c>width: auto</c> table sizes its columns to
+/// their max-content instead of filling; a percentage column (the <c>&lt;td class="w-full"&gt;</c>
+/// spacer idiom) absorbs the surplus so a following content cell shrinks and hugs the right edge; a
+/// percentage width on a NESTED table behaves as auto under the intrinsic probe (Step D) so it does
+/// not poison its containing cell's max-content.
+/// </summary>
+public sealed class TableShrinkToFitTests
+{
+    private static HtmlPdfOptions Opts() => new() { FontResolver = new SynthResolver(), PrintBackgrounds = true };
+
+    // Filled rects of a given device-RGB fill color → (x, width) pt.
+    private static List<(double X, double W)> Rects(string bodyInner, string colorRg = "1 0 0", string extraCss = "") =>
+        Regex.Matches(
+                Encoding.Latin1.GetString(HtmlPdf.Convert(
+                    "<!DOCTYPE html><html><head><style>@page{size:A4;margin:0}*{box-sizing:border-box}"
+                    + "body{margin:0}table{border-collapse:collapse}" + extraCss + "</style></head>"
+                    + "<body>" + bodyInner + "</body></html>", Opts())),
+                Regex.Escape(colorRg) + @" rg\s+(-?[\d.]+) -?[\d.]+ (-?[\d.]+) -?[\d.]+ re")
+            .Select(m => (
+                X: double.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture),
+                W: double.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture)))
+            .ToList();
+
+    [Fact]
+    public void Auto_table_shrinks_to_max_content_not_fill()
+    {
+        // reproH — a single-cell auto table collapses to the cell's max-content, not the ~595pt fill.
+        var rects = Rects("<table><tbody><tr><td>X</td></tr></tbody></table>", "1 0 0", "td{background:#f00}");
+        Assert.NotEmpty(rects);
+        Assert.All(rects, r => Assert.True(r.W < 40 && r.W > 0,
+            $"auto cell {r.W:0.##}pt should be max-content, not fill."));
+    }
+
+    [Fact]
+    public void Percent_spacer_absorbs_extra_and_content_cell_hugs_the_right()
+    {
+        // Step E — `<td class="w-full">` (width:100%) spacer absorbs the surplus; the content cell
+        // shrinks to its max-content and sits at the right edge. A4 content width = 595.28pt.
+        var spacer = Rects(
+            "<table style='width:100%'><tbody><tr><td class='sp'></td><td class='c'>Total</td></tr></tbody></table>",
+            "0 1 0", ".sp{width:100%;background:#0f0}.c{background:#f00}");
+        var content = Rects(
+            "<table style='width:100%'><tbody><tr><td class='sp'></td><td class='c'>Total</td></tr></tbody></table>",
+            "1 0 0", ".sp{width:100%;background:#0f0}.c{background:#f00}");
+
+        Assert.Single(spacer);
+        Assert.Single(content);
+        // The spacer takes the lion's share; the content cell is narrow and at the right edge.
+        Assert.True(spacer[0].W > 500, $"spacer {spacer[0].W:0.##}pt should absorb the extra (~569).");
+        Assert.True(content[0].W < 40, $"content cell {content[0].W:0.##}pt should be max-content (~26).");
+        Assert.True(content[0].X > 500 && System.Math.Abs(content[0].X + content[0].W - 595.28) < 1.0,
+            $"content cell [{content[0].X:0.##}..{content[0].X + content[0].W:0.##}] should hug the right edge.");
+    }
+
+    [Fact]
+    public void Nested_percent_table_does_not_poison_the_cell_max_content()
+    {
+        // Step D — a `width:100%` NESTED table behaves as auto under the intrinsic max-content probe
+        // (css-sizing-3 §5.2.4), so it shrinks-to-fit instead of resolving 100% against the ~1e6 probe.
+        // The outer 2-column auto table: col A "left", col B holds the nested table. Col B must be the
+        // nested table's real max-content ("Y"), NOT ~1e6 → the outer table stays narrow, not page-wide.
+        var rects = Rects(
+            "<table><tbody><tr>"
+            + "<td class='a'>left</td>"
+            + "<td class='b'><table style='width:100%'><tbody><tr><td>Y</td></tr></tbody></table></td>"
+            + "</tr></tbody></table>",
+            "1 0 0", ".a{background:#f00}");
+        Assert.NotEmpty(rects);
+        // Col A ("left") is a handful of pt — nowhere near a poisoned ~page/1e6 width.
+        Assert.All(rects, r => Assert.True(r.W < 60,
+            $"col A {r.W:0.##}pt — a nested %-table poisoned the cell max-content (col grew huge)."));
+    }
+
+    private sealed class SynthResolver : IFontResolver
+    {
+        private static readonly byte[] FontBytes = SyntheticFont.Build();
+
+        public ValueTask<FontFaceData?> ResolveAsync(FontQuery query, CancellationToken ct)
+            => new(new FontFaceData { Bytes = FontBytes, Family = query.Family });
+    }
+}

--- a/tests/NetPdf.UnitTests/Layout/TableShrinkToFitTests.cs
+++ b/tests/NetPdf.UnitTests/Layout/TableShrinkToFitTests.cs
@@ -90,6 +90,25 @@ public sealed class TableShrinkToFitTests
             $"col A {r.W:0.##}pt — a nested %-table poisoned the cell max-content (col grew huge)."));
     }
 
+    [Theory]
+    [InlineData("<colgroup><col style='width:100%'><col></colgroup>")]   // CSS percent on <col>
+    [InlineData("<colgroup><col width='100%'><col></colgroup>")]          // HTML width attr percent
+    public void Col_percent_spacer_absorbs_extra(string colgroup)
+    {
+        // review [P2] — Step E must also honor a percentage declared on `<col>` / `<colgroup>`, not
+        // only on a cell. A `<col width:100%>` spacer column absorbs the surplus so the content column
+        // ("Total") shrinks to max-content and hugs the right edge.
+        var content = Rects(
+            "<table style='width:100%'>" + colgroup
+            + "<tbody><tr><td></td><td class='c'>Total</td></tr></tbody></table>",
+            "1 0 0", ".c{background:#f00}");
+        Assert.Single(content);
+        Assert.True(content[0].W < 40, $"content cell {content[0].W:0.##}pt should be max-content (~26).");
+        Assert.True(content[0].X > 500 && System.Math.Abs(content[0].X + content[0].W - 595.28) < 1.0,
+            $"content cell [{content[0].X:0.##}..{content[0].X + content[0].W:0.##}] should hug the right "
+            + "edge — the <col> percent spacer did not absorb the surplus.");
+    }
+
     private sealed class SynthResolver : IFontResolver
     {
         private static readonly byte[] FontBytes = SyntheticFont.Build();

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterProductionTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterProductionTests.cs
@@ -347,7 +347,11 @@ public sealed class TableLayouterProductionTests
             }
         }
         Assert.NotNull(headerFragment);
-        Assert.Equal(600, headerFragment!.Value.InlineSize);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // The colspan=2 cell spans both columns at their max-content ("Header" ≈ 43.2pt
+        // drives the two spanned columns), NOT 2 × 300pt fill. It still starts at inline
+        // offset 0 and spans the full grid width.
+        Assert.Equal(43.2, headerFragment!.Value.InlineSize, precision: 1);
         Assert.Equal(0, headerFragment.Value.InlineOffset);
     }
 
@@ -600,10 +604,11 @@ public sealed class TableLayouterProductionTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Col 0 is floored by <col width="100"> AND gets the
-        // saturated-path extra; col 1 only gets the extra. Both
-        // sum to contentInlineSize=600.
-        Assert.Equal(600, cells[0].InlineSize + cells[1].InlineSize, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box,
+        // so there is no saturated-path extra. Col 0 is floored by <col width="100"> (its
+        // "A" max-content is smaller) → 100; col 1 is its intrinsic "B" (≈ 6). The grid
+        // total is their sum (≈ 106), NOT 600. Col 0 (floored) still wins over col 1.
+        Assert.Equal(106, cells[0].InlineSize + cells[1].InlineSize, precision: 1);
         Assert.True(cells[0].InlineSize > cells[1].InlineSize,
             $"Expected col 0 (floored by <col width=100>) wider than col 1 "
             + $"(intrinsic only); got col0={cells[0].InlineSize}, col1={cells[1].InlineSize}.");
@@ -645,9 +650,10 @@ public sealed class TableLayouterProductionTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Combined widths cover the wrapper's content-inline-size
-        // (600 from the test fixture).
-        Assert.Equal(600, cells[0].InlineSize + cells[1].InlineSize, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // The combined widths are the columns' max-content total ("A" = 6pt +
+        // "BBBBBBBBBB" = 60pt = 66), NOT the 600pt fill.
+        Assert.Equal(66, cells[0].InlineSize + cells[1].InlineSize, precision: 1);
         // Column 0 (shorter content) is narrower than column 1
         // (longer content) — the §3 shrink-to-fit derives widths
         // from intrinsic content extents.
@@ -702,10 +708,12 @@ public sealed class TableLayouterProductionTests
         Assert.True(cells[1].InlineSize > cells[3].InlineSize,
             $"Expected description col (width={cells[1].InlineSize}) "
             + $"to be wider than date col (width={cells[3].InlineSize}).");
-        // The four columns sum to contentInlineSize = 600.
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // The four columns sum to their max-content total (≈ 189.6), NOT the 600pt fill.
+        // The description column is still the widest (ordering asserted above).
         var totalWidth = cells[0].InlineSize + cells[1].InlineSize
             + cells[2].InlineSize + cells[3].InlineSize;
-        Assert.Equal(600, totalWidth, precision: 3);
+        Assert.Equal(189.6, totalWidth, precision: 1);
     }
 
     // ====================================================================
@@ -801,11 +809,11 @@ public sealed class TableLayouterProductionTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Each column carries the 20px padding inline-edges; the
-        // sum still equals contentInlineSize (600) under the
-        // saturated path. The content fragment should be inset
-        // by padding-left within the cell.
-        Assert.Equal(600, cells[0].InlineSize + cells[1].InlineSize, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // Each column still carries its 20px padding inline-edges, so the grid total is
+        // the sum of the padded max-contents ("A"+pad = 26pt, "B"+pad = 26pt = 52), NOT
+        // the 600pt fill. The content fragment is still inset by padding-left in the cell.
+        Assert.Equal(52, cells[0].InlineSize + cells[1].InlineSize, precision: 1);
     }
 
     [Fact]

--- a/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
+++ b/tests/NetPdf.UnitTests/Phase3/TableLayouterTests.cs
@@ -111,15 +111,15 @@ public sealed class TableLayouterTests
         Assert.Equal(2, rowFragments.Count);
         Assert.Equal(4, cellFragments.Count);
 
-        // Equal column split — content inline size is 600 (no padding /
-        // border on the wrapper in this test); column width = 300.
-        Assert.Equal(300, cellFragments[0].InlineSize);
-        Assert.Equal(300, cellFragments[1].InlineSize);
+        // F3 used-table-width — a `width: auto` table SHRINKS-TO-FIT: each column is its
+        // max-content ("X" = 7.2pt in the synthetic font), NOT an equal split of the 600pt fill.
+        Assert.Equal(7.2, cellFragments[0].InlineSize, 1);
+        Assert.Equal(7.2, cellFragments[1].InlineSize, 1);
         Assert.Equal(0, cellFragments[0].InlineOffset);
-        Assert.Equal(300, cellFragments[1].InlineOffset);
+        Assert.Equal(7.2, cellFragments[1].InlineOffset, 1);
 
-        // Row 0 spans full width.
-        Assert.Equal(600, rowFragments[0].InlineSize);
+        // Row 0 spans the shrunk grid width (2 × 7.2 = 14.4pt), not the 600pt fill.
+        Assert.Equal(14.4, rowFragments[0].InlineSize, 1);
         Assert.Equal(0, rowFragments[0].InlineOffset);
     }
 
@@ -5310,11 +5310,12 @@ public sealed class TableLayouterTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Per Finding 2 — col 0 is floored by <col width="100"> +
-        // gets +250 from the saturated-path extra distribution =
-        // 350; col 1 gets only the +250 from the extra = 250.
-        Assert.Equal(350, cells[0].InlineSize);
-        Assert.Equal(250, cells[1].InlineSize);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box,
+        // so there is no saturated-path extra to distribute. Col 0 is floored to its
+        // <col width="100"> max-content (its cell is empty, so the floor wins) = 100;
+        // col 1 is empty with no floor → 0. The <col> floor is still demonstrated (100 > 0).
+        Assert.Equal(100, cells[0].InlineSize, 1);
+        Assert.Equal(0, cells[1].InlineSize, 1);
     }
 
     [Fact]
@@ -5366,10 +5367,13 @@ public sealed class TableLayouterTests
         }
         Assert.Equal(2, cells.Count);
         // Col 0's max-content exceeds 50 → col 0 gets max-content
-        // (not clamped). The cells sum to contentInlineSize=600.
+        // (not clamped). The floor-doesn't-clamp intent is preserved.
         Assert.True(cells[0].InlineSize > 50,
             $"Expected col 0 width > 50 (intrinsic max-content), got {cells[0].InlineSize}");
-        Assert.Equal(600, cells[0].InlineSize + cells[1].InlineSize, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // The grid total is the sum of column max-contents ("AAAAAAAAAAAA" = 72pt +
+        // empty col 1 = 0), NOT the 600pt fill.
+        Assert.Equal(72, cells[0].InlineSize + cells[1].InlineSize, precision: 1);
     }
 
     // ====================================================================
@@ -5428,8 +5432,10 @@ public sealed class TableLayouterTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Both columns sum to contentInlineSize = 600.
-        Assert.Equal(600, cells[0].InlineSize + cells[1].InlineSize, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // The columns sum to their max-content total ("A" = 6pt + "BBBBB" = 30pt = 36),
+        // NOT the 600pt fill.
+        Assert.Equal(36, cells[0].InlineSize + cells[1].InlineSize, precision: 1);
         // Cell A (shorter text) gets a NARROWER column than cell B
         // (longer text). Pre-sub-cycle-5 the equal-split made
         // cells[0].InlineSize == cells[1].InlineSize; sub-cycle 5
@@ -5505,12 +5511,19 @@ public sealed class TableLayouterTests
         // content "AB" — sumMin = sumMax = 2 * glyphWidth ≈ 12px (well
         // below 600). Saturated path: each column reaches its max +
         // an equal share of the (large) excess → both columns are
-        // equal and sum to contentInlineSize.
+        // equal and sum to the table width.
+        //
+        // F3 shrink-to-fit: an AUTO (`width: auto`) table has NO extra above max-content
+        // to distribute — its used width == sum of max-content. To keep THIS test's intent
+        // (the saturated path distributing extra equally), give the table an EXPLICIT width
+        // (600) wider than its content (sumMax ≈ 24) so there genuinely IS extra to spread.
         var sink = new RecordingFragmentSink();
         using var shaper = new SyntheticShaperResolver();
 
         var root = Box.CreateRoot(MakeStyle());
-        var table = Box.ForElement(BoxKind.Table, MakeStyle(), MakeElement());
+        var tableStyle = MakeStyle();
+        SetLengthPx(tableStyle, PropertyId.Width, 600);
+        var table = Box.ForElement(BoxKind.Table, tableStyle, MakeElement());
         var grid = Box.Anonymous(BoxKind.TableGrid, MakeStyle());
 
         var row = Box.ForElement(BoxKind.TableRow, MakeStyle(), MakeElement());
@@ -5538,8 +5551,8 @@ public sealed class TableLayouterTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Symmetric content + saturated path → both cells = 300 (sum
-        // = contentInlineSize = 600).
+        // Symmetric content + saturated path → both cells = 300 (sum = the explicit
+        // table width 600). The 600 - 24 = 576 extra above max-content is split equally.
         Assert.Equal(300, cells[0].InlineSize, precision: 3);
         Assert.Equal(300, cells[1].InlineSize, precision: 3);
     }
@@ -5677,14 +5690,17 @@ public sealed class TableLayouterTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(3, cells.Count);
-        // Symmetric content + saturated path → cols 0 + 1 each = 300;
-        // colspan cell = 600 (sum); row 1 cells = 300 each.
-        Assert.Equal(600, cells[0].InlineSize, precision: 3);
-        Assert.Equal(0, cells[0].InlineOffset, precision: 3);
-        Assert.Equal(300, cells[1].InlineSize, precision: 3);
-        Assert.Equal(0, cells[1].InlineOffset, precision: 3);
-        Assert.Equal(300, cells[2].InlineSize, precision: 3);
-        Assert.Equal(300, cells[2].InlineOffset, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box.
+        // Columns are their max-content ("AB" = 12pt each), NOT an equal split of 600.
+        // The colspan=2 cell still spans BOTH columns (width = col0 + col1 = 24, offset 0);
+        // row 1's cells anchor at col 0 / col 1 (12pt each; offsets 0 and 12). The
+        // colspan-distributes-across-columns intent is preserved.
+        Assert.Equal(24, cells[0].InlineSize, precision: 1);
+        Assert.Equal(0, cells[0].InlineOffset, precision: 1);
+        Assert.Equal(12, cells[1].InlineSize, precision: 1);
+        Assert.Equal(0, cells[1].InlineOffset, precision: 1);
+        Assert.Equal(12, cells[2].InlineSize, precision: 1);
+        Assert.Equal(12, cells[2].InlineOffset, precision: 1);
     }
 
     [Fact]
@@ -5883,12 +5899,13 @@ public sealed class TableLayouterTests
             if (f.Box.Kind == BoxKind.TableCell) cells.Add(f);
         }
         Assert.Equal(2, cells.Count);
-        // Col 0 floored by first-row cell width=200 → col 0 gets at
-        // least 200; saturated-path extra distributed across the
-        // remaining 400 → +200 each → col 0 = 400, col 1 = 200.
+        // Col 0 floored by first-row cell width=200 → col 0 gets at least 200.
         Assert.True(cells[0].InlineSize >= 200,
             $"Expected col 0 >= 200 (floored), got {cells[0].InlineSize}");
-        Assert.Equal(600, cells[0].InlineSize + cells[1].InlineSize, precision: 3);
+        // F3 shrink-to-fit: a `width: auto` table no longer fills the 600pt content box,
+        // so there is no extra to distribute. The grid total is the sum of column
+        // max-contents (col 0 floored to 200 + empty col 1 = 0), NOT the 600pt fill.
+        Assert.Equal(200, cells[0].InlineSize + cells[1].InlineSize, precision: 1);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Completes F3 (used-table-width) from the 2026-07-08 corpus QA plan — the auto-table **shrink-to-fit** that was deferred from #301. This is the "LARGEST engine change" of the round; it lands the full CSS 2.2 §17.5.2 / CSS Tables L3 §3 used-width model (Steps A–E) with the caption-collapse blocker solved.

## What lands (Steps A–E)

- **A + C — auto shrink-to-fit.** `ComputeColumnWidthsAuto` spends the *used* table width (a shrink-to-fit clamp for auto; the declared width for explicit) so auto columns land at max-content, and the measured grid **narrows** the wrapper (both BlockLayouter dispatch paths), instead of always filling.
- **Caption / degenerate guard.** A table with **no** max-content (all-empty cells, `sumMax == 0`) keeps the fill width — a 0-width wrapper is degenerate and its emit (and any caption) gets dropped. This was the blocker that collapsed table captions under shrink-to-fit; real content tables (`sumMax > 0`) shrink normally.
- **`table { margin: 0 auto }` centering** — already shipped in #301, now exercised by shrunk tables.
- **D — percent-as-auto under the intrinsic probe.** A `width: N%` **nested** table behaves as auto under a max-content probe (css-sizing-3 §5.2.4), so it shrinks-to-fit instead of resolving 100% against the ~1e6 probe — killing the nested-table max-content poison.
- **E — percentage-column distribution.** The saturated path routes its surplus to percentage columns before the equal split (§3.5.3), so a `<td style="width:100%">` spacer absorbs the leftover and a following content cell stays at max-content and **hugs the right edge**.

## Verification

| Case | Result |
|---|---|
| single-cell auto table | shrinks to max-content (was full-width) |
| `table{width:150px}` | 112.5pt (Step B, #301) |
| 2-cell `w-full` spacer | spacer 569pt, content cell 26pt at the right edge ✓ |
| nested `width:100%` table | no longer poisons the outer cell max-content ✓ |
| table captions | emit correctly (empty tables keep fill) ✓ |

Re-pinned **12** table-contract unit tests fill→max-content (verified deterministic max-content values; one converted to explicit-width to preserve its "extra-distribution" intent). New `TableShrinkToFitTests` + updated `TableExplicitWidthTests`. **Full solution green: 8592 unit / 3 skip · 30 snapshot · 36 corpus · 105 real-doc · 6 W3C** — no golden re-pins outside the intended table-contract ones.

## Residual (documented)

The **deep 3-level** index.html totals card (items table → colspan cell → `w-full` wrapper → auto cell → totals table) still splits its label/value to opposite edges — the percentage does not propagate through that many nested intrinsic measures. The **direct 2-cell spacer works** (test above); this is a nested-measurement propagation issue, documented in `docs/deferrals.md#table-auto-fixed-spans-borders` with the pickup path. Every other F3 case (auto shrink-to-fit, explicit width, centering, nested percent-as-auto, direct spacer) is fixed.

## Gate

Build 0-warn · full solution green locally. Determinism unaffected. (CI is red on the repo-wide GitHub Actions billing block — verified locally per the established workflow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)