### PR TITLE
docs: add an honest "rendering fidelity" positioning note

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ NetPdf fills the gap: **truly free, truly forever, truly open source.**
 
 It is a print-focused document engine rather than a screen-rendering wrapper — layout-engine first, paint-engine second, PDF byte-writer third — all built from scratch using public W3C / Unicode / ISO specifications under a [clean-room policy](https://github.com/raroche/NetPdf/blob/main/docs/clean-room-policy.md).
 
+## Rendering fidelity — what to expect
+
+NetPdf does **not** aim to render identically to a web browser, and it deliberately doesn't try to. It is a print- and paged-media engine: its purpose is to turn document-shaped HTML and CSS into well-formed, deterministic PDFs, not to reproduce a browser's on-screen rendering pixel-for-pixel.
+
+For the content it is built for — invoices, statements, reports, letters, certificates, and similar documents — NetPdf targets **close visual parity with a browser's _print_ output** (the result of the browser's "Print → Save as PDF"), which is a different and more constrained target than interactive on-screen layout.
+
+Accordingly, "renders identically to any browser" is not a claim NetPdf makes. Screen-oriented or interactive layouts, scripted content, and pixel-exact matching of a specific browser engine are out of scope. Where a feature falls outside that scope, NetPdf emits a stable, structured [diagnostic](https://github.com/raroche/NetPdf/blob/main/docs/diagnostics-codes.md) rather than silently approximating or dropping content — so the places where output differs are explicit, not surprising.
+
 ## Using the API
 
 The public surface is the single static `HtmlPdf` facade plus a small set of option/result types (namespace `NetPdf`). Every overload below returns real PDF bytes for the full feature set — layout, pagination, paged media, text shaping, images, and visual parity (gradients, shadows, transforms, filters, SVG). Unsupported features emit a stable structured diagnostic rather than throwing or silently dropping content.

--- a/docs-site/compatibility.md
+++ b/docs-site/compatibility.md
@@ -5,6 +5,22 @@ paged output — not parity with an interactive browser. This page summarizes wh
 authoritative, feature-by-feature matrix is
 [`docs/compatibility-matrix.md`](https://github.com/raroche/NetPdf/blob/main/docs/compatibility-matrix.md).
 
+## Rendering fidelity — what to expect
+
+NetPdf does **not** aim to render identically to a web browser, and it deliberately doesn't try to. It is a
+print- and paged-media engine: its purpose is to turn document-shaped HTML and CSS into well-formed,
+deterministic PDFs, not to reproduce a browser's on-screen rendering pixel-for-pixel.
+
+For the content it is built for — invoices, statements, reports, letters, certificates, and similar
+documents — NetPdf targets **close visual parity with a browser's _print_ output** (the result of the
+browser's "Print → Save as PDF"), a different and more constrained target than interactive on-screen layout.
+
+"Renders identically to any browser" is therefore not a claim NetPdf makes. Screen-oriented or interactive
+layouts, scripted content, and pixel-exact matching of a specific browser engine are out of scope. Where a
+feature falls outside that scope, NetPdf emits a stable, structured [diagnostic](diagnostics.md) rather than
+silently approximating or dropping content, so the places where output differs are explicit rather than
+surprising.
+
 ## Status legend
 
 | | Meaning |

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -10,6 +10,12 @@ This document is the authoritative answer to "does NetPdf support feature X?" Up
 
 ---
 
+## Rendering fidelity
+
+NetPdf does **not** aim to render identically to a web browser, and deliberately does not try to. It is a print- and paged-media engine: it turns document-shaped HTML/CSS into well-formed, deterministic PDFs rather than reproducing a browser's on-screen rendering pixel-for-pixel. For the documents it targets (invoices, statements, reports, letters, certificates), it aims for **close visual parity with a browser's _print_ output** ("Print → Save as PDF") — not with interactive on-screen layout, and not with a specific browser engine byte-for-byte. Anything outside that scope is marked ❌ below and emits a diagnostic rather than being silently approximated or dropped.
+
+---
+
 ## HTML
 
 | Feature | Status | Notes |


### PR DESCRIPTION
Adds a professionally-worded **"Rendering fidelity — what to expect"** note in three places so the positioning is honest and consistent:

- **`README.md`** — new `## Rendering fidelity` section.
- **`docs-site/compatibility.md`** — new section (surfaces on the Pages site, next to the in/out-of-scope tables).
- **`docs/compatibility-matrix.md`** — a short preamble in the authoritative matrix.

**The point it makes:** NetPdf is a print/paged-media engine and deliberately does **not** try to render identically to a browser. For document-shaped content it targets **close visual parity with a browser's _print_ output** ("Print → Save as PDF"); interactive/on-screen layout, scripted content, and byte-for-byte matching of a specific browser engine are out of scope and emit a structured diagnostic rather than silently approximating or dropping content.

Consistent with the prior change, the note **names no third-party engine** and adds **no external links** — only self-repo / internal doc references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)