### PR TITLE
docs: drop Prince/WeasyPrint comparison + external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Every existing free option for .NET fails one or more critical criteria:
 
 NetPdf fills the gap: **truly free, truly forever, truly open source.**
 
-Its direction is closer to **Prince**, **WeasyPrint**, **OpenHTMLtoPDF** than to Playwright/Puppeteer/wkhtmltopdf — layout-engine first, paint-engine second, PDF byte-writer third — all built from scratch using public W3C / Unicode / ISO specifications under a [clean-room policy](https://github.com/raroche/NetPdf/blob/main/docs/clean-room-policy.md).
+It is a print-focused document engine rather than a screen-rendering wrapper — layout-engine first, paint-engine second, PDF byte-writer third — all built from scratch using public W3C / Unicode / ISO specifications under a [clean-room policy](https://github.com/raroche/NetPdf/blob/main/docs/clean-room-policy.md).
 
 ## Using the API
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -5,8 +5,8 @@ _layout: landing
 # NetPdf
 
 **Pure C# / .NET 10 HTML + CSS → PDF.** No browser, no native Chromium, no subprocess at render time, no
-AGPL or revenue-capped dependencies. Apache-2.0. Direction: [Prince](https://www.princexml.com/) /
-[WeasyPrint](https://weasyprint.org/), not Playwright / wkhtmltopdf.
+AGPL or revenue-capped dependencies. Apache-2.0. A real HTML/CSS layout engine built for print and paged
+media — rendered straight to PDF, not driven through a headless browser.
 
 NetPdf ships its own HTML/CSS layout engine — block / inline / flex / grid / table layout, fragmentation
 across pages, international text shaping (HarfBuzz), a bounded "least-ugly page split" pagination cost model,


### PR DESCRIPTION
Removes the Prince / WeasyPrint reference — and the external links to `princexml.com` / `weasyprint.org` — from the two public-facing surfaces:

- **`docs-site/index.md`** — the GitHub Pages landing (https://raroche.github.io/NetPdf/). The `Direction: [Prince](…) / [WeasyPrint](…)` line (with external links) is replaced by link-free wording.
- **`README.md`** — the "closer to Prince, WeasyPrint, OpenHTMLtoPDF than to Playwright…" sentence is reworded to describe the print/paged-media direction without naming any third-party engine.

Neither replacement links to any external page or service.

Not touched (no links, not public-facing — technical/clean-room rationale citing prior-art behavior): a few code comments (`MulticolLayouter`, `BidiAlgorithm`, `ComputedStyleLayoutExtensions`), `docs/clean-room-policy.md` (lists engines devs may read for understanding), `docs/deferrals.md`, `docs/authoring-html-for-pdf.md`, and the test-corpus `Invoices/README.md`. Say the word if you want those scrubbed too.

Merging to `main` triggers `docs.yml`, which redeploys the Pages site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)