### PR TITLE
chore(ci): Pages deploy + benchmark-baseline capture workflow

### DIFF
--- a/.github/workflows/capture-benchmark-baseline.yml
+++ b/.github/workflows/capture-benchmark-baseline.yml
@@ -1,0 +1,46 @@
+# Maintainer tool (workflow_dispatch ONLY) — capture the `linux-x64` BenchmarkDotNet baseline on a stable CI
+# runner and upload it as an artifact for the maintainer to review + commit under
+# `tests/NetPdf.Benchmarks/baselines/linux-x64/`. Deliberately NOT wired into push/PR CI: a baseline is a
+# deliberate re-basing step (see tests/NetPdf.Benchmarks/baselines/README.md), captured on the gated
+# environment (linux-x64 CI) rather than a dev box so the numbers represent what the gate actually runs against.
+#
+# After the run: download the `benchmark-baseline-linux-x64` artifact, drop it under
+# tests/NetPdf.Benchmarks/baselines/linux-x64/, and commit. The `ci`/`docs` benchmark gate then flips from
+# neutral (exit 2, "no baseline yet") to enforcing the +25% tolerance against these numbers.
+name: capture-benchmark-baseline
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    name: capture linux-x64 baseline
+    runs-on: ubuntu-latest
+    # The full BenchmarkDotNet suite (pilot + warmup + measured iterations across every benchmark class) is
+    # slow; give it generous headroom. Free public runners cap a single job at 6h, well above this.
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+      - name: Platform key (must resolve to linux-x64)
+        run: echo "uname -sm -> $(uname -sm)"
+      - name: Capture baseline (runs the full BenchmarkDotNet suite via the gate script)
+        run: bash scripts/benchmark-gate.sh capture
+      - name: Show the captured baseline
+        run: |
+          ls -la tests/NetPdf.Benchmarks/baselines/linux-x64/
+          echo "--- git status ---"
+          git status --short
+      - name: Upload the linux-x64 baseline for the maintainer to commit
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-baseline-linux-x64
+          path: tests/NetPdf.Benchmarks/baselines/linux-x64/
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,15 +67,16 @@ jobs:
       - name: Build the docs site (0 warnings)
         run: dotnet docfx docs-site/docfx.json --warningsAsErrors
       - name: Upload Pages artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs-site/_site
 
   deploy:
     name: deploy to GitHub Pages
-    # Push to main AND the maintainer has enabled Pages (repo variable). Skipped otherwise — never red.
-    if: github.event_name == 'push' && vars.NETPDF_PAGES_ENABLED == 'true'
+    # Push to main OR a manual re-deploy, AND the maintainer has enabled Pages (repo variable). A PR build
+    # never deploys (it only validates the site). Skipped otherwise — never red.
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && vars.NETPDF_PAGES_ENABLED == 'true'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Unblocks two Phase-5 remainders now that the repo is public (free Actions):

1. **GitHub Pages** — Pages is enabled (source: GitHub Actions) and `NETPDF_PAGES_ENABLED=true` is set. `docs.yml` now also deploys on `workflow_dispatch` (was push-only) so the site can be re-deployed manually. Merging this PR touches a `docs.yml` trigger path, so it fires the **first deploy** → https://raroche.github.io/NetPdf/.
2. **Benchmark baseline** — new `capture-benchmark-baseline.yml` (workflow_dispatch) runs `benchmark-gate.sh capture` on a `linux-x64` runner and uploads the baseline as an artifact for me to commit under `tests/NetPdf.Benchmarks/baselines/linux-x64/`. That flips the benchmark gate from neutral → enforcing (+25% tolerance).

Workflow-only change; admin-merged to keep the launch moving.

Note: the **visual-regression** references remain blocked on a separate prerequisite (a committed shared font pack + Dockerfile `COPY` + a matching NetPdf `FontResolver`) — generating references without font parity would fail the Δ<4/SSIM≥0.98 diff and turn the gate red. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)