### PR TITLE
fix(bench): capture the first per-platform baseline (chicken-and-egg)

### DIFF
--- a/.github/workflows/capture-benchmark-baseline.yml
+++ b/.github/workflows/capture-benchmark-baseline.yml
@@ -1,11 +1,11 @@
 # Maintainer tool (workflow_dispatch ONLY) — capture the `linux-x64` BenchmarkDotNet baseline on a stable CI
 # runner and upload it as an artifact for the maintainer to review + commit under
-# `tests/NetPdf.Benchmarks/baselines/linux-x64/`. Deliberately NOT wired into push/PR CI: a baseline is a
+# `tests/NetPdf.Benchmarks/baselines/phase-1-linux-x64/`. Deliberately NOT wired into push/PR CI: a baseline is a
 # deliberate re-basing step (see tests/NetPdf.Benchmarks/baselines/README.md), captured on the gated
 # environment (linux-x64 CI) rather than a dev box so the numbers represent what the gate actually runs against.
 #
 # After the run: download the `benchmark-baseline-linux-x64` artifact, drop it under
-# tests/NetPdf.Benchmarks/baselines/linux-x64/, and commit. The `ci`/`docs` benchmark gate then flips from
+# tests/NetPdf.Benchmarks/baselines/phase-1-linux-x64/, and commit. The `ci`/`docs` benchmark gate then flips from
 # neutral (exit 2, "no baseline yet") to enforcing the +25% tolerance against these numbers.
 name: capture-benchmark-baseline
 
@@ -34,13 +34,13 @@ jobs:
         run: bash scripts/benchmark-gate.sh capture
       - name: Show the captured baseline
         run: |
-          ls -la tests/NetPdf.Benchmarks/baselines/linux-x64/
+          ls -la tests/NetPdf.Benchmarks/baselines/phase-1-linux-x64/
           echo "--- git status ---"
           git status --short
       - name: Upload the linux-x64 baseline for the maintainer to commit
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-baseline-linux-x64
-          path: tests/NetPdf.Benchmarks/baselines/linux-x64/
+          path: tests/NetPdf.Benchmarks/baselines/phase-1-linux-x64/
           if-no-files-found: error
           retention-days: 7

--- a/scripts/benchmark-gate.sh
+++ b/scripts/benchmark-gate.sh
@@ -36,14 +36,10 @@ esac
 PLATFORM_KEY="${OS}-${ARCH}"
 BASELINE_DIR="$BASELINE_ROOT/phase-1-${PLATFORM_KEY}"
 
-if [ ! -d "$BASELINE_DIR" ]; then
-  echo "warn: no baseline pinned for platform '$PLATFORM_KEY' at $BASELINE_DIR" >&2
-  echo "      Capture one with: ./scripts/benchmark-gate.sh capture" >&2
-  exit 2
-fi
-
-# 'capture' subcommand: run + replace the baseline (used during deliberate
-# re-baselining; never run by CI).
+# 'capture' subcommand: run + (re)write the baseline (used during deliberate
+# re-baselining; never run by CI). Handled BEFORE the "baseline missing" guard so the
+# FIRST baseline for a platform CAN be captured — otherwise the guard's `exit 2` fires
+# first and a brand-new platform (e.g. linux-x64 on the CI runner) can never be seeded.
 if [ "${1:-}" = "capture" ]; then
   echo "==> Capturing new baseline for $PLATFORM_KEY"
   rm -rf "$ARTIFACTS_DIR"
@@ -54,6 +50,12 @@ if [ "${1:-}" = "capture" ]; then
   echo "==> Baseline written to $BASELINE_DIR"
   echo "    Review the diff in git, verify the changes are deliberate, then commit."
   exit 0
+fi
+
+if [ ! -d "$BASELINE_DIR" ]; then
+  echo "warn: no baseline pinned for platform '$PLATFORM_KEY' at $BASELINE_DIR" >&2
+  echo "      Capture one with: ./scripts/benchmark-gate.sh capture" >&2
+  exit 2
 fi
 
 echo "==> Running benchmark suite ($PLATFORM_KEY)"


### PR DESCRIPTION
`benchmark-gate.sh` exited 2 on the "no baseline pinned" guard *before* reaching the `capture` subcommand, so the first `linux-x64` baseline could never be seeded (the CI capture run failed instantly with exit 2). Move `capture` ahead of the guard. Also corrects the capture workflow's path: baselines live under `baselines/phase-1-<platform>`, not `baselines/<platform>`.

Enables the `capture-benchmark-baseline` workflow to actually produce the `linux-x64` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)