### PR TITLE
docs(deferrals): track remaining items + add Priority field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,10 @@ jobs:
   # (libSkiaSharp) fails to load under musl on the stock SDK-alpine image — a pre-existing
   # environment gap that needs hardening on a real Alpine runner (musl native-asset + font
   # deps), not reproducible on the macOS/glibc dev box. Until that's hardened the leg runs and
-  # surfaces its status but does not gate merge; the five glibc/Windows/macOS legs above are the
-  # enforcing matrix. Tracked as a known CI-hardening remainder: docs/deferrals.md deferral
-  # `ci-nonblocking-platform-native-deps`.
+  # surfaces its status but does not gate merge; the ENFORCING matrix is exactly three legs —
+  # linux-x64, windows-x64, macos-arm64 — while linux-arm64 and macos-x64 (above) plus this alpine
+  # leg are the three NON-BLOCKING legs. Tracked as a known CI-hardening remainder: docs/deferrals.md
+  # deferral `ci-nonblocking-platform-native-deps`.
   build-test-alpine:
     name: build+test (alpine-musl-x64, non-blocking)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     # Two matrix legs are NON-BLOCKING (continue-on-error via a `nonblocking: true` flag) — they run and
-    # surface status but don't gate merge. Both are tracked as Phase-5 remainders:
+    # surface status but don't gate merge. Both are tracked as Phase-5 remainders in docs/deferrals.md:
+    #   linux-arm64 → deferral `ci-nonblocking-platform-native-deps` (also covers the alpine leg below);
+    #   macos-x64   → deferral `ci-nonblocking-macos-x64-runner-availability`.
     #   * linux-arm64 — SkiaSharp's raster-fallback native (libSkiaSharp) on the arm64 image is
     #     under-provisioned: it resolves symbols from the *system* libuuid / libfreetype the runner doesn't
     #     satisfy (undefined uuid_generate_random, then — once libuuid is preloaded — FT_Get_BDF_Property).
@@ -92,7 +94,8 @@ jobs:
   # environment gap that needs hardening on a real Alpine runner (musl native-asset + font
   # deps), not reproducible on the macOS/glibc dev box. Until that's hardened the leg runs and
   # surfaces its status but does not gate merge; the five glibc/Windows/macOS legs above are the
-  # enforcing matrix. Tracked as a known CI-hardening remainder.
+  # enforcing matrix. Tracked as a known CI-hardening remainder: docs/deferrals.md deferral
+  # `ci-nonblocking-platform-native-deps`.
   build-test-alpine:
     name: build+test (alpine-musl-x64, non-blocking)
     runs-on: ubuntu-latest

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -23,8 +23,9 @@ can verify entries don't drift away from source. Required labels:
 - **Owner files** — files (and rough locations) that change when picked up.
 - **Removal condition** — explicit criterion for deleting the entry.
 - **Priority** *(optional)* — relative pickup value: `P1` (high) / `P2` (medium) /
-  `P3` (low), with a one-line rationale. Newer entries carry it so the backlog can
-  be worked value-first; older entries may omit it (add on next touch).
+  `P3` (low), with a brief rationale (a sentence or two; it may soft-wrap across
+  lines like the other fields). Newer entries carry it so the backlog can be worked
+  value-first; older entries may omit it (add on next touch).
 
 When you add a deferral, also add its ID to the expected list in
 `DeferralsParityTests.cs` (and reference this doc in the throw-message /

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -22,6 +22,9 @@ can verify entries don't drift away from source. Required labels:
 - **Trigger** — the condition that moves this off the deferral list.
 - **Owner files** — files (and rough locations) that change when picked up.
 - **Removal condition** — explicit criterion for deleting the entry.
+- **Priority** *(optional)* — relative pickup value: `P1` (high) / `P2` (medium) /
+  `P3` (low), with a one-line rationale. Newer entries carry it so the backlog can
+  be worked value-first; older entries may omit it (add on next touch).
 
 When you add a deferral, also add its ID to the expected list in
 `DeferralsParityTests.cs` (and reference this doc in the throw-message /
@@ -3919,3 +3922,71 @@ grepping the ID).
 - **Removal condition** — a bordered / backgrounded inline paints its decoration
   per line box; the `LAYOUT-INLINE-UNSUPPORTED-001` inline-decoration warning is
   removed.
+
+
+
+## visual-regression-cross-engine-tolerance
+
+- **ID** — `visual-regression-cross-engine-tolerance`
+- **Status** — `not-started`. The gate is INERT (no reference PNGs committed), so
+  it never fails; every other piece of the harness is wired.
+- **Priority** — **P2 (medium).** A live visual-regression gate gives ongoing
+  protection against rendering regressions across the whole engine — high long-term
+  value for a rendering library. But activation needs a tolerance-policy decision
+  and carries some CI flakiness, and the engine ships correct output without it, so
+  it's not release-blocking.
+- **Behavior** — `tests/NetPdf.RenderingCorpus/Visual/CorpusVisualRegressionTests`
+  diffs NetPdf's render of each diffable corpus invoice against a committed **Chrome
+  reference PNG** (per page, 300 dpi). It stays inert (logged skip) while the
+  `references/` dir has no PNGs. Fully wired: the PDFium rasterizer, the pinned
+  DejaVu font pack shared by BOTH sides (`PinnedFontResolver` + the Docker
+  fontconfig alias), the page-size pin (US Letter, matching Chrome's default), the
+  ≤2px page-rounding reconcile, and the `generate-visual-references.yml`
+  workflow_dispatch that produces the Chrome references on a Linux runner.
+- **Missing** — the committed tolerance is per-pixel RGBA **Δ<4 AND SSIM≥0.98**
+  (`PixelDiff.MaxPerPixelDelta` / `MinSsim`). That is an engine-vs-**SELF**
+  regression tolerance; NetPdf-vs-Chrome is a **cross-engine** diff — two different
+  rasterizers differ at every anti-aliased glyph edge, so `maxΔ≈255` and
+  `SSIM≈0.958` **even when the layout is pixel-correct** (verified: fixing the
+  `01-classic` float/clear overlap did NOT move the SSIM). The gate therefore cannot
+  be activated at that tolerance. Needs a cross-engine tolerance policy: an
+  SSIM-based floor (~0.90) with the per-pixel-Δ demoted to diagnostic-only, then
+  commit the reference PNGs. `01-classic` is verified to render correctly (so its
+  0.958 is AA noise, not a defect); `04-anvil` is not yet visually verified.
+- **Trigger** — a decision to enforce cross-engine visual fidelity: set the
+  cross-engine tolerance, verify each diffable invoice renders correctly
+  (`01-classic` done, `04-anvil` pending), and commit the reference PNGs.
+- **Owner files** — `tests/NetPdf.RenderingCorpus/Visual/PixelDiff.cs` (tolerance
+  constants + the gate metric); `tests/NetPdf.RenderingCorpus/references/*.png`
+  (commit, via `gh workflow run generate-visual-references.yml`);
+  `tests/NetPdf.RenderingCorpus/Visual/CorpusVisualRegressionTests.cs`.
+- **Removal condition** — reference PNGs committed for every diffable invoice, the
+  gate enforces a documented cross-engine tolerance, and CI is green.
+
+
+
+## ci-nonblocking-platform-native-deps
+
+- **ID** — `ci-nonblocking-platform-native-deps`
+- **Status** — `not-started`. The two legs are `continue-on-error: true`
+  (non-blocking) and currently fail at the Test step.
+- **Priority** — **P3 (low).** These are the two NON-enforcing extra RIDs; the
+  enforcing matrix (`linux-x64`, `windows-x64`, `macos-arm64`) already covers the
+  shipping platforms, so this is platform-coverage confidence, not a correctness
+  gate. Bump if a customer targets Alpine/arm64.
+- **Behavior** — the `build+test (linux-arm64, non-blocking)` and
+  `build+test (alpine-musl-x64, non-blocking)` CI legs run but don't gate merge.
+  They fail at the Test step on SkiaSharp/HarfBuzz native-dependency gaps in those
+  runner images (fontconfig + font packs were added; the next gap surfaces after
+  each fix).
+- **Missing** — the remaining native deps for the SkiaSharp text stack on those
+  platforms. **arm64** (ubuntu-24.04-arm): `libSkiaSharp.so: undefined symbol:
+  uuid_generate_random` → install `libuuid1` (and whatever the next symbol needs).
+  **alpine** (musl): the raster-fallback native (`libSkiaSharp`) load + any font
+  deps beyond the added `ttf-dejavu`/`freetype`/`fontconfig`. Iterative: each fix
+  tends to reveal the next missing lib.
+- **Trigger** — a decision to make the two extra RIDs green (or enforcing), OR a
+  customer running on Alpine / Linux-arm64 hits a native-load failure.
+- **Owner files** — `.github/workflows/ci.yml` (the `build-test` arm64-scoped
+  install step + the `build-test-alpine` `apk add` step).
+- **Removal condition** — both non-blocking legs pass the Test step in CI (green).

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -3953,6 +3953,17 @@ grepping the ID).
   SSIM-based floor (~0.90) with the per-pixel-Δ demoted to diagnostic-only, then
   commit the reference PNGs. `01-classic` is verified to render correctly (so its
   0.958 is AA noise, not a defect); `04-anvil` is not yet visually verified.
+- **Evidence / reproduce** — the `maxΔ≈255` / `SSIM≈0.958` figures are for `01-classic`
+  ONLY; `04-anvil` is NOT yet measured, so the proposed `~0.90` floor is a starting
+  hypothesis, not a finalized policy (do not enforce until both diffable invoices are
+  measured). To reproduce the numbers on a Linux runner (Chrome + fonts are pinned in
+  the Docker image, so the raster is deterministic there): (1) generate the Chrome
+  references — `gh workflow run generate-visual-references.yml`, download the artifact
+  into `tests/NetPdf.RenderingCorpus/references/`; (2) run the gate —
+  `dotnet test tests/NetPdf.RenderingCorpus -c Release --filter FullyQualifiedName~CorpusVisualRegression`;
+  the per-page `maxΔ` / `ssim` are printed by `PixelDiffResult.ToString()` (format
+  `WxH maxΔ=… ssim=…`). Re-run after any layout fix to confirm the SSIM does not move
+  (the `01-classic` float/clear check above was done exactly this way).
 - **Trigger** — a decision to enforce cross-engine visual fidelity: set the
   cross-engine tolerance, verify each diffable invoice renders correctly
   (`01-classic` done, `04-anvil` pending), and commit the reference PNGs.
@@ -3968,9 +3979,12 @@ grepping the ID).
 ## ci-nonblocking-platform-native-deps
 
 - **ID** — `ci-nonblocking-platform-native-deps`
-- **Status** — `not-started`. The two legs are `continue-on-error: true`
-  (non-blocking) and currently fail at the Test step.
-- **Priority** — **P3 (low).** These are the two NON-enforcing extra RIDs; the
+- **Status** — `not-started`. The two NATIVE-DEPENDENCY legs (`linux-arm64` +
+  `alpine-musl-x64`) are `continue-on-error: true` (non-blocking) and currently fail
+  at the Test step. (The third non-blocking leg, `macos-x64`, is a distinct
+  runner-availability issue tracked separately as
+  [`ci-nonblocking-macos-x64-runner-availability`](#ci-nonblocking-macos-x64-runner-availability).)
+- **Priority** — **P3 (low).** These are the two NON-enforcing native-dep RIDs; the
   enforcing matrix (`linux-x64`, `windows-x64`, `macos-arm64`) already covers the
   shipping platforms, so this is platform-coverage confidence, not a correctness
   gate. Bump if a customer targets Alpine/arm64.
@@ -3990,3 +4004,29 @@ grepping the ID).
 - **Owner files** — `.github/workflows/ci.yml` (the `build-test` arm64-scoped
   install step + the `build-test-alpine` `apk add` step).
 - **Removal condition** — both non-blocking legs pass the Test step in CI (green).
+
+
+
+## ci-nonblocking-macos-x64-runner-availability
+
+- **ID** — `ci-nonblocking-macos-x64-runner-availability`
+- **Status** — `not-started`. The `macos-x64` (macos-13) matrix leg is
+  `continue-on-error: true` (non-blocking) and is chronically UNSCHEDULABLE — it
+  stays queued for the whole timeout rather than failing on a test.
+- **Priority** — **P3 (low).** `macos-arm64` provides the enforcing macOS coverage;
+  Intel-mac is best-effort. This is a hosted-runner-availability gap, not a
+  NetPdf correctness or native-dependency issue — distinct from
+  [`ci-nonblocking-platform-native-deps`](#ci-nonblocking-platform-native-deps)
+  (which is about missing SkiaSharp/HarfBuzz native libs on arm64/alpine).
+- **Behavior** — the `build+test (macos-x64, non-blocking)` CI leg runs but doesn't
+  gate merge. GitHub is deprecating the Intel-mac hosted runners, so the leg is
+  routinely unschedulable and stays queued until the workflow timeout.
+- **Missing** — a schedulable Intel-mac runner. Nothing in NetPdf can fix this; it
+  is entirely a GitHub-hosted-runner-fleet constraint.
+- **Trigger** — GitHub restores reliable Intel-mac hosted-runner availability, OR a
+  decision to drop the `macos-x64` leg entirely (macos-arm64 already gives enforcing
+  macOS coverage), OR a customer needs verified Intel-mac support.
+- **Owner files** — `.github/workflows/ci.yml` (the `macos-13` / `macos-x64` matrix
+  `include` entry + its `nonblocking: true` flag).
+- **Removal condition** — the `macos-x64` leg either schedules + passes reliably in
+  CI, or is removed from the matrix (with this entry deleted in the same commit).

--- a/tests/NetPdf.RenderingCorpus/Visual/PixelDiff.cs
+++ b/tests/NetPdf.RenderingCorpus/Visual/PixelDiff.cs
@@ -24,6 +24,11 @@ public readonly record struct PixelDiffResult(int MaxChannelDelta, double Ssim, 
 /// rasterized to <see cref="RasterImage"/> elsewhere; this only compares.</summary>
 public static class PixelDiff
 {
+    // These are the engine-vs-SELF regression tolerances. Activating the gate against the pinned-Chrome
+    // reference PNGs is a CROSS-engine diff (two rasterizers differ at every AA glyph edge), which these
+    // strict values reject even on pixel-correct layout — see the `visual-regression-cross-engine-tolerance`
+    // deferral in docs/deferrals.md for the tolerance-policy decision that must precede committing references.
+
     /// <summary>Per-pixel RGBA channel tolerance: a difference of this much or more on any channel of any
     /// pixel fails the gate (Phase-4 exit criterion: per-pixel RGBA Δ &lt; 4).</summary>
     public const int MaxPerPixelDelta = 4;

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace NetPdf.UnitTests.Docs;
@@ -66,6 +67,7 @@ public sealed class DeferralsParityTests
         "layout-to-pdf-pipeline",
         "visual-regression-cross-engine-tolerance",
         "ci-nonblocking-platform-native-deps",
+        "ci-nonblocking-macos-x64-runner-availability",
     };
 
     [Fact]
@@ -143,6 +145,44 @@ public sealed class DeferralsParityTests
                 $"Saw: '{snippet.Trim()}'.");
             pos = snippetEnd;
         }
+    }
+
+    [Fact]
+    public void Deferrals_priority_lines_use_a_defined_level_and_carry_a_rationale()
+    {
+        // The optional Priority field, when present, must use P1|P2|P3 AND carry a one-line rationale
+        // (schema preamble: "`P1` (high) / `P2` (medium) / `P3` (low), with a one-line rationale"). Without
+        // this, a future edit could write `P0`/`High`, omit the rationale, or malform the syntax and CI would
+        // stay green. Lightweight schema protection matching the ID/status guards above.
+        var content = LoadDeferralsDoc();
+        const string marker = "**Priority** — ";
+        // Priority value is a bold token like `**P2 (medium).**` immediately followed by the rationale on the
+        // same line (which may then wrap onto following lines — we only assert the rationale STARTS non-empty).
+        var lineRegex = new Regex(@"^\*\*(P[123])\b[^\r\n*]*\*\*\s+(\S[^\r\n]*)$");
+        var pos = 0;
+        var seen = 0;
+        while (true)
+        {
+            var start = content.IndexOf(marker, pos, StringComparison.Ordinal);
+            if (start < 0) break;
+            start += marker.Length;
+            var eol = content.IndexOfAny(new[] { '\r', '\n' }, start);
+            if (eol < 0) eol = content.Length;
+            var line = content.Substring(start, eol - start);
+            var m = lineRegex.Match(line);
+            Assert.True(m.Success,
+                "Priority line in docs/deferrals.md is malformed. Expected " +
+                "`**P1|P2|P3 (word).** <rationale>` (levels: P1 high / P2 medium / P3 low). " +
+                $"Saw: '{line.Trim()}'.");
+            Assert.True(m.Groups[2].Value.Trim().Length > 0,
+                $"Priority '{m.Groups[1].Value}' in docs/deferrals.md has no rationale. Saw: '{line.Trim()}'.");
+            seen++;
+            pos = eol;
+        }
+        // Guard against the marker/format silently changing so nothing is validated (the newer entries carry
+        // a Priority, so at least a couple must be present + well-formed).
+        Assert.True(seen >= 2,
+            $"expected the newer deferral entries to carry a well-formed Priority field; matched {seen}.");
     }
 
     private static string LoadDeferralsDoc()

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -147,18 +147,36 @@ public sealed class DeferralsParityTests
         }
     }
 
-    [Fact]
-    public void Deferrals_priority_lines_use_a_defined_level_and_carry_a_rationale()
+    /// <summary>The exact Priority LEVEL each newly-added deferral (that carries the optional Priority
+    /// field) must declare. Guards the field per-ID so a new entry can't silently drop its Priority line —
+    /// the `seen >= 2` count alone would still pass if one of three lost its Priority (PR #315 review [P2]).
+    /// Add an entry here when a new deferral carries a Priority; the level must match the doc.</summary>
+    private static readonly System.Collections.Generic.Dictionary<string, string> ExpectedPriorities = new()
     {
-        // The optional Priority field, when present, must use P1|P2|P3 AND carry a one-line rationale
-        // (schema preamble: "`P1` (high) / `P2` (medium) / `P3` (low), with a one-line rationale"). Without
-        // this, a future edit could write `P0`/`High`, omit the rationale, or malform the syntax and CI would
-        // stay green. Lightweight schema protection matching the ID/status guards above.
+        ["visual-regression-cross-engine-tolerance"] = "P2",
+        ["ci-nonblocking-platform-native-deps"] = "P3",
+        ["ci-nonblocking-macos-x64-runner-availability"] = "P3",
+    };
+
+    /// <summary>The documented label for each level (schema: `P1` high / `P2` medium / `P3` low).</summary>
+    private static readonly System.Collections.Generic.Dictionary<string, string> PriorityLabels = new()
+    {
+        ["P1"] = "high",
+        ["P2"] = "medium",
+        ["P3"] = "low",
+    };
+
+    [Fact]
+    public void Deferrals_priority_lines_use_a_defined_level_with_matching_label_and_carry_a_rationale()
+    {
+        // The optional Priority field, when present, must use P1|P2|P3, the label must MATCH the schema
+        // mapping (P1 high / P2 medium / P3 low — so `P1 (low)` is rejected, PR #315 review [P3]), and it
+        // must carry a one-line rationale. Without this a malformed `P0`/`High`, a mismatched label, or a
+        // rationale-less line would keep CI green.
         var content = LoadDeferralsDoc();
         const string marker = "**Priority** — ";
-        // Priority value is a bold token like `**P2 (medium).**` immediately followed by the rationale on the
-        // same line (which may then wrap onto following lines — we only assert the rationale STARTS non-empty).
-        var lineRegex = new Regex(@"^\*\*(P[123])\b[^\r\n*]*\*\*\s+(\S[^\r\n]*)$");
+        // `**P2 (medium).**` — capture level + label + the rationale that starts on the same line.
+        var lineRegex = new Regex(@"^\*\*(P[123])\s+\(([a-z]+)\)\.?\*\*\s+(\S[^\r\n]*)$");
         var pos = 0;
         var seen = 0;
         while (true)
@@ -172,17 +190,45 @@ public sealed class DeferralsParityTests
             var m = lineRegex.Match(line);
             Assert.True(m.Success,
                 "Priority line in docs/deferrals.md is malformed. Expected " +
-                "`**P1|P2|P3 (word).** <rationale>` (levels: P1 high / P2 medium / P3 low). " +
+                "`**P1|P2|P3 (label).** <rationale>` (P1 high / P2 medium / P3 low). " +
                 $"Saw: '{line.Trim()}'.");
-            Assert.True(m.Groups[2].Value.Trim().Length > 0,
-                $"Priority '{m.Groups[1].Value}' in docs/deferrals.md has no rationale. Saw: '{line.Trim()}'.");
+            var level = m.Groups[1].Value;
+            var label = m.Groups[2].Value;
+            Assert.True(PriorityLabels[level] == label,
+                $"Priority '{level}' in docs/deferrals.md is labeled '({label})' but the schema maps " +
+                $"{level} → '{PriorityLabels[level]}'. Saw: '{line.Trim()}'.");
+            Assert.True(m.Groups[3].Value.Trim().Length > 0,
+                $"Priority '{level}' in docs/deferrals.md has no rationale. Saw: '{line.Trim()}'.");
             seen++;
             pos = eol;
         }
-        // Guard against the marker/format silently changing so nothing is validated (the newer entries carry
-        // a Priority, so at least a couple must be present + well-formed).
-        Assert.True(seen >= 2,
-            $"expected the newer deferral entries to carry a well-formed Priority field; matched {seen}.");
+        // Guard against the marker/format silently changing so nothing is validated.
+        Assert.True(seen >= ExpectedPriorities.Count,
+            $"expected at least {ExpectedPriorities.Count} well-formed Priority lines; matched {seen}.");
+    }
+
+    [Fact]
+    public void Newly_added_deferrals_carry_their_expected_priority_level()
+    {
+        // Per-ID guard (PR #315 review [P2]): each newly-added deferral must still declare its Priority at the
+        // expected level. A durable map so backlog ordering can't silently drift and no new entry loses its
+        // Priority line unnoticed.
+        var content = LoadDeferralsDoc();
+        foreach (var (id, level) in ExpectedPriorities)
+        {
+            var anchor = content.IndexOf($"**ID** — `{id}`", StringComparison.Ordinal);
+            Assert.True(anchor >= 0,
+                $"deferral '{id}' (in ExpectedPriorities) has no entry in docs/deferrals.md.");
+            // The entry's own section runs from its ID anchor to the next `## ` heading.
+            var nextSection = content.IndexOf("\n## ", anchor, StringComparison.Ordinal);
+            var section = nextSection < 0
+                ? content.Substring(anchor)
+                : content.Substring(anchor, nextSection - anchor);
+            Assert.True(
+                section.Contains($"**Priority** — **{level} (", StringComparison.Ordinal),
+                $"deferral '{id}' must declare Priority '{level}' (schema label " +
+                $"'{PriorityLabels[level]}'), but its entry does not. Update the entry or ExpectedPriorities.");
+        }
     }
 
     private static string LoadDeferralsDoc()

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -64,6 +64,8 @@ public sealed class DeferralsParityTests
         "abspos-cycle-1-explicit-only",
         "fixed-cycle-1",
         "layout-to-pdf-pipeline",
+        "visual-regression-cross-engine-tolerance",
+        "ci-nonblocking-platform-native-deps",
     };
 
     [Fact]


### PR DESCRIPTION
Adds the two open items from this cycle to `docs/deferrals.md` as proper deferral entries, each with a new optional **Priority** field (P1/P2/P3 by pickup value) so the backlog can be worked value-first.

- **`visual-regression-cross-engine-tolerance`** (P2) — the gate is inert; `Δ<4 / SSIM≥0.98` is an engine-vs-*self* regression spec and is unachievable cross-engine (NetPdf vs Chrome → `maxΔ≈255`, `SSIM≈0.958` even when the layout is pixel-correct — verified by fixing `01-classic`'s float/clear overlap without moving the SSIM). Needs a cross-engine SSIM floor (~0.90) + committed references.
- **`ci-nonblocking-platform-native-deps`** (P3) — the `linux-arm64` + `alpine-musl` non-blocking legs fail on SkiaSharp native-dep gaps (arm64: `libuuid`; alpine: raster-fallback native + fonts).

Schema preamble now documents `Priority` as optional; both IDs added to `DeferralsParityTests.ExpectedDeferralIds` (parity test green). No behavior change.

Left open for review — not admin-merged.