### PR TITLE
chore(visual): reconcile <=2px page-rounding before the diff

### DIFF
--- a/tests/NetPdf.RenderingCorpus/Visual/CorpusVisualRegressionTests.cs
+++ b/tests/NetPdf.RenderingCorpus/Visual/CorpusVisualRegressionTests.cs
@@ -70,8 +70,11 @@ public sealed class CorpusVisualRegressionTests(ITestOutputHelper output)
 
         for (var i = 0; i < pages.Count; i++)
         {
-            var expected = VisualHarness.LoadPng(references[i]);
-            var diff = PixelDiff.Compare(expected, pages[i]);
+            var reference = VisualHarness.LoadPng(references[i]);
+            // Reconcile a sub-pixel page-height rounding difference (Chrome vs NetPdf rasterize the same
+            // Letter page to a ≤2 px different height) before the exact-size diff; a larger delta still throws.
+            var (expected, actual) = VisualHarness.ReconcilePageRounding(reference, pages[i]);
+            var diff = PixelDiff.Compare(expected, actual);
             _output.WriteLine($"{invoice} page {i + 1}: {diff}");
             Assert.True(diff.WithinTolerance,
                 $"{invoice} page {i + 1} exceeds the visual tolerance: {diff}. "

--- a/tests/NetPdf.RenderingCorpus/Visual/RasterImage.cs
+++ b/tests/NetPdf.RenderingCorpus/Visual/RasterImage.cs
@@ -24,4 +24,22 @@ public sealed record RasterImage(int Width, int Height, byte[] Rgba)
             throw new System.ArgumentException(
                 $"raster buffer length {Rgba.Length} != expected {ExpectedLength} for {Width}x{Height} RGBA");
     }
+
+    /// <summary>Return the top-left <paramref name="width"/>×<paramref name="height"/> sub-raster (row-major
+    /// RGBA copy). Used to reconcile a sub-pixel page-size rounding difference between the two renderers:
+    /// Chrome and NetPdf can rasterize the SAME logical page size (US Letter, 792 pt) to a 1–2 px different
+    /// pixel height, and cropping both to the common minimum drops only page-bottom/right margin whitespace.
+    /// No-op when the requested size already equals this raster's.</summary>
+    public RasterImage CropTo(int width, int height)
+    {
+        if (width == Width && height == Height) return this;
+        if (width < 0 || height < 0 || width > Width || height > Height)
+            throw new System.ArgumentException($"crop {width}x{height} out of bounds for {Width}x{Height}");
+        var dst = new byte[width * height * 4];
+        var srcStride = Width * 4;
+        var dstStride = width * 4;
+        for (var y = 0; y < height; y++)
+            System.Array.Copy(Rgba, y * srcStride, dst, y * dstStride, dstStride);
+        return new RasterImage(width, height, dst);
+    }
 }

--- a/tests/NetPdf.RenderingCorpus/Visual/VisualHarness.cs
+++ b/tests/NetPdf.RenderingCorpus/Visual/VisualHarness.cs
@@ -72,6 +72,26 @@ public static class VisualHarness
     /// even run. Pinned here so a future page-size change is a single edit shared by both diff render sites.</summary>
     public static PageSize ReferencePageSize => PageSize.Letter;
 
+    /// <summary>Sub-pixel page-size rounding slack (px). Chrome and NetPdf can rasterize the SAME logical
+    /// page size (US Letter, 792 pt tall) to pixel heights differing by a couple of px at 300 dpi — Chrome
+    /// rounds 792 pt → 3301, NetPdf → 3299. A delta THIS small is a rounding artifact, not a layout bug.</summary>
+    public const int PageRoundingSlackPx = 2;
+
+    /// <summary>Crop both rasters to their common minimum dimensions when they differ by at most
+    /// <see cref="PageRoundingSlackPx"/> on each axis (dropping only page-edge margin whitespace), so the
+    /// page-for-page diff isn't defeated by rasterization rounding. A LARGER delta is a real page-size bug
+    /// and is returned unchanged, so <see cref="PixelDiff.Compare"/> still surfaces it as a size mismatch.</summary>
+    public static (RasterImage Expected, RasterImage Actual) ReconcilePageRounding(RasterImage expected, RasterImage actual)
+    {
+        var dw = Math.Abs(expected.Width - actual.Width);
+        var dh = Math.Abs(expected.Height - actual.Height);
+        if ((dw == 0 && dh == 0) || dw > PageRoundingSlackPx || dh > PageRoundingSlackPx)
+            return (expected, actual);
+        var w = Math.Min(expected.Width, actual.Width);
+        var h = Math.Min(expected.Height, actual.Height);
+        return (expected.CropTo(w, h), actual.CropTo(w, h));
+    }
+
     /// <summary>The reference PNG path for a 1-based page of an invoice (e.g.
     /// <c>01-classic-pure-css.html</c> page 1 → <c>references/01-classic-pure-css-page-001.png</c>).</summary>
     public static string ReferencePagePath(string invoiceFileName, int pageNumber) =>


### PR DESCRIPTION
Crop both rasters to common min dims when they differ by <=2px (a 300dpi page-height rounding artifact) so the diff isn't defeated before it runs; larger deltas still throw. Gate still inert.