### PR TITLE
chore(release): NetPdf 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to NetPdf are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
-Post-`1.0.0` improvements accumulate here until the next release is cut.
+Post-`1.0.1` improvements accumulate here until the next release is cut.
+
+## [1.0.1]
+
+A patch release: layout fixes for auto-height floats around page breaks, plus repository and release hygiene. No public API changes.
+
+### Fixed
+- **Auto-height float sizing in the break planner.** The break-planning pre-check now content-sizes an auto-height float, so a float taller than the remaining space on a page defers to a fresh page instead of overflowing it. (#314, #316)
+- **`clear` after a float.** An inline-only (text) block with `clear` now resolves clearance correctly and no longer overlaps a preceding auto-height float. (#314, #316)
 
 ## [1.0.0]
 
@@ -56,5 +64,6 @@ The first stable release. `HtmlPdf.Convert(html)` runs the full HTML → CSS →
 - Single `NetPdf` NuGet package bundling the whole engine; optional `NetPdf.Languages.*` hyphenation add-ons.
 - Source Link + symbol packages for source-stepping.
 
-[Unreleased]: https://github.com/raroche/NetPdf/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/raroche/NetPdf/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/raroche/NetPdf/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/raroche/NetPdf/compare/0.9.0-rc1...v1.0.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,7 +76,7 @@
       doesn't parse XML; if they ever disagree, this file wins for what NuGet
       actually packs. Bump protocol: update BOTH files, commit, then `git tag`.
     -->
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 
     <!-- Symbols & Source Link: enable source-stepping for downstream consumers. -->
@@ -99,7 +99,9 @@
       any accidental public-API break vs. the last release.
     -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion> set at v1.0.1 -->
+    <!-- Enabled at v1.0.1 (1.0.0 is published on nuget.org): fail the build on any accidental
+         public-API break vs. the last release. -->
+    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
 
     <!-- NuGet client requirement. -->
     <MinClientVersion>5.0.0</MinClientVersion>

--- a/build/version.json
+++ b/build/version.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "phase": 5,
   "phaseDescription": "Packaging & release (v1.0 launch)",
   "publicApiFrozen": true,
-  "lastUpdated": "2026-07-06",
+  "lastUpdated": "2026-07-09",
   "_note": "Informational only. The MSBuild source-of-truth is Directory.Build.props (VersionPrefix + VersionSuffix). When bumping versions, update BOTH files together, then create the git tag. ReleaseVersionParityTests guards that this file, Directory.Build.props, and the CHANGELOG's latest version heading agree. Phase 5 will introduce a small MSBuild task that reads this file directly."
 }

--- a/tests/NetPdf.UnitTests/HtmlPdfFacadeTests.cs
+++ b/tests/NetPdf.UnitTests/HtmlPdfFacadeTests.cs
@@ -40,9 +40,10 @@ public sealed class HtmlPdfFacadeTests
         // ReleaseVersionParityTests guards that this matches Directory.Build.props +
         // build/version.json + the CHANGELOG's latest version heading.
         // Pin the EXACT version (start + an optional `+build` metadata boundary or end) — a loose Contains
-        // would also pass `1.0.00` or an unrelated string carrying the fragment (PR-258 Copilot). The 1.0.0
-        // launch release drops the prerelease suffix.
-        Assert.Matches(@"^1\.0\.0(\+.*)?$", version);
+        // would also pass `1.0.10` or an unrelated string carrying the fragment (PR-258 Copilot). Stable
+        // releases from 1.0.0 on carry no prerelease suffix. Bump this on each release (guarded by
+        // ReleaseVersionParityTests, which keeps the three version surfaces in agreement).
+        Assert.Matches(@"^1\.0\.1(\+.*)?$", version);
     }
 
     [Fact]


### PR DESCRIPTION
## Release NetPdf 1.0.1

Patch release cutting **1.0.1** off `main` (HEAD includes #313–#316).

### Version surfaces bumped (guarded by `ReleaseVersionParityTests`)
- `Directory.Build.props` `VersionPrefix` → `1.0.1`
- `build/version.json` → `1.0.1`
- `CHANGELOG.md` → new `## [1.0.1]` entry + re-based compare links

### Shipped changes since 1.0.0 (user-facing)
- **Fixed:** auto-height float sizing in the break planner — a too-tall float defers to a fresh page instead of overflowing (#314, #316).
- **Fixed:** inline-only (text) block with `clear` resolves clearance and no longer overlaps a preceding float (#314, #316).

No public API changes (`src/NetPdf/` unchanged vs `v1.0.0`).

### Package validation
Enables `PackageValidationBaselineVersion=1.0.0` (documented "set at v1.0.1" plan; all six packages exist on nuget.org at 1.0.0). Verified locally: `dotnet pack` emits all 6 packages at 1.0.1 with baseline validation passing.

### After merge
Tag `v1.0.1` on the merge commit → `release.yml` `validate` runs, then `publish` waits on the `nuget-release` environment approval before pushing to nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)