### PR TITLE
fix(layout): flex-wrap multi-line auto-height overlap + post-fragment…

### DIFF
--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1439,15 +1439,30 @@ grepping the ID).
       **atomic** granularity (the "mid-split" limitation — a subtree
       commits on one page or breaks between children, without filling the trailing
       page). Closing that is the deferred mid-split engine work, tracked here. The
-      overlap (the visible defect) is resolved. **SCOPE:** the fix is
+      overlap (the visible defect) is resolved. **SCOPE:** the original fix was
       NOWRAP single-line row flex — `autoRowContentCross` is `max(item cross)`
-      (the single line's cross), and both dispatch resize consumers gate on
-      `!IsFlexWrapping`. A `flex-wrap: wrap` auto-height row flex still
-      under-reports its cross (the wrap pre-measure `FlexLinePacker.SumCrossExtent`
-      reads DECLARED cross sizes, 0 for content-determined items; the correct value
-      is Σ per-line max content cross + row gaps) — a following sibling can still
-      overlap. Separate open case. Row-WRAP line-split resume (no dual-input resize
-      consumer) is a separate residual, also unfixed on a fresh resume page.
+      (the single line's cross), and both dispatch resize consumers gated on
+      `!IsFlexWrapping`. **✅ WRAP auto-height row now shipped (06 travel-voucher
+      "What's Included" overlap):** `FlexLayouter.AttemptLayout` folds the
+      content-measured cross into EACH packed line (`lines[i].LineCrossSize =
+      max(declared, Σ-per-item-max content cross via `itemBaselineCrossSizes`)`) and
+      re-derives the auto container cross = Σ per-line cross + row gaps (CSS Flexbox
+      §9.4 steps 8+15), so the emission cursor stacks the lines instead of collapsing
+      them to a shared offset and `maxEmittedCrossBottom` → `LastEmittedBlockExtent`
+      reports the true stacked extent. Both `DispatchFlexInner` resize consumers
+      (outer + recursive) now gate on `!= WrapReverse` (was `!IsFlexWrapping`), so the
+      wrapper resizes + the sibling cursor advances for a wrapping auto-height row too
+      — a trailing sibling (`.terms` after a wrapped `.included` list) no longer
+      overlaps. Gated to auto-height, non-wrap-reverse rows; an explicit container
+      height feeds align-content distribution (separate path), wrap-reverse derives its
+      cross origin from the unfragmented extent (deferred). **STILL OPEN — the
+      PRE-measure `FlexLinePacker.SumCrossExtent` / `PreMeasureFlexMultiLineCrossExtent`
+      still reads DECLARED cross sizes** (0 for content-determined items): the
+      post-layout `LastEmittedBlockExtent` correction fixes the single-page overlap,
+      but a wrapping auto-height flex TALL ENOUGH to paginate could still under-report
+      to the paginatable-flex clamp during pre-measure (a multi-page wrapping
+      auto-height flex — no corpus case yet). Row-WRAP line-split resume (no dual-input
+      resize consumer) is a separate residual, also unfixed on a fresh resume page.
     - ✅**shipped:**
       `DispatchFlexInner` helper now used by BOTH direct
       recursive paths to eliminate drift between them. 135 + 107

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -1445,8 +1445,8 @@ grepping the ID).
       `!IsFlexWrapping`. **✅ WRAP auto-height row now shipped (06 travel-voucher
       "What's Included" overlap):** `FlexLayouter.AttemptLayout` folds the
       content-measured cross into EACH packed line (`lines[i].LineCrossSize =
-      max(declared, Σ-per-item-max content cross via `itemBaselineCrossSizes`)`) and
-      re-derives the auto container cross = Σ per-line cross + row gaps (CSS Flexbox
+      max(declared, per-line MAX of the items' content cross via `itemBaselineCrossSizes`)`)
+      and re-derives the auto container cross = Σ per-line cross + row gaps (CSS Flexbox
       §9.4 steps 8+15), so the emission cursor stacks the lines instead of collapsing
       them to a shared offset and `maxEmittedCrossBottom` → `LastEmittedBlockExtent`
       reports the true stacked extent. Both `DispatchFlexInner` resize consumers

--- a/src/NetPdf.Layout/Layouters/BlockLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/BlockLayouter.cs
@@ -3616,13 +3616,18 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 }
                 else if (IsFlexContainer(child) && IsHeightAuto(child)
                     && !child.Style.ReadFlexDirection().IsFlexColumnDirection()
-                    && !child.Style.ReadFlexWrap().IsFlexWrapping())
+                    && child.Style.ReadFlexWrap() != FlexWrapValue.WrapReverse)
                 {
-                    // Corpus-fidelity (03 itinerary footer overlap), mirror of the recursive site — an
-                    // AUTO-height ROW flex's used cross size is its content cross extent (FlexLinePacker
-                    // sizes lines from the items' DECLARED cross only, 0 for auto). `outerFlexLastEmittedExtent`
-                    // carries the real content cross; resize the wrapper + advance the cursor by it so a
-                    // trailing sibling doesn't overlap the flex content. Byte-identical when content fits.
+                    // Corpus-fidelity (03 itinerary footer overlap + 06 travel-voucher "What's Included"
+                    // overlap), mirror of the recursive site — an AUTO-height ROW flex's used cross size is
+                    // its content cross extent (FlexLinePacker sizes lines from the items' DECLARED cross
+                    // only, 0 for auto). `outerFlexLastEmittedExtent` carries the real content cross:
+                    // nowrap → FlexLayouter's `autoRowContentCross`; wrap → the summed per-line content
+                    // cross (the wrap fold now grows each line's cross size so `maxEmittedCrossBottom`
+                    // reports the stacked-line extent). Resize the wrapper + advance the cursor by it so a
+                    // trailing sibling lands below the flex content instead of overlapping it. wrap-reverse
+                    // stays excluded (its cross origin derives from the unfragmented extent — deferred).
+                    // Byte-identical when content fits (the guard keeps the larger value only).
                     var flexChromeBlock = borderStart + paddingStart + paddingEnd + borderEnd;
                     var resizedFlexWrapperBlockSize = flexChromeBlock + outerFlexLastEmittedExtent;
                     if (resizedFlexWrapperBlockSize > marginBoxBlockSizeForCursor - topShift - marginEnd)
@@ -5613,6 +5618,26 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                     {
                         childEffectiveBlockSize = tableDriven;
                     }
+                    // Mirror the OUTER-dispatch table clamp (BlockLayouter.cs:2428-2432) at the
+                    // recursion site. `childSubtreeExtent` was measured by
+                    // MeasureSubtreeVisualBlockExtentRecursive, which walks the table from row 0 at
+                    // page-top (resumeAtRow:0, startOffsetOverride defaulting to 0) — so on the table's
+                    // LAST fragment it over-measures the extent as a fresh full page of rows, and the
+                    // Math.Max above baked that into `childEffectiveBlockSize`. `tableDriven` (from the
+                    // resume-aware DryRun, useDryRunCommittedHeight:true) is the REAL committed extent of
+                    // this fragment and now lives in `childBorderBoxBlockSize` (what the fragment actually
+                    // paints, via ResolveAutoHeightEmittedBlockSize). Clamp the cursor-advance extent back
+                    // down to it so a trailing sibling after a table that finished high on the page flows
+                    // right below it instead of being pushed onto a fresh page over a mostly-empty one
+                    // (invoice-10/11: `.note`/`.stamp` marooned on the next page under ~2/3 blank space).
+                    // Gated inside `nestedPendingTable is not null` so ONLY table wrappers clamp — a flex/
+                    // grid wrapper whose effective extent was legitimately GROWN past its border box
+                    // (e.g. the auto-height wrap fold) is untouched. Byte-identical for a table that fits
+                    // one page (tableDriven == the natural extent, so the clamp is a no-op).
+                    if (childEffectiveBlockSize > childBorderBoxBlockSize)
+                    {
+                        childEffectiveBlockSize = childBorderBoxBlockSize;
+                    }
 
                     // Per Phase 3 Task 12 sub-cycle 5 hardening
                     // Finding 6 — widen the wrapper's INLINE border-
@@ -6468,16 +6493,20 @@ internal sealed class BlockLayouter : ILayouter, IDisposable
                 }
                 else if (IsFlexContainer(child) && IsHeightAuto(child)
                     && !child.Style.ReadFlexDirection().IsFlexColumnDirection()
-                    && !child.Style.ReadFlexWrap().IsFlexWrapping())
+                    && child.Style.ReadFlexWrap() != FlexWrapValue.WrapReverse)
                 {
-                    // Corpus-fidelity (03 itinerary footer overlap) — an AUTO-height ROW flex's used cross
-                    // (block) size is its content cross extent, but FlexLinePacker sizes lines from the
-                    // items' DECLARED cross only (0 for auto-height items), so the wrapper's resolved
-                    // border box is chrome-only. `nestedFlexLastEmittedExtent` now carries the real content
-                    // cross (FlexLayouter's `autoRowContentCross`); resize the wrapper + advance the cursor
-                    // by it so a trailing sibling (`.note` after a `.timeline` of flex `.day` rows) lands
-                    // below the content instead of overlapping it. Byte-identical when content fits the
-                    // resolved box (the guard keeps the larger value only).
+                    // Corpus-fidelity (03 itinerary footer overlap + 06 travel-voucher "What's Included"
+                    // overlap) — an AUTO-height ROW flex's used cross (block) size is its content cross
+                    // extent, but FlexLinePacker sizes lines from the items' DECLARED cross only (0 for
+                    // auto-height items), so the wrapper's resolved border box is chrome-only.
+                    // `nestedFlexLastEmittedExtent` now carries the real content cross — nowrap →
+                    // FlexLayouter's `autoRowContentCross`; wrap → the summed per-line content cross (the
+                    // wrap fold grows each line so `maxEmittedCrossBottom` reports the stacked-line
+                    // extent). Resize the wrapper + advance the cursor by it so a trailing sibling (`.note`
+                    // after a `.timeline` of flex `.day` rows, or `.terms` after a wrapped `.included`
+                    // list) lands below the content instead of overlapping it. wrap-reverse stays excluded
+                    // (cross origin derives from the unfragmented extent — deferred). Byte-identical when
+                    // content fits the resolved box (the guard keeps the larger value only).
                     var flexChromeBlock = borderStart + paddingStart + paddingEnd + borderEnd;
                     var resizedFlexWrapperBlockSize = flexChromeBlock + nestedFlexLastEmittedExtent;
                     if (resizedFlexWrapperBlockSize > childEffectiveBlockSize)

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -1172,11 +1172,13 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
         // the sibling cursor past the real content — otherwise a trailing sibling overlaps the flex content
         // (03 `.note` over the `.timeline`). Byte-identical when the content is no taller than the resolved
         // cross (max ≤ existing).
-        // SCOPE (review) — NOWRAP single-line only: `max(item cross)` is the line's cross size for one
-        // line. For `flex-wrap: wrap` the auto cross is the SUM of each packed line's max content cross +
-        // row gaps, and the wrap cross pre-measure (FlexLinePacker.SumCrossExtent) still reads DECLARED
-        // cross sizes — so a content-sized wrapped flex is a separate (still-open) case; not folded here to
-        // avoid under/over-counting. An explicit height is the used block size, so gate that out too.
+        // SCOPE — this NOWRAP branch handles the single line (`max(item cross)` IS the line's cross size).
+        // The `flex-wrap: wrap` companion — where the auto container cross is the SUM of each packed line's
+        // max content cross + row gaps — is folded IMMEDIATELY BELOW (the `isWrapAutoHeightRow` block). The
+        // residual that REMAINS open is the wrap PRE-measure (`FlexLinePacker.SumCrossExtent`, via
+        // `BlockLayouter.PreMeasureFlexMultiLineCrossExtent`), which still reads DECLARED cross sizes — so a
+        // wrapping auto-height flex tall enough to PAGINATE is not yet content-sized before dispatch
+        // (docs/deferrals.md). An explicit height is the used block size, so gate that out too.
         var autoRowContentCross = 0.0;
         var isAutoHeightRow = !isColumn && !isWrapping
             && _rootBox.Style.Get(PropertyId.Height).Tag is ComputedSlotTag.Unset or ComputedSlotTag.Keyword;

--- a/src/NetPdf.Layout/Layouters/FlexLayouter.cs
+++ b/src/NetPdf.Layout/Layouters/FlexLayouter.cs
@@ -1200,6 +1200,52 @@ internal sealed class FlexLayouter : ILayouter, IDisposable
             containerCrossSize = autoRowContentCross;
         }
 
+        // Corpus-fidelity (06 travel-voucher "What's Included" overlap) — the WRAP companion to
+        // the nowrap auto-height fold above, closing the "still-open case" flagged in the SCOPE note.
+        // For a MULTI-LINE (`flex-wrap: wrap`) AUTO-height ROW container CSS Flexbox L1 §9.4 sizes
+        // each flex line to the MAX used cross size of the items ON THAT LINE (step 8) and the
+        // container's auto cross size to the SUM of the lines' cross sizes + row gaps (step 15).
+        // FlexLinePacker sized every line from the items' DECLARED cross only (0 for an auto-height
+        // item — it doesn't content-measure), so absent this fold EVERY line's `LineCrossSize` is 0:
+        // the emission cursor never advances, so all lines stack at the same cross offset (items
+        // overlap), and `maxEmittedCrossBottom` → `LastEmittedBlockExtent` come out 0 so the wrapper
+        // reports a chrome-only box + the trailing sibling overlaps it. `itemBaselineCrossSizes`
+        // (computed for every ROW flex above) holds each item's content-measured cross border box;
+        // take the per-line max, grow each line, and re-derive the auto container cross from the line
+        // sum + `crossGapTotal` (§9.4 step 15). Gated to auto-height, non-wrap-reverse rows: an
+        // explicit container cross is the used size and feeds align-content distribution (a separate,
+        // still-open path); wrap-reverse derives its cross-axis SWAP origin from the UNFRAGMENTED
+        // extent (deferred, mirroring the emission-loop swap). Byte-identical when every line's
+        // content is no taller than its declared cross (the per-line grow + the container fold are
+        // both `max`), and the auto container's freeCrossSpace was 0 so align-content contributed no
+        // offset/stretch to disturb.
+        var isWrapAutoHeightRow = !isColumn && isWrapping && !isWrapReverse
+            && _rootBox.Style.Get(PropertyId.Height).Tag is ComputedSlotTag.Unset or ComputedSlotTag.Keyword;
+        if (isWrapAutoHeightRow && itemBaselineCrossSizes is not null)
+        {
+            var sumLineCrossFromContent = 0.0;
+            for (var li = 0; li < lines.Count; li++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var line = lines[li];
+                var contentLineCross = 0.0;
+                var endPos = line.FirstItemIndex + line.ItemCount;
+                for (var sp = line.FirstItemIndex; sp < endPos; sp++)
+                {
+                    var idx = _sortedFlexChildIndices[sp];
+                    var cs = itemBaselineCrossSizes[idx];
+                    if (!double.IsNaN(cs) && cs > contentLineCross) contentLineCross = cs;
+                }
+                if (contentLineCross > line.LineCrossSize)
+                {
+                    lines[li] = line with { LineCrossSize = contentLineCross };
+                }
+                sumLineCrossFromContent += lines[li].LineCrossSize;
+            }
+            var autoWrapCross = sumLineCrossFromContent + crossGapTotal;
+            if (autoWrapCross > containerCrossSize) containerCrossSize = autoWrapCross;
+        }
+
         // PR #189 review P2 — the row-nowrap content-measure budget is a PRACTICAL cap
         // (NestedContentMeasurer.EffectivelyUnboundedBlockBudgetPx), not truly unbounded:
         // an item whose measured content REACHES it was clipped by the single atomic pass.

--- a/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
+++ b/tests/NetPdf.UnitTests/Performance/PerformanceGateTests.cs
@@ -51,8 +51,13 @@ public sealed class PerformanceGateTests
     {
         // lineItems recalibrated 80 → 68 after RC-UA (WP-2): the UA stylesheet adds the h1 and <p>
         // default margins the fixture didn't previously carry, so 80 rows now spill to 4 pages. 68
-        // rows restores the intended clean 3-page (exit-criterion-7) workload.
-        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Invoice(lineItems: 68), warmup: 5, iters: 15);
+        // rows restored the intended clean 3-page (exit-criterion-7) workload.
+        // Recalibrated 68 → 88 after the recursive nested-table cursor over-advance fix
+        // (BlockLayouter.cs:5621) — a `<table>` followed by a trailing `<p>` no longer over-advances the
+        // flow cursor by the table's row-0 natural full-page extent, so the trailing paragraph + last rows
+        // pack onto the previous page instead of spilling to an extra one. 68 rows now lay out in 2 pages;
+        // 88 (mid the 74–104 three-page band under the synthetic font) restores the clean 3-page workload.
+        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Invoice(lineItems: 88), warmup: 5, iters: 15);
         Assert.Equal(3, pages);   // the fixture must actually paginate to 3 pages for the gate to be meaningful
         Assert.True(p50 <= 200.0,
             $"Exit criterion 7: the 3-page invoice p50 {p50:F1} ms exceeds the 200 ms gate.");
@@ -63,9 +68,13 @@ public sealed class PerformanceGateTests
     public void Report_20_page_renders_within_1500ms_p50()
     {
         // rowsPerSection recalibrated 18 → 34 after RC-9 (WP-1): the cell double-padding fix removed the
-        // ~1.5–2× row-height inflation, so the old 22×18 fixture now lays out in ~11 pages. 22×34 restores
+        // ~1.5–2× row-height inflation, so the old 22×18 fixture now lays out in ~11 pages. 22×34 restored
         // the intended ~22-page (exit-criterion-7) workload against the corrected, un-inflated row height.
-        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Report(sections: 22, rowsPerSection: 34),
+        // Recalibrated 34 → 40 after the recursive nested-table cursor over-advance fix
+        // (BlockLayouter.cs:5621) — back-to-back `<h2>`+`<table>` sections no longer over-advance past each
+        // fragmented table's last fragment, so following sections pack tighter (22×34 now lays out in
+        // 19 pages). 22×40 = 22 pages under the synthetic font, restoring the intended ~22-page workload.
+        var (pages, p50) = PerfFixtures.Median(PerfFixtures.Report(sections: 22, rowsPerSection: 40),
             warmup: 2, iters: 7);
         // Bound BOTH sides: the deterministic synthetic fixture lands at a fixed page count, so a regression
         // that duplicates pages or over-fragments (→ 30-40 pages) must fail even if it stays under 1.5 s —

--- a/tests/NetPdf.UnitTests/Rendering/FlexWrapAndNestedTablePaginationTests.cs
+++ b/tests/NetPdf.UnitTests/Rendering/FlexWrapAndNestedTablePaginationTests.cs
@@ -1,0 +1,186 @@
+// Copyright 2026 Roland Aroche and NetPdf contributors.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the repository root.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NetPdf;
+using Xunit;
+
+namespace NetPdf.UnitTests.Rendering;
+
+/// <summary>
+/// Regression tests for the two round-3 corpus fixes:
+/// <list type="number">
+///   <item><b>flex-wrap multi-line auto-height overlap</b> (06-travel-voucher "What's Included") — a
+///   wrapping <c>display:flex</c> row of auto-height items packed every line at cross-size 0
+///   (<c>FlexLinePacker</c> reads DECLARED cross only), so all wrapped lines painted at the same cross
+///   offset (items overlapping) and the container collapsed to one line so the trailing sibling overlapped
+///   too. FlexLayouter now folds each item's content-measured cross into its line.</item>
+///   <item><b>post-fragmented nested-table trailing sibling</b> (invoice-10/11 <c>.note</c>/<c>.stamp</c>)
+///   — a <c>body &gt; div &gt; table</c> laid out by the RECURSIVE dispatch advanced the flow cursor by the
+///   table's row-0 full-page over-measure instead of its last-fragment committed height, marooning the
+///   trailing sibling on a mostly-empty next page. The recursive path now clamps the cursor-advance extent
+///   to the committed height.</item>
+/// </list>
+/// Assertions are RELATIVE (marker below content / rows above marker / distinct cross bands / page count),
+/// so they hold under platform-dependent real-font metrics — mirroring
+/// <see cref="AutoHeightFlexTimelineFooterTests"/>. Marker strings are single unbreakable tokens (no spaces
+/// or hyphens) so they never wrap into more than one glyph run regardless of font.
+/// </summary>
+public sealed class FlexWrapAndNestedTablePaginationTests
+{
+    /// <summary>Parse the PDF content streams into per-page lists of (baseline-y, glyph-count) text runs.
+    /// A run's glyph count is a stable per-element fingerprint (used to locate a uniquely long marker),
+    /// and its y is the emission baseline (higher y = higher on the page). Pages are returned in file /
+    /// document order. Copied from <see cref="AutoHeightFlexTimelineFooterTests"/> (a future cleanup can
+    /// share it).</summary>
+    private static List<List<(double Y, int G)>> Pages(string html)
+    {
+        var pdf = Encoding.Latin1.GetString(
+            HtmlPdf.ConvertDetailed(html, new HtmlPdfOptions { PrintBackgrounds = true }).Pdf);
+        var pages = new List<List<(double, int)>>();
+        foreach (Match sm in Regex.Matches(pdf, @"stream\r?\n(.*?)\r?\nendstream", RegexOptions.Singleline))
+        {
+            var s = sm.Groups[1].Value;
+            if (!s.Contains(" Tf")) continue;
+            var runs = new List<(double, int)>();
+            foreach (Match m in Regex.Matches(s, @"BT(.*?)ET", RegexOptions.Singleline))
+            {
+                var b = m.Groups[1].Value;
+                var h = Regex.Match(b, @"<([0-9A-Fa-f]+)> *T[jJ]");
+                if (!h.Success) continue;
+                double y = double.NaN;
+                var tm = Regex.Match(b, @"(-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) (-?[\d.]+) Tm");
+                if (tm.Success) y = double.Parse(tm.Groups[6].Value, CultureInfo.InvariantCulture);
+                else { var td = Regex.Match(b, @"(-?[\d.]+) (-?[\d.]+) (?:Td|TD)"); if (td.Success) y = double.Parse(td.Groups[2].Value, CultureInfo.InvariantCulture); }
+                if (!double.IsNaN(y)) runs.Add((y, h.Groups[1].Value.Length / 4));
+            }
+            if (runs.Count > 0) pages.Add(runs);
+        }
+        return pages;
+    }
+
+    // A wrapping auto-height ROW flex (li width:50% → 2 per line, 3 lines) with row-gap, followed by a
+    // sibling carrying a uniquely long marker token. Pre-fix: the 3 lines collapsed to one cross offset
+    // (items overlap) and .after overlapped the list.
+    private const string FlexWrapDoc =
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>"
+        + "@page{size:A4;margin:16mm}body{font-family:Arial;font-size:12px;margin:0}"
+        + "ul{list-style:none;padding:0;margin:0;display:flex;flex-wrap:wrap;row-gap:10px}"
+        + "li{width:50%;padding:5px 0;font-size:12px}.after{border:1px solid #000;padding:8px}"
+        + "</style></head><body><ul>"
+        + "<li>AlphaLeftOne</li><li>BravoRightTwo</li>"
+        + "<li>CharlieLeftThree</li><li>DeltaRightFour</li>"
+        + "<li>EchoLeftFive</li><li>FoxtrotRightSix</li>"
+        + "</ul><div class=\"after\">TRAILINGSIBLINGMARKERZZZZZZZZZZZZZZZZZZ</div></body></html>";
+
+    // A NESTED (body>div>table) table long enough to fragment across two A4 pages, whose last fragment ends
+    // high on the final page, followed by a sibling stamp carrying a uniquely long marker token. Pre-fix:
+    // the recursive dispatch over-advanced the cursor and marooned the stamp on a mostly-empty extra page.
+    private static string NestedTableDoc()
+    {
+        var sb = new StringBuilder(
+            "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>"
+            + "@page{size:A4;margin:16mm}body{font-family:Arial;font-size:12px;margin:0}"
+            + "table{width:100%;border-collapse:collapse}td{padding:6px;border-bottom:1px solid #ccc}"
+            + ".stamp{margin-top:16px;border:2px solid #000;padding:8px;display:inline-block}"
+            + "</style></head><body><div class=\"wrap\"><table><tbody>");
+        for (var i = 1; i <= 45; i++)
+            sb.Append("<tr><td>LineNum").Append(i).Append("</td><td>DescRowValue").Append(i).Append("</td></tr>");
+        sb.Append("</tbody></table><div class=\"stamp\">STAMPMARKERBALANCEDUEQQQQQQQQQQQQ</div></div></body></html>");
+        return sb.ToString();
+    }
+
+    // A WRAPPING auto-height row flex far taller than one page (60 lines) — a correct multi-page
+    // implementation would paginate it; the current single-page fold does not (see the deferred test below).
+    private static string TallWrapDoc()
+    {
+        var sb = new StringBuilder(
+            "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>"
+            + "@page{size:A4;margin:16mm}body{font-family:Arial;font-size:12px;margin:0}"
+            + "ul{list-style:none;padding:0;margin:0;display:flex;flex-wrap:wrap}"
+            + "li{width:50%;padding:6px 0;font-size:12px}"
+            + "</style></head><body><ul>");
+        for (var i = 1; i <= 120; i++)
+            sb.Append("<li>RowItemNumber").Append(i).Append("WithDescriptiveText</li>");
+        sb.Append("</ul></body></html>");
+        return sb.ToString();
+    }
+
+    [Fact]
+    public void FlexWrap_auto_height_lines_stack_and_trailing_sibling_sits_below()
+    {
+        var pages = Pages(FlexWrapDoc);
+        Assert.Single(pages);   // the single-page 06-travel-voucher shape
+        var runs = pages[0];
+
+        // The trailing sibling is the single longest run (a unique marker token).
+        var markerG = runs.Max(r => r.G);
+        var markerY = runs.First(r => r.G == markerG).Y;
+
+        // (a) NOTHING sits below the trailing sibling → it is not overlapped by (does not overlap) the list.
+        foreach (var (y, g) in runs)
+            Assert.False(g != markerG && y < markerY - 0.5,
+                $"a flex item (glyphs={g}) at y={y:0.#} sits below the trailing sibling (y={markerY:0.#}) — "
+                + "the sibling overlaps the wrapped list.");
+
+        // (b) The wrapped auto-height items STACK into >= 3 distinct cross bands (the 3 lines did not
+        // collapse to a shared cross offset — the pre-fix bug painted all 3 lines at the same y).
+        var bands = runs.Where(r => r.G != markerG)
+            .Select(r => Math.Round(r.Y)).Distinct().Count();
+        Assert.True(bands >= 3,
+            $"expected the 3 wrapped auto-height lines to stack at distinct cross offsets; got {bands} "
+            + "band(s) — the lines collapsed onto a single offset (items overlap).");
+    }
+
+    [Fact]
+    public void Nested_table_trailing_sibling_stays_on_the_final_fragment_page()
+    {
+        var pages = Pages(NestedTableDoc());
+        Assert.True(pages.Count >= 2,
+            $"the nested table must fragment across pages for this regression to bite; got {pages.Count} page(s).");
+
+        // The stamp is the single longest run across the document; it must appear exactly once.
+        var markerG = pages.SelectMany(p => p).Max(r => r.G);
+        var hits = 0; var stampPage = -1; var stampY = double.NaN;
+        for (var pi = 0; pi < pages.Count; pi++)
+            foreach (var (y, g) in pages[pi]) if (g == markerG) { hits++; stampPage = pi; stampY = y; }
+        Assert.Equal(1, hits);
+
+        // The stamp is NOT marooned on a fresh page: its page also carries the table's final fragment
+        // (multiple table-row runs ABOVE it). Pre-fix the cursor over-advanced and the stamp landed alone
+        // on the next page (rowsAbove == 0).
+        var rowsAbove = pages[stampPage].Count(r => r.G != markerG && r.Y > stampY + 20);
+        Assert.True(rowsAbove >= 3,
+            $"the trailing sibling landed on a page with {rowsAbove} table-row run(s) above it — it should "
+            + "flow directly below the table's last fragment on the same page, not on a mostly-empty next page.");
+
+        // The stamp is the last content on its page (nothing below it; these docs have no page footer).
+        foreach (var (y, g) in pages[stampPage])
+            Assert.False(g != markerG && y < stampY - 0.5,
+                $"content (glyphs={g}) at y={y:0.#} sits below the trailing stamp (y={stampY:0.#}).");
+    }
+
+    [Fact]
+    public void Tall_wrapped_auto_height_flex_pagination_remains_a_known_deferral()
+    {
+        // KNOWN DEFERRAL — see docs/deferrals.md (the wrap fold's "STILL OPEN — the PRE-measure ...
+        // still reads DECLARED cross sizes" note). The single-page overlap fix folds the content-measured
+        // per-line cross AFTER FlexLayouter's fragment-range decision (which reads the packer's declared
+        // 0 cross) and AFTER BlockLayouter's pre-measure (FlexLinePacker.SumCrossExtent, also declared
+        // cross). So a WRAPPING auto-height row flex tall enough to need pagination does NOT yet paginate:
+        // the pre-measure sees a ~0-height wrapper so the paginatable-flex clamp never fires, and every
+        // line stacks onto ONE page (content past the page bottom is emitted off-page). A correct
+        // multi-page implementation would produce >= 2 pages.
+        //
+        // This test PINS the residual so it is KNOWN, not accidentally "fixed". When the content-aware
+        // pre-measure / fragment-range lands, PageCount becomes >= 2 and this assertion fails — that
+        // failure is the reminder to flip this to the positive (>= 2) check.
+        var pageCount = HtmlPdf.ConvertDetailed(TallWrapDoc(), new HtmlPdfOptions()).PageCount;
+        Assert.Equal(1, pageCount);   // DEFERRED: should be >= 2 once multi-page wrapped auto-height lands
+    }
+}


### PR DESCRIPTION
…ed-table trailing-sibling pagination

Two release-QA defects on the NetPdf-tester invoice corpus:

1. flex-wrap multi-line auto-height row overlap (06-travel-voucher "What's Included"): a wrapping flex container with auto-height items packed every line at cross-size 0 (FlexLinePacker reads DECLARED cross only), so all wrapped lines painted at the same cross offset (items overlap) and the container collapsed to one line so the trailing sibling overlapped too. FlexLayouter now folds each item's content-measured cross into its line and re-derives the auto container cross = sum of line cross + row gaps (CSS Flexbox L1 §9.4 steps 8+15); both DispatchFlexInner sibling-resize gates relax !IsFlexWrapping -> != WrapReverse so the wrapper resizes + the sibling cursor advances. No-op for definite-cross items (whole suite byte-identical).

2. post-fragmented-table trailing sibling pushed to a mostly-empty next page (invoice-10/11 .note/.stamp; also 04/05/07/08/12): a body>table is laid out by the recursive dispatch, which lacked the outer path's downward clamp (BlockLayouter.cs:2428), so it advanced the flow cursor by the table's row-0 full-page over-measure instead of the last fragment's committed height. Add the mirror clamp, gated to table wrappers so it can't touch the flex fold above. invoice-10 4->3 pages.

Whole test suite byte-identical except two PerformanceGateTests page-count sanity asserts (the tighter, correct pagination): recalibrate Invoice 68->88 rows and Report 34->40 rows/section to keep the intended ~3-page / ~22-page throughput workloads. docs/deferrals.md updated (wrap auto-height case closed; pre-measure-still-reads-declared residual noted).
---

### Scope (narrowed per review)

This PR fixes the two reported **single-page** rendering defects and their layout mechanisms. It does **not** implement multi-page pagination of a wrapping auto-height flex — that is a documented, test-pinned deferral:

- **In scope / fixed:** flex-wrap multi-line auto-height *overlap* on a single page (06-travel-voucher), and the post-fragmented nested-table *trailing-sibling* placement (invoice-10/11/…).
- **Explicit deferral:** a `flex-wrap: wrap` auto-height row flex *tall enough to paginate* is not yet content-sized before dispatch — `FlexLinePacker.SumCrossExtent` / `BlockLayouter.PreMeasureFlexMultiLineCrossExtent` still read declared cross, and `FlexLayouter`'s fragment-range is decided before the content fold. Documented in `docs/deferrals.md` and **pinned** by `Tall_wrapped_auto_height_flex_pagination_remains_a_known_deferral` (asserts `PageCount == 1` today; flips to `>= 2` when the content-aware pre-measure lands, so it can't be silently "fixed").