### PR TITLE
chore(release): NetPdf 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to NetPdf are documented here. The format follows [Keep a Ch
 
 ## [Unreleased]
 
-Post-`1.0.1` improvements accumulate here until the next release is cut.
+Post-`1.0.2` improvements accumulate here until the next release is cut.
+
+## [1.0.2]
+
+A maintenance release: dependency updates only. No functional or public API changes, and output is byte-for-byte unchanged (all rendering goldens are identical).
+
+### Changed
+- Updated bundled native/runtime dependencies to their latest patch releases: **SkiaSharp** 3.119.4 and **HarfBuzzSharp** 8.3.1.5.
+- Updated build and test tooling (test SDK, analyzers pin, CI actions).
 
 ## [1.0.1]
 
@@ -64,6 +72,7 @@ The first stable release. `HtmlPdf.Convert(html)` runs the full HTML → CSS →
 - Single `NetPdf` NuGet package bundling the whole engine; optional `NetPdf.Languages.*` hyphenation add-ons.
 - Source Link + symbol packages for source-stepping.
 
-[Unreleased]: https://github.com/raroche/NetPdf/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/raroche/NetPdf/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/raroche/NetPdf/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/raroche/NetPdf/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/raroche/NetPdf/compare/0.9.0-rc1...v1.0.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,7 +76,7 @@
       doesn't parse XML; if they ever disagree, this file wins for what NuGet
       actually packs. Bump protocol: update BOTH files, commit, then `git tag`.
     -->
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
 
     <!-- Symbols & Source Link: enable source-stepping for downstream consumers. -->
@@ -99,9 +99,9 @@
       any accidental public-API break vs. the last release.
     -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <!-- Enabled at v1.0.1 (1.0.0 is published on nuget.org): fail the build on any accidental
-         public-API break vs. the last release. -->
-    <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
+    <!-- Baseline = the previous published release (must exist on nuget.org): fail the build on any
+         accidental public-API break vs. that release. Bump this to <prev> on each release. -->
+    <PackageValidationBaselineVersion>1.0.1</PackageValidationBaselineVersion>
 
     <!-- NuGet client requirement. -->
     <MinClientVersion>5.0.0</MinClientVersion>

--- a/build/version.json
+++ b/build/version.json
@@ -1,8 +1,8 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "phase": 5,
   "phaseDescription": "Packaging & release (v1.0 launch)",
   "publicApiFrozen": true,
-  "lastUpdated": "2026-07-09",
+  "lastUpdated": "2026-07-10",
   "_note": "Informational only. The MSBuild source-of-truth is Directory.Build.props (VersionPrefix + VersionSuffix). When bumping versions, update BOTH files together, then create the git tag. ReleaseVersionParityTests guards that this file, Directory.Build.props, and the CHANGELOG's latest version heading agree. Phase 5 will introduce a small MSBuild task that reads this file directly."
 }

--- a/tests/NetPdf.UnitTests/HtmlPdfFacadeTests.cs
+++ b/tests/NetPdf.UnitTests/HtmlPdfFacadeTests.cs
@@ -43,7 +43,7 @@ public sealed class HtmlPdfFacadeTests
         // would also pass `1.0.10` or an unrelated string carrying the fragment (PR-258 Copilot). Stable
         // releases from 1.0.0 on carry no prerelease suffix. Bump this on each release (guarded by
         // ReleaseVersionParityTests, which keeps the three version surfaces in agreement).
-        Assert.Matches(@"^1\.0\.1(\+.*)?$", version);
+        Assert.Matches(@"^1\.0\.2(\+.*)?$", version);
     }
 
     [Fact]


### PR DESCRIPTION
Cuts **1.0.2**, a maintenance release carrying the dependency + CI updates from #339 and #340.

### Version surfaces (guarded by `ReleaseVersionParityTests`)
- `Directory.Build.props` `VersionPrefix` → `1.0.2`
- `build/version.json` → `1.0.2`
- `CHANGELOG.md` → new `## [1.0.2]` entry + re-based compare links
- `PackageValidationBaselineVersion` `1.0.0` → `1.0.1`
- Facade version-pin test → `1.0.2`

### Contents of the release (once #339 + #340 land)
- **Changed:** bundled native deps to latest patches (SkiaSharp 3.119.4, HarfBuzzSharp 8.3.1.5); build/test tooling + CI actions.
- **No functional or public-API changes** — output is byte-for-byte unchanged (all goldens identical). AngleSharp is intentionally held (see #339).

Verified locally: parity + facade version tests green; `dotnet pack` validates the public surface clean against the 1.0.1 baseline.

**After merge:** tag `v1.0.2` → `release.yml` validates + publishes (gated on the `nuget-release` environment approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)