### PR TITLE
fix(deps): revert Microsoft.CodeAnalysis to 4.11.0 (Roslyn build-floor)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,8 +41,15 @@
 
   <!-- Roslyn / source generator infrastructure. -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <!--
+      Pinned to a Roslyn version the source generator (NetPdf.SourceGen) can reference without forcing a
+      newer compiler than the build SDK ships. Dependabot's bump to 5.6.0 passed CI (runner SDK shipped
+      Roslyn 5.6+) but broke `dotnet build` on any SDK whose compiler is older (CS9057: "analyzer references
+      a newer compiler than the currently running version"). Bump only in lockstep with the minimum
+      supported .NET SDK — not to the latest Roslyn. Reverts PR #331.
+    -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
   </ItemGroup>
 
   <!-- Build infrastructure. -->


### PR DESCRIPTION
Reverts the CodeAnalysis bump from #331 (`CodeAnalysis.CSharp` 4.11.0→5.6.0, `Analyzers` 3.11.0→5.3.0).

**Why:** #331 passed CI (the runner's `10.0.x` SDK shipped Roslyn ≥ 5.6), but it makes the repo un-buildable on any SDK whose compiler is older:

```
error CS9057: Analyzer assembly 'NetPdf.SourceGen.dll' cannot be used because it references
version '5.6.0.0' of the compiler, which is newer than the currently running version '5.3.0.0'.
```

`NetPdf.SourceGen` (a build-time source generator) must reference a Roslyn **no newer than the minimum supported build SDK** — that's why `CodeAnalysis.CSharp` was pinned at `4.11.0`. Reproduced locally: `dotnet build` fails with 5.6.0 and succeeds after reverting.

The other four Dependabot merges from this batch (#317, #318, #320, #333) are unaffected and stay. This keeps SourceLink at 10.0.300 (#333), which is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)