### PR TITLE
chore(deps): take the safe half of the August bumps; hold AngleSharp

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,14 +20,14 @@
     -->
     <PackageVersion Include="AngleSharp" Version="1.6.0" />
     <PackageVersion Include="AngleSharp.Css" Version="1.0.0-beta.144" />
-    <PackageVersion Include="HarfBuzzSharp" Version="14.2.1.1" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1.1" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.1.1" />
-    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.1.1" />
-    <PackageVersion Include="SkiaSharp" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.150.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.150.1" />
+    <PackageVersion Include="HarfBuzzSharp" Version="14.2.1.2" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1.2" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.1.2" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.1.2" />
+    <PackageVersion Include="SkiaSharp" Version="4.151.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.151.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.151.1" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.151.1" />
   </ItemGroup>
 
   <!-- Test-only dependencies. -->
@@ -38,16 +38,17 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="SharpFuzz" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.62.0" />
     <!-- Visual-regression harness (PR 8): PDFium (via PDFtoImage, ships bblanchon.PDFium native for
-         macOS/Linux/Win) rasterizes the NetPdf PDF -> RGBA; SkiaSharp only WRITES PDF. PDFtoImage 5.2.1
-         declares a SkiaSharp FLOOR of 3.119.2; production intentionally pins 4.150.1 above (PR #355), and
-         NuGet unifies the graph to that single higher version — so the harness still rasterizes against the
-         SAME SkiaSharp the shipped package uses. The tradeoff of the gap: PDFtoImage runs against a SkiaSharp
-         newer than it compiled against, so a removed 3.x API would surface as a runtime MissingMethodException
-         rather than a build break. The RenderingCorpus suite is what proves that hasn't happened — if it ever
-         fails after a SkiaSharp major bump, suspect this gap first. -->
-    <PackageVersion Include="PDFtoImage" Version="5.2.1" />
+         macOS/Linux/Win) rasterizes the NetPdf PDF -> RGBA; SkiaSharp only WRITES PDF.
+         PDFtoImage 5.4.0 declares SkiaSharp 4.150.1, and production pins 4.151.1 just above it, so NuGet
+         unifies the graph on 4.151.1 and the harness rasterizes against the SAME SkiaSharp the shipped
+         package uses. This CLOSES the gap the 5.2.1 entry warned about: that release still declared a
+         3.119.2 floor, so PDFium ran against a SkiaSharp a whole major version newer than it compiled
+         against, where a removed 3.x API would only surface as a runtime MissingMethodException. The
+         remaining skew is a single patch. RenderingCorpus is still the suite that proves it — if it fails
+         after a SkiaSharp bump, suspect this pairing first. -->
+    <PackageVersion Include="PDFtoImage" Version="5.4.0" />
   </ItemGroup>
 
   <!-- Roslyn / source generator infrastructure. -->
@@ -66,7 +67,7 @@
 
   <!-- Build infrastructure. -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Dependabot's grouped PR (#367, plus its stale duplicate #363) bundled genuinely good updates with one that breaks the engine. The group was closed and the safe subset is taken here — the same split #355 used.

## Held — why #367 was closed

**AngleSharp 1.6.0 → 1.7.1 and AngleSharp.Css 1.0.0-beta.144 → 1.0.1.**

The 1.0.0 CHANGELOG note said the prerelease exception should be *"revisited when AngleSharp.Css ships a stable 1.x"*. That has now happened — and the answer is no. Stable **1.0.1 still carries the background-image regression**, and breaks more than the beta did. All five enforcing legs failed with **34 unit + 1 RealDocuments** failures (8580/8617):

- **20 `Background_*` paint tests** — clip/position/size/repeat/no-repeat plus the sliced multi-page ones. Same signature as before: `background-image: url(...)` stops painting.
- **CSS preprocessor / at-rule tests** — `CssParserAdapterPreprocessTests` (opaque `@layer`/`@container` raw-body carriage), the `@layer` corpus case, `GridShorthandProductionTests`. This part is new and broader than the beta regression.

## Taken

| Package | Change | Note |
|---|---|---|
| SkiaSharp (+3 NativeAssets) | 4.150.1 → 4.151.1 | all four in lockstep |
| HarfBuzzSharp (+3 NativeAssets) | 14.2.1.1 → 14.2.1.2 | all four in lockstep |
| Microsoft.Playwright | 1.61.0 → 1.62.0 | re-pairs with the Docker image from #360 |
| PDFtoImage | 5.2.1 → 5.4.0 | closes a documented caveat, below |
| Microsoft.SourceLink.GitHub | 10.0.301 → 10.0.400 | |

The native-asset packages are moved **in lockstep** deliberately — a partial bump produces a managed/native mismatch.

`Microsoft.Playwright` matters here beyond the version number: #360 just bumped the `playwright/python` Docker image to v1.62.0, and both halves of the reference harness should pin the same Chrome.

## The PDFtoImage comment is rewritten because the bump closes its own caveat

5.2.1 declared a **SkiaSharp 3.119.2** floor while production pinned 4.x, so PDFium ran against a SkiaSharp a whole major version newer than it compiled against — a removed 3.x API would only have surfaced as a runtime `MissingMethodException`. **5.4.0 declares 4.150.1**, and production pins 4.151.1, so the skew is now a single patch.

## Not taken

`Microsoft.NET.Test.Sdk` 18.9.0 — it appeared only in the stale #363 and Dependabot dropped it from the newer group. Left for Dependabot to re-propose on its own.

## Verification

CI-green is not sufficient for dependency bumps in this repo, so this was verified locally:

- build **0 errors / 0 NU warnings**
- UnitTests **8614 passed / 3 skipped**
- RenderingCorpus **41** — the suite that actually proves the PDFium/SkiaSharp pairing
- RealDocuments **105**
- `git diff --check` clean

Note on the `benchmark gate`: it is currently failing intermittently on `main` itself (different sub-millisecond benchmarks on different runs — `CacheHits_Isolated` 1.46×, `BlankPages(100)` 1.25×). That is shared-runner noise against a tight 1.25% tolerance, unrelated to this PR, and is worth addressing separately now that the gate actually measures (post-#356).