### PR TITLE
ci: promote linux-arm64 + alpine-musl to enforcing; close the native-deps deferral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
     # the Windows leg honors LD_PRELOAD and aborts if the named lib is absent.
     #
     # Enforcing matrix: linux-x64, linux-arm64, windows-x64, macos-arm64 (+ the alpine job below).
+    # CAVEAT: "enforcing" here means a failure turns the WORKFLOW red. It does not block a merge until
+    # the check is also listed in branch protection's required contexts — a repo SETTING, not something a
+    # PR can change. `build+test (linux-arm64)`, `build+test (alpine-musl-x64)` and
+    # `benchmark gate (linux-x64)` are not required yet; tracked as deferral
+    # `ci-branch-protection-required-contexts` in docs/deferrals.md (with the exact gh command).
     continue-on-error: ${{ matrix.nonblocking == true }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,28 +24,30 @@ jobs:
     name: build+test (${{ matrix.label }}${{ matrix.nonblocking && ', non-blocking' || '' }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
-    # Two matrix legs are NON-BLOCKING (continue-on-error via a `nonblocking: true` flag) — they run and
-    # surface status but don't gate merge. Both are tracked as Phase-5 remainders in docs/deferrals.md:
-    #   linux-arm64 → deferral `ci-nonblocking-platform-native-deps` (also covers the alpine leg below);
-    #   macos-x64   → deferral `ci-nonblocking-macos-x64-runner-availability`.
-    #   * linux-arm64 — SkiaSharp's raster-fallback native (libSkiaSharp) on the arm64 image is
-    #     under-provisioned: it resolves symbols from the *system* libuuid / libfreetype the runner doesn't
-    #     satisfy (undefined uuid_generate_random, then — once libuuid is preloaded — FT_Get_BDF_Property).
-    #     Chasing these per-symbol isn't reproducible on the macOS/x64 dev box; the real fix is to harden the
-    #     arm64 native (e.g. the self-contained NoDependencies SkiaSharp asset) on a real arm64 runner. NOTE:
-    #     do NOT set a matrix-wide LD_PRELOAD to paper over it — Git Bash (Cygwin) on the Windows leg honors
-    #     LD_PRELOAD and aborts if the named lib is absent.
-    #   * macos-x64 (macos-13) — GitHub is deprecating the Intel-mac hosted runners; the leg is chronically
-    #     unschedulable (stays queued for the whole timeout). macos-arm64 provides the enforcing macOS
-    #     coverage; Intel-mac is best-effort until a runner is available.
-    # Enforcing matrix: linux-x64, windows-x64, macos-arm64.
+    # ONE matrix leg is NON-BLOCKING (continue-on-error via a `nonblocking: true` flag) — it runs and
+    # surfaces status but doesn't gate merge:
+    #   * macos-x64 (macos-13) → deferral `ci-nonblocking-macos-x64-runner-availability`. GitHub is
+    #     deprecating the Intel-mac hosted runners; the leg is chronically unschedulable (stays queued for
+    #     the whole timeout). macos-arm64 provides the enforcing macOS coverage; Intel-mac is best-effort
+    #     until a runner is available.
+    #
+    # linux-arm64 is now ENFORCING (PR #357, closing deferral `ci-nonblocking-platform-native-deps`).
+    # It was non-blocking because libSkiaSharp on the arm64 image resolved symbols from a system
+    # libuuid/libfreetype the runner didn't satisfy (undefined uuid_generate_random, then
+    # FT_Get_BDF_Property). That is fixed: the fontconfig-hardening step below plus the SkiaSharp 4.150.1
+    # bump (#355) load the native cleanly, and the leg's only remaining failures were two font-dependent
+    # ASSERTIONS — not native loading — fixed in #356. It has since run the full suite green.
+    # NOTE: do NOT set a matrix-wide LD_PRELOAD to paper over any future symbol gap — Git Bash (Cygwin) on
+    # the Windows leg honors LD_PRELOAD and aborts if the named lib is absent.
+    #
+    # Enforcing matrix: linux-x64, linux-arm64, windows-x64, macos-arm64 (+ the alpine job below).
     continue-on-error: ${{ matrix.nonblocking == true }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - { os: ubuntu-latest,   label: linux-x64,   aot: true }
-          - { os: ubuntu-24.04-arm, label: linux-arm64, aot: true, nonblocking: true }
+          - { os: ubuntu-24.04-arm, label: linux-arm64, aot: true }
           - { os: windows-latest,  label: windows-x64, aot: true }
           - { os: macos-14,        label: macos-arm64, aot: true }
           - { os: macos-13,        label: macos-x64,   aot: true, nonblocking: true }
@@ -89,18 +91,16 @@ jobs:
         run: bash scripts/aot-parity.sh
 
   # T1/T2 — Alpine (musl) build + test + AOT, inside the pinned .NET SDK container.
-  # BEST-EFFORT / NON-BLOCKING (continue-on-error): the SkiaSharp raster-fallback native
-  # (libSkiaSharp) fails to load under musl on the stock SDK-alpine image — a pre-existing
-  # environment gap that needs hardening on a real Alpine runner (musl native-asset + font
-  # deps), not reproducible on the macOS/glibc dev box. Until that's hardened the leg runs and
-  # surfaces its status but does not gate merge; the ENFORCING matrix is exactly three legs —
-  # linux-x64, windows-x64, macos-arm64 — while linux-arm64 and macos-x64 (above) plus this alpine
-  # leg are the three NON-BLOCKING legs. Tracked as a known CI-hardening remainder: docs/deferrals.md
-  # deferral `ci-nonblocking-platform-native-deps`.
+  # ENFORCING since PR #357 (closing deferral `ci-nonblocking-platform-native-deps`). This leg was
+  # best-effort because the SkiaSharp raster-fallback native (libSkiaSharp) was believed not to load under
+  # musl on the stock SDK-alpine image. That premise no longer holds: with the apk prerequisites below the
+  # native loads and the full suite runs, and the leg's only remaining failures were two font-dependent
+  # ASSERTIONS — not native loading — fixed in #356. It has since run green.
+  # Enforcing legs: linux-x64, linux-arm64, windows-x64, macos-arm64, alpine-musl-x64. The only
+  # non-blocking leg left is macos-x64 (runner availability — see the note on the matrix above).
   build-test-alpine:
-    name: build+test (alpine-musl-x64, non-blocking)
+    name: build+test (alpine-musl-x64)
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 40
     container: mcr.microsoft.com/dotnet/sdk:10.0-alpine
     steps:

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -3977,37 +3977,6 @@ grepping the ID).
 
 
 
-## ci-nonblocking-platform-native-deps
-
-- **ID** — `ci-nonblocking-platform-native-deps`
-- **Status** — `not-started`. The two NATIVE-DEPENDENCY legs (`linux-arm64` +
-  `alpine-musl-x64`) are `continue-on-error: true` (non-blocking) and currently fail
-  at the Test step. (The third non-blocking leg, `macos-x64`, is a distinct
-  runner-availability issue tracked separately as
-  [`ci-nonblocking-macos-x64-runner-availability`](#ci-nonblocking-macos-x64-runner-availability).)
-- **Priority** — **P3 (low).** These are the two NON-enforcing native-dep RIDs; the
-  enforcing matrix (`linux-x64`, `windows-x64`, `macos-arm64`) already covers the
-  shipping platforms, so this is platform-coverage confidence, not a correctness
-  gate. Bump if a customer targets Alpine/arm64.
-- **Behavior** — the `build+test (linux-arm64, non-blocking)` and
-  `build+test (alpine-musl-x64, non-blocking)` CI legs run but don't gate merge.
-  They fail at the Test step on SkiaSharp/HarfBuzz native-dependency gaps in those
-  runner images (fontconfig + font packs were added; the next gap surfaces after
-  each fix).
-- **Missing** — the remaining native deps for the SkiaSharp text stack on those
-  platforms. **arm64** (ubuntu-24.04-arm): `libSkiaSharp.so: undefined symbol:
-  uuid_generate_random` → install `libuuid1` (and whatever the next symbol needs).
-  **alpine** (musl): the raster-fallback native (`libSkiaSharp`) load + any font
-  deps beyond the added `ttf-dejavu`/`freetype`/`fontconfig`. Iterative: each fix
-  tends to reveal the next missing lib.
-- **Trigger** — a decision to make the two extra RIDs green (or enforcing), OR a
-  customer running on Alpine / Linux-arm64 hits a native-load failure.
-- **Owner files** — `.github/workflows/ci.yml` (the `build-test` arm64-scoped
-  install step + the `build-test-alpine` `apk add` step).
-- **Removal condition** — both non-blocking legs pass the Test step in CI (green).
-
-
-
 ## ci-nonblocking-macos-x64-runner-availability
 
 - **ID** — `ci-nonblocking-macos-x64-runner-availability`
@@ -4016,9 +3985,10 @@ grepping the ID).
   stays queued for the whole timeout rather than failing on a test.
 - **Priority** — **P3 (low).** `macos-arm64` provides the enforcing macOS coverage;
   Intel-mac is best-effort. This is a hosted-runner-availability gap, not a
-  NetPdf correctness or native-dependency issue — distinct from
-  [`ci-nonblocking-platform-native-deps`](#ci-nonblocking-platform-native-deps)
-  (which is about missing SkiaSharp/HarfBuzz native libs on arm64/alpine).
+  NetPdf correctness or native-dependency issue — nothing in the repo can fix it,
+  which is why it is the ONLY non-blocking leg left after `linux-arm64` and
+  `alpine-musl-x64` became enforcing (PR #357, which closed the former
+  `ci-nonblocking-platform-native-deps` deferral).
 - **Behavior** — the `build+test (macos-x64, non-blocking)` CI leg runs but doesn't
   gate merge. GitHub is deprecating the Intel-mac hosted runners, so the leg is
   routinely unschedulable and stays queued until the workflow timeout.

--- a/docs/deferrals.md
+++ b/docs/deferrals.md
@@ -4001,3 +4001,51 @@ grepping the ID).
   `include` entry + its `nonblocking: true` flag).
 - **Removal condition** — the `macos-x64` leg either schedules + passes reliably in
   CI, or is removed from the matrix (with this entry deleted in the same commit).
+
+
+
+## ci-branch-protection-required-contexts
+
+- **ID** — `ci-branch-protection-required-contexts`
+- **Status** — `not-started`. Three CI checks are WORKFLOW-enforcing (a failure turns
+  the run red) but not MERGE-enforcing, because branch protection's
+  `required_status_checks.contexts` on `main` has not been updated to list them.
+- **Priority** — **P2 (medium).** This is the gap between "CI says no" and "GitHub
+  won't let it merge". Two of the three are freshly promoted platform legs, but the
+  third is the PERFORMANCE gate — until it is required, a genuine perf regression
+  reports red and still merges, which silently weakens the performance contract in
+  `CLAUDE.md`. Not P1 only because the enforcing legs still surface the failure
+  loudly on the PR.
+- **Behavior** — `main` currently requires exactly: `build+test (linux-x64)`,
+  `build+test (windows-x64)`, `build+test (macos-arm64)`, `security-gate`,
+  `dependency-scan`. The following run and can fail the workflow, but do not block a
+  merge:
+  - `build+test (linux-arm64)` — promoted to enforcing in PR #357.
+  - `build+test (alpine-musl-x64)` — promoted to enforcing in PR #357.
+  - `benchmark gate (linux-x64)` — has measured again since PR #356 (before that it
+    aborted during restore, so it was never a gate at all).
+- **Missing** — a repository-settings change; there is nothing to change in the repo.
+  Adding the three contexts (alongside the five existing ones — the API REPLACES the
+  list, so all eight must be sent):
+  ```bash
+  gh api -X PATCH repos/raroche/NetPdf/branches/main/protection/required_status_checks \
+    -f 'contexts[]=build+test (linux-x64)' \
+    -f 'contexts[]=build+test (windows-x64)' \
+    -f 'contexts[]=build+test (macos-arm64)' \
+    -f 'contexts[]=build+test (linux-arm64)' \
+    -f 'contexts[]=build+test (alpine-musl-x64)' \
+    -f 'contexts[]=benchmark gate (linux-x64)' \
+    -f 'contexts[]=security-gate' \
+    -f 'contexts[]=dependency-scan'
+  ```
+  NOTE: context names must match the rendered job names EXACTLY. PR #357 renamed two
+  of them by dropping the `", non-blocking"` suffix, so the old names will never
+  report again — do not re-add them.
+- **Trigger** — the maintainer applies the settings change (it needs admin rights on
+  the repo, so it cannot land through a PR), OR a red enforcing leg is merged past
+  and causes a regression on `main`.
+- **Owner files** — none in-repo. Repository settings only:
+  Settings → Branches → `main` → "Require status checks to pass".
+- **Removal condition** — `gh api repos/raroche/NetPdf/branches/main/protection`
+  lists all three contexts under `required_status_checks.contexts` (delete this entry
+  in the same commit).

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -71,6 +71,11 @@ public sealed class DeferralsParityTests
         // alpine-musl-x64 are now enforcing. macos-x64 stays deferred — a runner-availability
         // gap nothing in this repo can fix.
         "ci-nonblocking-macos-x64-runner-availability",
+        // PR #357 review [P2]: promoting the two native legs made them WORKFLOW-enforcing but not
+        // MERGE-enforcing, and deleting the old deferral removed the only thing tracking that gap.
+        // This entry holds it (plus the still-unrequired benchmark gate) until branch protection is
+        // updated — a repo SETTING, so it cannot land through a PR.
+        "ci-branch-protection-required-contexts",
     };
 
     [Fact]
@@ -158,6 +163,7 @@ public sealed class DeferralsParityTests
     {
         ["visual-regression-cross-engine-tolerance"] = "P2",
         ["ci-nonblocking-macos-x64-runner-availability"] = "P3",
+        ["ci-branch-protection-required-contexts"] = "P2",
     };
 
     /// <summary>The documented label for each level (schema: `P1` high / `P2` medium / `P3` low).</summary>

--- a/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
+++ b/tests/NetPdf.UnitTests/Docs/DeferralsParityTests.cs
@@ -66,7 +66,10 @@ public sealed class DeferralsParityTests
         "fixed-cycle-1",
         "layout-to-pdf-pipeline",
         "visual-regression-cross-engine-tolerance",
-        "ci-nonblocking-platform-native-deps",
+        // `ci-nonblocking-platform-native-deps` was picked up in PR #357: its removal condition
+        // ("both non-blocking legs pass the Test step in CI") is met, so linux-arm64 +
+        // alpine-musl-x64 are now enforcing. macos-x64 stays deferred — a runner-availability
+        // gap nothing in this repo can fix.
         "ci-nonblocking-macos-x64-runner-availability",
     };
 
@@ -154,7 +157,6 @@ public sealed class DeferralsParityTests
     private static readonly System.Collections.Generic.Dictionary<string, string> ExpectedPriorities = new()
     {
         ["visual-regression-cross-engine-tolerance"] = "P2",
-        ["ci-nonblocking-platform-native-deps"] = "P3",
         ["ci-nonblocking-macos-x64-runner-availability"] = "P3",
     };
 


### PR DESCRIPTION
Picks up the `ci-nonblocking-platform-native-deps` deferral. **Its own removal condition — "both non-blocking legs pass the Test step in CI (green)" — is now met**, and the premise it was written on is obsolete.

## Why the premise no longer holds

The deferral described a genuine native-loading failure:

- **arm64** — `libSkiaSharp.so: undefined symbol: uuid_generate_random`, then `FT_Get_BDF_Property` once libuuid was preloaded
- **alpine (musl)** — the raster-fallback native failing to load at all

That is fixed. The fontconfig-hardening step and the `apk` prerequisites, together with the **SkiaSharp 4.150.1** bump in #355, load the native cleanly.

The decisive evidence is what those legs were actually doing while still labelled red: **8604 of 8609 tests passing**, with the only two failures being font-dependent *assertions* in `AutoHeightFlexTimelineFooterTests` — never a native-load error. Those were fixed in #356, and both legs have since run the full suite green:

| Leg | Before #356 | Now |
|---|---|---|
| `linux-arm64` | fail (2 assertions, 8604 passing) | **pass** |
| `alpine-musl-x64` | fail (same 2 assertions) | **pass** |

## Changes

- `linux-arm64` loses `nonblocking: true`; the alpine job loses `continue-on-error: true`. Both are **renamed** as a result — the `", non-blocking"` suffix is part of the check name. Neither name is in branch protection's required contexts today, so **no existing required check breaks**.
- `macos-x64` stays non-blocking and keeps its own separate deferral: hosted Intel-mac runner availability, which nothing in this repo can fix. It is now the only non-blocking leg.
- The deferral is removed from `docs/deferrals.md` and `DeferralsParityTests` (the documented convention for picking one up), and the `macos-x64` entry's cross-reference is rewritten so it no longer points at a deleted anchor.
- Stale rationale comments in `ci.yml` replaced with what is actually true now.

## Maintainer action still needed

Making these legs enforcing turns the **workflow** red on failure, but it does **not block a merge** until the two renamed contexts are added to branch protection's required checks:

- `build+test (linux-arm64)`
- `build+test (alpine-musl-x64)`

Worth doing alongside **`benchmark gate (linux-x64)`**, which is still not a required check — so even now that it measures again (#356), a genuine perf regression would not block a merge.

## Verification

Build 0 errors · UnitTests **8614 passed / 3 skipped** (including `DeferralsParityTests`, which enforces the doc/ID parity this PR changes) · `git diff --check` clean.

`PROGRESS.md` was rolled too, but it is gitignored — untracked deliberately in #284 as an internal doc — so it stays local and out of this PR.