### PR TITLE
chore(visual): render corpus at the reference page size (Letter)

### DIFF
--- a/tests/NetPdf.RenderingCorpus/Visual/CorpusVisualRegressionTests.cs
+++ b/tests/NetPdf.RenderingCorpus/Visual/CorpusVisualRegressionTests.cs
@@ -35,7 +35,7 @@ public sealed class CorpusVisualRegressionTests(ITestOutputHelper output)
         // End-to-end smoke independent of the visual backend: NetPdf renders the (self-contained) invoice
         // with the PINNED font pack (so it matches the Chrome reference oracle when the diff runs).
         var pdf = HtmlPdf.Convert(VisualHarness.ReadInvoiceHtml(invoice),
-            new HtmlPdfOptions { FontResolver = VisualHarness.PinnedFonts() });
+            new HtmlPdfOptions { PageSize = VisualHarness.ReferencePageSize, FontResolver = VisualHarness.PinnedFonts() });
         Assert.NotEmpty(pdf);
     }
 
@@ -62,7 +62,7 @@ public sealed class CorpusVisualRegressionTests(ITestOutputHelper output)
         // renders with the PINNED DejaVu pack — the SAME font Chrome used to generate the references — so the
         // diff isolates layout-engine deltas from font differences.
         var pdf = HtmlPdf.Convert(VisualHarness.ReadInvoiceHtml(invoice),
-            new HtmlPdfOptions { FontResolver = VisualHarness.PinnedFonts() });
+            new HtmlPdfOptions { PageSize = VisualHarness.ReferencePageSize, FontResolver = VisualHarness.PinnedFonts() });
         var pages = rasterizer!.RasterizeAllPages(pdf, VisualHarness.Dpi);
         var references = VisualHarness.ReferencePagePaths(invoice);
         Assert.True(pages.Count == references.Count,

--- a/tests/NetPdf.RenderingCorpus/Visual/VisualHarness.cs
+++ b/tests/NetPdf.RenderingCorpus/Visual/VisualHarness.cs
@@ -65,6 +65,13 @@ public static class VisualHarness
     /// so the NetPdf side of the diff is font-deterministic and matches the Chrome reference oracle.</summary>
     public static IFontResolver PinnedFonts() => new PinnedFontResolver();
 
+    /// <summary>The page size NetPdf must render the corpus at to match the reference oracle. The generator
+    /// drives Chrome's <c>page.pdf(prefer_css_page_size=True)</c>, and the corpus invoices declare no explicit
+    /// <c>@page size</c>, so Chrome falls back to its default US <b>Letter</b> — 2550×3301 px at 300 dpi.
+    /// NetPdf's own default is A4 (2481×3509), so without this the rasters differ in size and the diff can't
+    /// even run. Pinned here so a future page-size change is a single edit shared by both diff render sites.</summary>
+    public static PageSize ReferencePageSize => PageSize.Letter;
+
     /// <summary>The reference PNG path for a 1-based page of an invoice (e.g.
     /// <c>01-classic-pure-css.html</c> page 1 → <c>references/01-classic-pure-css-page-001.png</c>).</summary>
     public static string ReferencePagePath(string invoiceFileName, int pageNumber) =>


### PR DESCRIPTION
NetPdf defaults to A4 but the Chrome reference oracle uses Letter — pin the diff render to Letter so the rasters are the same geometry. Gate still inert (no references).