### PR TITLE
ci(deps): bump artifact + pages actions to latest (paired)

### DIFF
--- a/.github/workflows/capture-benchmark-baseline.yml
+++ b/.github/workflows/capture-benchmark-baseline.yml
@@ -38,7 +38,7 @@ jobs:
           echo "--- git status ---"
           git status --short
       - name: Upload the linux-x64 baseline for the maintainer to commit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-baseline-linux-x64
           path: tests/NetPdf.Benchmarks/baselines/phase-1-linux-x64/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,7 +68,7 @@ jobs:
         run: dotnet docfx docs-site/docfx.json --warningsAsErrors
       - name: Upload Pages artifact
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/_site
 
@@ -90,4 +90,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/generate-visual-references.yml
+++ b/.github/workflows/generate-visual-references.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Show the generated references
         run: ls -la tests/NetPdf.RenderingCorpus/references/
       - name: Upload the reference PNGs for the maintainer to review + commit
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: visual-references
           path: tests/NetPdf.RenderingCorpus/references/*.png

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           ls -1 artifacts/
 
       - name: Upload packages for the publish job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: |
@@ -128,7 +128,7 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Download the validated packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nuget-packages
           path: artifacts


### PR DESCRIPTION
Does the workflow-action bumps I held during the Dependabot review, but **paired** so no action-version mismatch is introduced:

| Action | From | To | Files |
|--------|------|----|-------|
| actions/upload-artifact | v4 | **v7** | release.yml, generate-visual-references.yml, capture-benchmark-baseline.yml |
| actions/download-artifact | v4 | **v8** | release.yml |
| actions/upload-pages-artifact | v3 | **v5** | docs.yml |
| actions/deploy-pages | v4 | **v5** | docs.yml |

- Pairs upload/download-artifact together (addresses the mismatch that held **#319**).
- Pairs the two Pages actions together (supersedes **#321/#322**).

**Validation:** the Pages actions are exercised by the `docs.yml` deploy on merge to main (I'll verify the deploy); the `release.yml` artifact actions are exercised by the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)