### PR TITLE
fix(visual): playwright import in reference generator

### DIFF
--- a/tests/NetPdf.RenderingCorpus/docker/Dockerfile
+++ b/tests/NetPdf.RenderingCorpus/docker/Dockerfile
@@ -6,7 +6,11 @@
 FROM mcr.microsoft.com/playwright/python:v1.49.0-jammy
 
 # pypdfium2 rasterizes the Chrome print-to-PDF at the harness DPI (PDFium — SkiaSharp cannot read PDF).
-RUN pip install --no-cache-dir pypdfium2==4.30.0
+# Install playwright into the SAME python that runs the generator too: the base image ships Playwright but
+# in a location the plain `python3 generate-references.py` invocation didn't import ("No module named
+# 'playwright'"); reinstalling via pip puts it on the invoked interpreter's path alongside pypdfium2. Chromium
+# itself is already bundled in the base image, so no `playwright install` is needed.
+RUN pip install --no-cache-dir playwright==1.49.0 pypdfium2==4.30.0
 
 # A PINNED font pack used by BOTH Chrome and NetPdf keeps the diff stable across machines. Copy the repo's
 # committed DejaVu Sans pack in and alias the corpus families + generic sans-serif to it (00-netpdf-pin.conf),


### PR DESCRIPTION
The reference-generator Docker image (never run before) failed with 'No module named playwright'; install it via pip so the generator interpreter can import it.